### PR TITLE
feat: implement multiple arguments support in guard function

### DIFF
--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -42,11 +42,15 @@ _cg_resolve_command_path() {
 #   Defines a function named <command> that shadows the external command and
 #   dispatches to it by full path with all arguments forwarded.
 # Usage:
-#   guard <command>
+#   guard [command ...]
 # Example:
 #   guard ls
 #   ls -l
 #   # runs /usr/bin/ls -l (or /bin/ls)
+#   guard uname date hostname
+#   uname
+#   date
+#   hostname
 # Errors:
 #   CG_ERR_MISSING_COMMAND, CG_ERR_INVALID_NAME, CG_ERR_NOT_FOUND
 # Notes:
@@ -56,30 +60,46 @@ _cg_resolve_command_path() {
 #   This function uses eval to define the shadowing function; input is validated
 #   to be a legal Bash identifier before eval is invoked.
 guard() {
-    local cmd="$1"
-    local full_path
-
-    if [ -z "$cmd" ]; then
-        echo "[ERROR] Usage: 'guard <command>' Missing command argument." >&2
+    if [ $# -eq 0 ]; then
+        echo "[ERROR] Usage: 'guard <command> [command2 ...]' Missing command argument." >&2
         return "$CG_ERR_MISSING_COMMAND"
     fi
 
-    if ! [[ "$cmd" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-        echo "[ERROR] guard: invalid command identifier.'$cmd'." >&2
-        return "$CG_ERR_INVALID_NAME"
-    fi
+    # First pass: validate all commands
+    local cmd full_path
+    local -a valid_commands=()
+    local -a full_paths=()
 
-    full_path="$(_cg_resolve_command_path "$cmd")" || {
-        if [[ "$full_path" == "$cmd" ]]; then
-            # It's a builtin
-            echo "[BUG] guard: '$cmd' is a builtin and should not be guarded." >&2
-        elif [[ "$full_path" == alias\ * ]]; then
-            # it's an alias
-            echo "[BUG] guard: '$cmd' is an alias and should not be used in scripts." >&2
-        else
-            echo "[ERROR] guard: unable to resolve full path for '$cmd'. Use the full path." >&2
-        fi    
-        [[ "$BASHPID" != "$$" ]] && exit $CG_ERR_NOT_FOUND || return $CG_ERR_NOT_FOUND
-    }
-    eval "${cmd}() { \"${full_path}\" \"\$@\"; }"
+    for cmd in "$@"; do
+        if [ -z "$cmd" ]; then
+            echo "[ERROR] guard: empty command name in arguments." >&2
+            return "$CG_ERR_MISSING_COMMAND"
+        fi
+
+        if ! [[ "$cmd" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+            echo "[ERROR] guard: invalid command identifier '$cmd'." >&2
+            return "$CG_ERR_INVALID_NAME"
+        fi
+
+        full_path="$(_cg_resolve_command_path "$cmd")" || {
+            if [[ "$full_path" == "$cmd" ]]; then
+                # It's a builtin
+                echo "[BUG] guard: '$cmd' is a builtin and should not be guarded." >&2
+            elif [[ "$full_path" == alias\ * ]]; then
+                # it's an alias
+                echo "[BUG] guard: '$cmd' is an alias and should not be used in scripts." >&2
+            else
+                echo "[ERROR] guard: unable to resolve full path for '$cmd'. Use the full path." >&2
+            fi
+            [[ "$BASHPID" != "$$" ]] && exit $CG_ERR_NOT_FOUND || return $CG_ERR_NOT_FOUND
+        }
+        valid_commands+=("$cmd")
+        full_paths+=("$full_path")
+    done
+
+    # Second pass: create functions for all valid commands
+    local i
+    for ((i=0; i<${#valid_commands[@]}; i++)); do
+        eval "${valid_commands[i]}() { \"${full_paths[i]}\" \"\$@\"; }"
+    done
 }

--- a/test/test-command_guard.bats
+++ b/test/test-command_guard.bats
@@ -96,3 +96,268 @@ setup_file() {
   [[ "$output" != *"inside"* ]]
   [[ "$stderr" == "[BUG] guard: 'myalias' is an alias"* ]]
 }
+
+# --- PR#1: Multiple commands support (should fail initially) ---
+
+# bats test_tags=guard,pr1
+@test "PR#1: guard accepts multiple commands" {
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    guard uname date hostname
+  '
+}
+
+# bats test_tags=guard,pr1
+@test "PR#1: multiple commands all create wrapper functions" {
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    guard uname date hostname
+    [ "$(type -t uname)" = "function" ]
+    [ "$(type -t date)" = "function" ]
+    [ "$(type -t hostname)" = "function" ]
+  '
+}
+
+# bats test_tags=guard,pr1
+@test "PR#1: multiple guarded commands execute correctly" {
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    guard uname echo
+    out1="$(uname)"
+    out2="$(echo test)"
+    [ -n "$out1" ]
+    [ "$out2" = "test" ]
+  '
+}
+
+# bats test_tags=guard,pr1
+@test "PR#1: failure in one command stops processing, acts as no-op" {
+  # shellcheck disable=SC2016
+  run bash --noprofile -lc '
+    guard uname nonexistent_xyz date
+    echo "EXIT_CODE:$?"
+    type -t uname
+  '
+  [[ "${lines[0]}" == *"[ERROR] guard: unable to resolve full path"* ]]
+  [[ "${lines[1]}" == "EXIT_CODE:3" ]]
+  [[ "${lines[2]}" == "file" ]]
+}
+
+# bats test_tags=guard,pr1
+@test "PR#1: backward compatible with single command" {
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    guard uname
+    [ "$(type -t uname)" = "function" ]
+    out="$(uname)"
+    [ -n "$out" ]
+  '
+}
+
+# --- PR#2: Custom path syntax (should fail initially) ---
+
+# bats test_tags=guard,pr2
+@test "PR#2: guard accepts cmd=path syntax" {
+  skip "Feature not yet implemented - PR#2"
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    guard "uname=/usr/bin/uname"
+  '
+}
+
+# bats test_tags=guard,pr2
+@test "PR#2: custom path command creates wrapper function" {
+  skip "Feature not yet implemented - PR#2"
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    guard "uname=/usr/bin/uname"
+    [ "$(type -t uname)" = "function" ]
+  '
+}
+
+# bats test_tags=guard,pr2
+@test "PR#2: custom path command executes with specified path" {
+  skip "Feature not yet implemented - PR#2"
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    guard "uname=/usr/bin/uname"
+    out="$(uname)"
+    [ -n "$out" ]
+  '
+}
+
+# bats test_tags=guard,pr2
+@test "PR#2: mix of custom path and regular commands" {
+  skip "Feature not yet implemented - PR#2"
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    guard "uname=/usr/bin/uname" date hostname
+    [ "$(type -t uname)" = "function" ]
+    [ "$(type -t date)" = "function" ]
+    [ "$(type -t hostname)" = "function" ]
+  '
+}
+
+# bats test_tags=guard,pr2
+@test "PR#2: custom path with nonexistent file fails" {
+  skip "Feature not yet implemented - PR#2"
+  # shellcheck disable=SC2016
+  run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
+    guard "badcmd=/nonexistent/path/badcmd"
+  '
+  [[ "$output" == *"unable to resolve"* ]]
+}
+
+# bats test_tags=guard,pr2
+@test "PR#2: custom path with non-executable fails" {
+  skip "Feature not yet implemented - PR#2"
+  # shellcheck disable=SC2016
+  run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
+    tmpfile=$(mktemp)
+    guard "notexec=$tmpfile"
+    rm -f "$tmpfile"
+  '
+}
+
+# bats test_tags=guard,pr2
+@test "PR#2: custom path with relative path fails" {
+  skip "Feature not yet implemented - PR#2"
+  # shellcheck disable=SC2016
+  run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
+    guard "cmd=../bin/cmd"
+  '
+  [[ "$output" == *"absolute path"* ]]
+}
+
+# bats test_tags=guard,pr2
+@test "PR#2: invalid syntax in cmd=path fails gracefully" {
+  skip "Feature not yet implemented - PR#2"
+  # shellcheck disable=SC2016
+  run -"$CG_ERR_INVALID_NAME" bash --noprofile -lc '
+    guard "bad-name=/usr/bin/test"
+  '
+  [[ "$output" == *"invalid command identifier"* ]]
+}
+
+# --- PR#3: PATH enforcement and debug trap (should fail initially) ---
+
+# bats test_tags=guard,pr3
+@test "PR#3: original PATH is saved on source" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    original="$PATH"
+    source "$LIB"
+    [ -n "${_ORIGINAL_PATH}" ]
+    [ "${_ORIGINAL_PATH}" = "$original" ]
+  '
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: PATH is unset after sourcing" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    source "$LIB"
+    [ -z "${PATH+x}" ] && echo "PATH_UNSET" || echo "PATH_SET"
+  '
+  [[ "$output" == *"PATH_UNSET"* ]]
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: non-guarded command fails when PATH unset" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run -127 bash --noprofile -lc '
+    source "$LIB"
+    curl --version
+  '
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: guarded command works despite unset PATH" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile -lc '
+    source "$LIB"
+    guard uname
+    out="$(uname)"
+    [ -n "$out" ]
+  '
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: debug trap catches non-guarded command in debug mode" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run -127 --separate-stderr bash --noprofile -lc '
+    set -x
+    source "$LIB"
+    curl --version 2>&1 || true
+  '
+  [[ "$stderr" == *"WARNING: Non-guarded command attempted: curl"* ]]
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: debug trap suggests guard command with path" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run --separate-stderr bash --noprofile -lc '
+    set -x
+    source "$LIB"
+    ls / 2>&1 || true
+  '
+  [[ "$stderr" == *"Suggestion: guard ls="* ]]
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: debug trap uses default PATH for suggestions" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run --separate-stderr bash --noprofile -lc '
+    set -x
+    source "$LIB"
+    uname 2>&1 || true
+  '
+  [[ "$stderr" == *"Suggestion: guard uname=/usr/bin/uname"* ]] ||
+  [[ "$stderr" == *"Suggestion: guard uname=/bin/uname"* ]]
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: debug trap falls back to original PATH" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run --separate-stderr bash --noprofile -lc '
+    export PATH="/custom/bin:$PATH"
+    set -x
+    source "$LIB"
+    # Try a command that might only be in custom location
+    fakecmd 2>&1 || true
+  '
+  [[ "$stderr" == *"Suggestion:"* ]] || [[ "$stderr" == *"WARNING:"* ]]
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: debug trap does not trigger for guarded commands" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    set -x
+    source "$LIB"
+    guard uname
+    uname > /dev/null 2>&1
+  '
+  [[ "$stderr" != *"WARNING: Non-guarded command"* ]]
+}
+
+# bats test_tags=guard,pr3
+@test "PR#3: debug trap does not trigger for builtins" {
+  skip "Feature not yet implemented - PR#3"
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    set -x
+    source "$LIB"
+    echo "test" > /dev/null 2>&1
+  '
+  [[ "$stderr" != *"WARNING: Non-guarded command"* ]]
+}


### PR DESCRIPTION
- Modify guard() to accept multiple command arguments
- Validate all commands first, then create functions if all valid
- Update tests to enable PR#1 multiple commands support
- Maintain backward compatibility with single command usage