### PR TITLE
fix: use ${BASH:-bash} instead of $0 for collision-check subprocess

### DIFF
--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -209,7 +209,7 @@ hs_persist_state() {
         if [ -n "$__existing_state" ]; then
             # In a time-constrained subshell, declare "$__var_name" as local to capture its value
             # and attempt to restore it from "$__existing_state".
-            timeout --preserve-status -k 2 1 "$0" --noprofile -elc "
+            timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -elc "
                 command_not_found_handle() {
                     echo \"[ERROR] hs_persist_state: command '\$1' not found.\" >&2
                     exit 127

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -478,3 +478,19 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [[ "$stderr" =~ "prior state is corrupted" ]]
   [ -z "$output" ]
 }
+
+# bats test_tags=hs_persist_state
+@test "hs_persist_state -s works when called via bats run on a shell function" {
+  # Regression test for issue #59: hs_persist_state used $0 to re-invoke the
+  # shell for collision checking, but $0 is the Bats runner (not bash) when a
+  # function is invoked via 'bats run'.  The fix uses ${BASH:-bash} instead.
+  # Also verifies that the collision-check subshell does not leak 'a' globally.
+  state_accumulates() {
+    local incoming_state="local a=kept"
+    hs_persist_state -s "$incoming_state" b >/dev/null
+  }
+  run -0 --separate-stderr state_accumulates
+  [ -z "$stderr" ]
+  # a must not have leaked into the current scope from the collision-check subshell
+  [ -z "${a+set}" ]
+}


### PR DESCRIPTION
## Description

Fixes #59.

`hs_persist_state` shells out via `timeout ... "$0" --noprofile -elc ...` to
run the variable-name collision check in a time-bounded subprocess. `$0` holds
the name of the invoking process, which is the Bats runner (not `bash`) when
the function is called from code executed via `bats run` on a shell function.
This caused the subprocess to fail with `bats: --noprofile does not exist`,
which `hs_persist_state` misreported as a corrupted state.

The fix replaces `"$0"` with `"${BASH:-bash}"`. `$BASH` is set by Bash itself
to the absolute path of the running interpreter — it is always correct
regardless of how the parent process was invoked.

## Type of Change
- [x] Bug fix

## Testing
- New regression test `hs_persist_state -s works when called via bats run on a shell function` (test 30 in `test/test-hs_persist_state.bats`):
  - Confirmed failing before the fix (`bats: --noprofile does not exist`)
  - Confirmed passing after the fix
- Full `test/test-hs_persist_state.bats` suite: 30/30 pass
- Full `test/test-command_guard.bats` suite: 35/35 pass (skips excluded)

## Checklist
- [x] Code follows project standards
- [x] Tests pass locally
- [x] Minimal patch — one token changed (`"$0"` → `"${BASH:-bash}"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)