### PR TITLE
Refactor safer handle-state restoration flow

### DIFF
--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -13,11 +13,12 @@ API, warnings, and limitations.
 
 - Source `config/handle_state.sh` once in the main script or library entrypoint.
 - In init/setup or wherever the state information is created, define local scalar
-  variables holding the state, then call `hs_persist_state_as_code -S <state_var> <local1> <local2> ...`.
+  variables holding the state, then call
+  `hs_persist_state_as_code "$@" -- <local1> <local2> ...`.
 - Future libraries using `handle_state` are only required to support `-S`.
 - The state snippet is assigned directly to the specified variable; stdout-based state transport is obsolete and should not be supported in library APIs.
 - Pass the state variable to cleanup or any API function which needs state information.
-- In cleanup, declare locals with the same names, then `eval "$state"`.
+- In cleanup, restore the needed locals with `hs_read_persisted_state "$@" -- <local1> <local2> ...`.
 - If the same state variable must be reused across several init/cleanup cycles,
   provide a matching state-destruction path that removes the library's vars
   from the state vector before the next init.
@@ -28,71 +29,40 @@ API, warnings, and limitations.
 ```bash
 source "$(dirname "$0")/config/handle_state.sh"
 
-state_producer() {
-  local _state_var=""
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      -S) shift; _state_var=$1; shift ;;
-      *) echo "[ERROR] state_producer: unknown option '$1'" >&2; return 1 ;;
-    esac
-  done
-
-  [[ -n "$_state_var" ]] || {
-    echo "[ERROR] state_producer: missing required -S <state_var>" >&2
-    return 1
-  }
-
+init_function() {
   local temp_file="/tmp/resource"
   local resource_id="abc123"
-  hs_persist_state_as_code -S "$_state_var" temp_file resource_id
+  hs_persist_state_as_code "$@" -- temp_file resource_id
 }
 
-state_consumer() {
+cleanup_function() {
   local temp_file resource_id
-  eval "$1"
+  hs_read_persisted_state "$@" -- temp_file resource_id
   rm -f "$temp_file"
   echo "Cleaned $resource_id"
-}
-
-state_destroyer() {
-  local _state_var=""
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      -S)
-        # Same option shape as hs_persist_state_as_code; implementation is expected to
-        # delegate to a future hs_destroy_state helper.
-        break
-        ;;
-      *)
-        echo "[ERROR] state_destroyer: unknown option '$1'" >&2
-        return 1
-        ;;
-    esac
-  done
-
-  hs_destroy_state "$@" temp_file resource_id
+  hs_destroy_state "$@" -- temp_file resource_id
 }
 
 local state
-state_producer -S state
-state_consumer "$state"
-state_destroyer -S state
-state_producer -S state
+init_function -S state
+cleanup_function -S state
+init_function -S state
 ```
 
-**API Documentation Note**: New libraries should expose `-S` directly and should not preserve the older stdout-based calling convention. If a function both consumes and produces state, it can still use `hs_persist_state_as_code -S <var>` internally after processing its own arguments.
-
-The same function can begin by consuming some state and terminate producing some other state.
-If it receives a state variable name from the caller, that function can append
-to the supplied state vector by passing the same variable name to
-`hs_persist_state_as_code -S <var>` rather than producing a new one.
+**API Documentation Note**: New libraries should expose `-S` directly and should not preserve the older stdout-based calling convention. Pass the full parameter set to `hs_persist_state_as_code`, `hs_read_persisted_state`, and `hs_destroy_state`, then use `--` as the separator before the list of local variable names.
 
 When a library needs to reinitialize against the same state variable after
-cleanup, document a companion `state_destroyer` pattern. Its syntax should
-match `hs_persist_state_as_code`, but its implementation should rely on a future
-`hs_destroy_state` helper to remove the listed variables from the state vector
-before the next producer call. This avoids collision errors from repeated
-`hs_persist_state_as_code` calls on the same state variable.
+cleanup, the cleanup function must call `hs_destroy_state` to remove the
+library's variables from the state vector before the next init call. This
+avoids collision errors from repeated `hs_persist_state_as_code` calls on the
+same state variable.
+
+If a library function consumes some of its own arguments before calling
+`handle_state`, preserve the remaining parameter list and still pass the full
+residual `"$@"` to the helper. Use `--` before the local variable list so
+future helper options cannot collide with local variable names or parameter
+values. The last `--` is the effective separator; earlier ones may belong to the
+library's own API.
 
 ## Supported Variables
 
@@ -121,8 +91,9 @@ The following behaviors are tracked in GitHub; avoid them or apply workarounds.
 
 ## Safety Notes
 
-- `hs_persist_state_as_code` and `hs_read_persisted_state` rely on `eval`; treat state
-  strings as trusted input only.
+- Avoid direct `eval` of the raw state string in new library code.
+- `hs_persist_state_as_code` and `hs_read_persisted_state` still rely on `eval`
+  internally; treat state strings as trusted input only.
 - Avoid name collisions when chaining state through a shared state variable; prefer separate state
   variables if libraries overlap variable names.
 - Do not require stdout to carry state as part of a library API; reserve stdout for normal user-visible output.

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -22,7 +22,6 @@ API, warnings, and limitations.
 - If the same state variable must be reused across several init/cleanup cycles,
   provide a matching state-destruction path that removes the library's vars
   from the state vector before the next init.
-- Call `hs_cleanup_output` when done to stop the logging reader.
 
 ## Standard Pattern
 
@@ -69,7 +68,7 @@ library's own API.
 - Only local scalar variables (strings or numbers) are reliably preserved.
 - Encode any other state variable as a string. See encoding templates in
   `.github/skills/handle-state/references/templates.md`.
-- Always re-declare the same locals in cleanup before `eval`.
+- Re-declare the same locals in cleanup before `hs_read_persisted_state`.
 
 ## Known Limitations (Tracked)
 

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -15,7 +15,7 @@ API, warnings, and limitations.
 - In init/setup or wherever the state information is created, define local scalar
   variables holding the state, then call `hs_persist_state_as_code -S <state_var> <local1> <local2> ...`.
 - Future libraries using `handle_state` are only required to support `-S`.
-- The state snippet is assigned directly to the specified variable; do not rely on stdout emission as part of a library API.
+- The state snippet is assigned directly to the specified variable; stdout-based state transport is obsolete and should not be supported in library APIs.
 - Pass the state variable to cleanup or any API function which needs state information.
 - In cleanup, declare locals with the same names, then `eval "$state"`.
 - If the same state variable must be reused across several init/cleanup cycles,
@@ -58,7 +58,7 @@ state_destroyer() {
   local _state_var=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -s|-S)
+      -S)
         # Same option shape as hs_persist_state_as_code; implementation is expected to
         # delegate to a future hs_destroy_state helper.
         break
@@ -80,11 +80,12 @@ state_destroyer -S state
 state_producer -S state
 ```
 
-**API Documentation Note**: New libraries should expose `-S` directly and are not required to preserve the older stdout-based calling convention. If a function both consumes and produces state, it can still use `hs_persist_state_as_code -S <var>` internally after processing its own arguments.
+**API Documentation Note**: New libraries should expose `-S` directly and should not preserve the older stdout-based calling convention. If a function both consumes and produces state, it can still use `hs_persist_state_as_code -S <var>` internally after processing its own arguments.
 
 The same function can begin by consuming some state and terminate producing some other state.
-If it uses the `-s <$state>` option to `hs_persist_state_as_code`, that function can append to the
-supplied state vector rather than producing a new one.
+If it receives a state variable name from the caller, that function can append
+to the supplied state vector by passing the same variable name to
+`hs_persist_state_as_code -S <var>` rather than producing a new one.
 
 When a library needs to reinitialize against the same state variable after
 cleanup, document a companion `state_destroyer` pattern. Its syntax should
@@ -122,6 +123,6 @@ The following behaviors are tracked in GitHub; avoid them or apply workarounds.
 
 - `hs_persist_state_as_code` and `hs_read_persisted_state` rely on `eval`; treat state
   strings as trusted input only.
-- Avoid name collisions when chaining state snippets; prefer separate state
-  strings if libraries overlap variable names.
-- Do not require stdout to carry state as part of a new library API; reserve stdout for normal user-visible output.
+- Avoid name collisions when chaining state through a shared state variable; prefer separate state
+  variables if libraries overlap variable names.
+- Do not require stdout to carry state as part of a library API; reserve stdout for normal user-visible output.

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -13,7 +13,7 @@ API, warnings, and limitations.
 
 - Source `config/handle_state.sh` once in the main script or library entrypoint.
 - In init/setup or wherever the state information is created, define local scalar
-  variables holding the state, then call `hs_persist_state -S <state_var> <local1> <local2> ...`.
+  variables holding the state, then call `hs_persist_state_as_code -S <state_var> <local1> <local2> ...`.
 - Future libraries using `handle_state` are only required to support `-S`.
 - The state snippet is assigned directly to the specified variable; do not rely on stdout emission as part of a library API.
 - Pass the state variable to cleanup or any API function which needs state information.
@@ -44,7 +44,7 @@ state_producer() {
 
   local temp_file="/tmp/resource"
   local resource_id="abc123"
-  hs_persist_state -S "$_state_var" temp_file resource_id
+  hs_persist_state_as_code -S "$_state_var" temp_file resource_id
 }
 
 state_consumer() {
@@ -59,7 +59,7 @@ state_destroyer() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -s|-S)
-        # Same option shape as hs_persist_state; implementation is expected to
+        # Same option shape as hs_persist_state_as_code; implementation is expected to
         # delegate to a future hs_destroy_state helper.
         break
         ;;
@@ -80,18 +80,18 @@ state_destroyer -S state
 state_producer -S state
 ```
 
-**API Documentation Note**: New libraries should expose `-S` directly and are not required to preserve the older stdout-based calling convention. If a function both consumes and produces state, it can still use `hs_persist_state -S <var>` internally after processing its own arguments.
+**API Documentation Note**: New libraries should expose `-S` directly and are not required to preserve the older stdout-based calling convention. If a function both consumes and produces state, it can still use `hs_persist_state_as_code -S <var>` internally after processing its own arguments.
 
 The same function can begin by consuming some state and terminate producing some other state.
-If it uses the `-s <$state>` option to `hs_persist_state`, that function can append to the
+If it uses the `-s <$state>` option to `hs_persist_state_as_code`, that function can append to the
 supplied state vector rather than producing a new one.
 
 When a library needs to reinitialize against the same state variable after
 cleanup, document a companion `state_destroyer` pattern. Its syntax should
-match `hs_persist_state`, but its implementation should rely on a future
+match `hs_persist_state_as_code`, but its implementation should rely on a future
 `hs_destroy_state` helper to remove the listed variables from the state vector
 before the next producer call. This avoids collision errors from repeated
-`hs_persist_state` calls on the same state variable.
+`hs_persist_state_as_code` calls on the same state variable.
 
 ## Supported Variables
 
@@ -120,7 +120,7 @@ The following behaviors are tracked in GitHub; avoid them or apply workarounds.
 
 ## Safety Notes
 
-- `hs_persist_state` and `hs_read_persisted_state` rely on `eval`; treat state
+- `hs_persist_state_as_code` and `hs_read_persisted_state` rely on `eval`; treat state
   strings as trusted input only.
 - Avoid name collisions when chaining state snippets; prefer separate state
   strings if libraries overlap variable names.

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -1,5 +1,5 @@
 ---
-description: Expert guidance for implementing and using the handle_state.sh Bash library to persist initialization state to cleanup functions, including hs_persist_state usage, logging FIFO setup, and limitations/workarounds for unsupported variable types. Triggers on requests like "pass information", "write initialization function" or "write cleanup function" while developing a library or code module.
+description: Expert guidance for implementing and using the handle_state.sh Bash library to persist initialization state to cleanup functions, centered on the -S state-variable pattern and limitations/workarounds for unsupported variable types. Triggers on requests like "pass information", "write initialization function" or "write cleanup function" while developing a library or code module.
 ---
 
 # Handle State Library Skill
@@ -13,10 +13,14 @@ API, warnings, and limitations.
 
 - Source `config/handle_state.sh` once in the main script or library entrypoint.
 - In init/setup or wherever the state information is created, define local scalar
-  variables holding the state, then call `hs_persist_state -S <var_name> <var_name> ...`.
-- The state snippet is assigned directly to the specified variable, avoiding stdout usage.
+  variables holding the state, then call `hs_persist_state -S <state_var> <local1> <local2> ...`.
+- Future libraries using `handle_state` are only required to support `-S`.
+- The state snippet is assigned directly to the specified variable; do not rely on stdout emission as part of a library API.
 - Pass the state variable to cleanup or any API function which needs state information.
 - In cleanup, declare locals with the same names, then `eval "$state"`.
+- If the same state variable must be reused across several init/cleanup cycles,
+  provide a matching state-destruction path that removes the library's vars
+  from the state vector before the next init.
 - Call `hs_cleanup_output` when done to stop the logging reader.
 
 ## Standard Pattern
@@ -25,11 +29,22 @@ API, warnings, and limitations.
 source "$(dirname "$0")/config/handle_state.sh"
 
 state_producer() {
-  # Defer option processing to hs_persist_state for full API flexibility
-  hs_echo "Starting init"
+  local _state_var=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -S) shift; _state_var=$1; shift ;;
+      *) echo "[ERROR] state_producer: unknown option '$1'" >&2; return 1 ;;
+    esac
+  done
+
+  [[ -n "$_state_var" ]] || {
+    echo "[ERROR] state_producer: missing required -S <state_var>" >&2
+    return 1
+  }
+
   local temp_file="/tmp/resource"
   local resource_id="abc123"
-  hs_persist_state "$@" temp_file resource_id
+  hs_persist_state -S "$_state_var" temp_file resource_id
 }
 
 state_consumer() {
@@ -39,23 +54,44 @@ state_consumer() {
   echo "Cleaned $resource_id"
 }
 
+state_destroyer() {
+  local _state_var=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -s|-S)
+        # Same option shape as hs_persist_state; implementation is expected to
+        # delegate to a future hs_destroy_state helper.
+        break
+        ;;
+      *)
+        echo "[ERROR] state_destroyer: unknown option '$1'" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  hs_destroy_state "$@" temp_file resource_id
+}
+
 local state
 state_producer -S state
-cleanup "$state"
+state_consumer "$state"
+state_destroyer -S state
+state_producer -S state
 ```
 
-**API Documentation Note**: The `state_producer` function defers all option processing to `hs_persist_state`, providing the same flexibility and future enhancements to library users.
+**API Documentation Note**: New libraries should expose `-S` directly and are not required to preserve the older stdout-based calling convention. If a function both consumes and produces state, it can still use `hs_persist_state -S <var>` internally after processing its own arguments.
 
 The same function can begin by consuming some state and terminate producing some other state.
 If it uses the `-s <$state>` option to `hs_persist_state`, that function can append to the
 supplied state vector rather than producing a new one.
 
-## Logging FIFO Guidance
-
-- `hs_setup_output_to_stdout` runs on source; it redirects `hs_echo` output to
-  the main stdout even when init runs inside `$(...)`.
-- Use `hs_echo` inside init functions when stdout is reserved for the state snippet.
-- Do not write to stdout directly in init; it will corrupt the state string.
+When a library needs to reinitialize against the same state variable after
+cleanup, document a companion `state_destroyer` pattern. Its syntax should
+match `hs_persist_state`, but its implementation should rely on a future
+`hs_destroy_state` helper to remove the listed variables from the state vector
+before the next producer call. This avoids collision errors from repeated
+`hs_persist_state` calls on the same state variable.
 
 ## Supported Variables
 
@@ -88,3 +124,4 @@ The following behaviors are tracked in GitHub; avoid them or apply workarounds.
   strings as trusted input only.
 - Avoid name collisions when chaining state snippets; prefer separate state
   strings if libraries overlap variable names.
+- Do not require stdout to carry state as part of a new library API; reserve stdout for normal user-visible output.

--- a/.github/skills/handle-state/SKILL.md
+++ b/.github/skills/handle-state/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handle-state
-description: Expert guidance for implementing and using the handle_state.sh Bash library to persist initialization state to cleanup functions, including hs_persist_state usage, logging FIFO setup, and limitations/workarounds for unsupported variable types. Triggers on requests like "pass information", "write initialization function" or "write cleanup function" while developing a library or code module.
+description: Expert guidance for implementing and using the handle_state.sh Bash library to persist initialization state to cleanup functions, centered on the -S state-variable pattern and current hs_persist_state_as_code / hs_read_persisted_state / hs_destroy_state API. Triggers on requests like "pass information", "write initialization function" or "write cleanup function" while developing a library or code module.
 ---
 
 # Handle State Library Skill
@@ -8,90 +8,105 @@ description: Expert guidance for implementing and using the handle_state.sh Bash
 ## Core Reference
 
 Use `docs/libraries/handle_state.rst` as the canonical local reference for the
-API, warnings, and limitations.
+current API, warnings, and limitations.
 
 ## Quick Workflow
 
 - Source `config/handle_state.sh` once in the main script or library entrypoint.
-- In init/setup or wherever the state information is created, define local scalar 
-  variables holding the state, then call `hs_persist_state -S <var_name> <var_name> ...`.
-- The state snippet is assigned directly to the specified variable, avoiding stdout usage.
-- Pass the state variable to cleanup or any API function which needs state information.
-- In cleanup, declare locals with the same names, then `eval "$state"`.
-- Call `hs_cleanup_output` when done to stop the logging reader.
+- In init/setup, define local scalar variables holding the state, then call
+  `hs_persist_state_as_code "$@" -- <local1> <local2> ...`.
+- Future libraries using `handle_state` are only required to support `-S`.
+- State transport is by name only. Do not design new library APIs around stdout
+  state transport.
+- Pass the state variable by name to cleanup or any API function that needs
+  state information.
+- In cleanup, declare matching locals and restore them with
+  `hs_read_persisted_state "$@" -- <local1> <local2> ...`.
+- If the same state variable must be reused across several init/cleanup cycles,
+  call `hs_destroy_state "$@" -- <local1> <local2> ...` during cleanup.
 
 ## Standard Pattern
 
-.. code-block:: bash
+```bash
+source "$(dirname "$0")/config/handle_state.sh"
 
-   source "$(dirname "$0")/config/handle_state.sh"
+init_function() {
+  local temp_file="/tmp/resource"
+  local resource_id="abc123"
+  hs_persist_state_as_code "$@" -- temp_file resource_id
+}
 
-   state_producer() {
-     # Defer option processing to hs_persist_state for full API flexibility
-     hs_echo "Starting init"
-     local temp_file="/tmp/resource"
-     local resource_id="abc123"
-     hs_persist_state "$@" temp_file resource_id
-   }
+cleanup_function() {
+  local temp_file resource_id
+  hs_read_persisted_state "$@" -- temp_file resource_id
+  rm -f "$temp_file"
+  echo "Cleaned $resource_id"
+  hs_destroy_state "$@" -- temp_file resource_id
+}
 
-   state_consumer() {
-     local temp_file resource_id
-     eval "$1"
-     rm -f "$temp_file"
-     echo "Cleaned $resource_id"
-   }
+local state=""
+init_function -S state
+cleanup_function -S state
+init_function -S state
+```
 
-   local state
-   state_producer -S state
-   cleanup "$state"
+## API Guidance
 
-**API Documentation Note**: The `state_producer` function defers all option processing to `hs_persist_state`, providing the same flexibility and future enhancements to library users.
+- Public library functions should expose `-S` directly instead of hiding it.
+- Pass the full residual `"$@"` to `hs_persist_state_as_code`,
+  `hs_read_persisted_state`, and `hs_destroy_state`.
+- Put `--` before the list of local variable names.
+- The last `--` is the effective separator; earlier ones may belong to the
+  library's own API.
+- If a library function consumes some of its own arguments first, forward the
+  remaining parameter list unchanged and still use `--` before the local names.
 
-The same function can begin by consuming some state and terminate producing some other state. 
-If it uses the ``-s <$state>`` option to ``hs_persist_state``, that function can append to the
-supplied state vector rather than producing a new one. The benefits of either option depend on 
-the use case and must be decided by analysis, but in general a library should have only one
-state vector unless its purpose implies the production of several similar state vectors.
+## Reading State
 
-## Logging FIFO Guidance
-
-- `hs_setup_output_to_stdout` runs on source; it redirects `hs_echo` output to
-  the main stdout even when init runs inside `$(...)`.
-- Use `hs_echo` inside init functions when stdout is reserved for the state
-  snippet.
-- Do not write to stdout directly in init; it will corrupt the state string.
+- Prefer explicit restore lists:
+  `hs_read_persisted_state "$@" -- var1 var2`.
+- Avoid direct `eval` of the raw state object in new library code.
+- `hs_read_persisted_state` can emit a locally generated probe snippet when no
+  explicit variable list is provided, but this is best reserved for simple
+  cases.
+- An explicit `--` with no following variable names suppresses probe-snippet
+  output. This is useful when the list is generated by an expansion that can
+  result in zero variables, and we want the function to stay silent on stdout.
+- Missing requested variables are warnings, one per variable, unless `-q` is
+  supplied.
 
 ## Supported Variables
 
 - Only local scalar variables (strings or numbers) are reliably preserved.
-- Encode any other state variable as a string. Use appropriate template from [references/templates.md](references/templates.md)
-- Always re-declare the same locals in cleanup before `eval`.
+- Encode any other state variable as a string. See
+  `.github/skills/handle-state/references/templates.md`.
+- Re-declare the same locals in cleanup before calling
+  `hs_read_persisted_state`.
 
 ## Known Limitations (Tracked)
 
 The following behaviors are tracked in GitHub; avoid them or apply workarounds.
 
-- Unknown variable names are silently ignored:
-  `Issue #1 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/1>`_.
-- Function names are silently ignored:
-  `Issue #2 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/2>`_.
-- Indexed arrays only preserve the first element (major):
-  `Issue #3 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/3>`_.
-- Associative arrays are silently ignored:
-  `Issue #4 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/4>`_.
-- Namerefs are persisted as scalars (indirection is lost):
-  `Issue #5 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/5>`_.
+- Unknown variable names are silently ignored (Issue #1).
+- Function names are silently ignored (Issue #2).
+- Indexed arrays only preserve the first element (Issue #3).
+- Associative arrays are silently ignored (Issue #4).
+- Namerefs are persisted as scalars; indirection is lost (Issue #5).
 
 ## Workarounds
 
-- Represent associative arrays as two indexed arrays (keys and values).
-- Represent indexed arrays as a single scalar string (encode/decode) or as an
-  associative array if appropriate.
+- Represent associative arrays as two encoded scalar strings.
+- Represent indexed arrays as a single encoded scalar string.
 - Convert other complex constructs into strings and rebuild them in cleanup.
+- See `.github/skills/handle-state/references/templates.md` for examples.
 
 ## Safety Notes
 
-- `hs_persist_state` and `hs_read_persisted_state` rely on `eval`; treat state
-  strings as trusted input only.
-- Avoid name collisions when chaining state snippets; prefer separate state
-  strings if libraries overlap variable names.
+- `hs_persist_state_as_code` and `hs_read_persisted_state` still rely on
+  `eval` internally; treat state objects as trusted input only.
+- Avoid direct `eval "$state"` in new library code.
+- Avoid name collisions when chaining state through a shared state variable; if
+  libraries overlap variable names, prefer separate state variables or ensure
+  cleanup destroys each library's own entries.
+- Do not require stdout to carry state as part of a library API; reserve stdout
+  for normal user-visible output.

--- a/.github/skills/handle-state/references/templates.md
+++ b/.github/skills/handle-state/references/templates.md
@@ -1,86 +1,84 @@
 # State encoding templates
 
-The handle state library works best with a fixed number of scalar variables. Anything else
-must be encoded as a string.
+The current `handle_state` API works best with a fixed set of local scalar
+variables. Anything else should be encoded into one or more scalars before
+calling `hs_persist_state_as_code`.
 
-## Array variables
+## Indexed arrays
 
 ```bash
-# In the state producer function
 producer() {
     local -a myarray=("value1" "value2" "value with spaces")
+    local encoded
     encoded=$(printf '%s\0' "${myarray[@]}" | base64 -w0)
-    hs_persist_state encoded
+    hs_persist_state_as_code "$@" -- encoded
 }
 
-# In a state consumer function
 consumer() {
     local encoded
-    eval "$(hs_read_persisted_state "$1")"
-    declare -a newarray
+    local -a newarray
+    hs_read_persisted_state "$@" -- encoded
     mapfile -d '' -t newarray < <(printf '%s' "$encoded" | base64 -d)
-    # Use newarray
     echo "${newarray[2]}"
 }
-# In the caller
-state=$(producer)
-consumer "$state"  # outputs yelvalue with spaces, the 3rd value
+
+local state=""
+producer -S state
+consumer -S state
 ```
 
 ## Associative arrays
 
 ```bash
-# In the state producer function
 producer() {
-    declare -A myarray=( [apple]="red" [banana]="yellow" [cherry]="dark red" )
+    local -A myarray=([apple]="red" [banana]="yellow" [cherry]="dark red")
     local array_keys array_values
     array_keys=$(printf '%s\0' "${!myarray[@]}" | base64 -w0)
     array_values=$(printf '%s\0' "${myarray[@]}" | base64 -w0)
-    hs_persist_state array_keys array_values
+    hs_persist_state_as_code "$@" -- array_keys array_values
 }
-# In a state consumer function
+
 consumer() {
     local array_keys array_values
-    eval "$(hs_read_persisted_state "$1")"
-    local -a keys
-    local -a values
+    local -a keys values
+    local -A newarray
+    local i
+    hs_read_persisted_state "$@" -- array_keys array_values
     mapfile -d '' -t keys < <(printf '%s' "$array_keys" | base64 -d)
     mapfile -d '' -t values < <(printf '%s' "$array_values" | base64 -d)
-    local -A newarray
     for i in "${!keys[@]}"; do
       newarray["${keys[i]}"]="${values[i]}"
     done
-    # Use newarray
     echo "${newarray[cherry]}"
 }
-# In the caller
-state=$(producer)
-consumer "$state"  # outputs dark red, the value associated with 'banana'.
+
+local state=""
+producer -S state
+consumer -S state
 ```
 
-## Name references
+## Namerefs
 
 ```bash
-# In the producer function
 producer() {
-    declare -n nameref
-    local target1 target2 encoding
-    target1=banana
-    target2=apple
-    nameref=target1
+    local target1=banana
+    local target2=apple
+    local -n nameref=target1
+    local encoding
     encoding="${!nameref}"
-    hs_persist_state encoding
+    hs_persist_state_as_code "$@" -- encoding
 }
-# In the consumer function
+
 consumer() {
     local encoding
-    eval "$(hs_read_persisted_state "$1")"
     local target1=yellow
     local target2=red
+    hs_read_persisted_state "$@" -- encoding
     local -n nameref=$encoding
-    echo $nameref
+    echo "$nameref"
 }
-# In the caller
-state=$(producer)
-consumer "$state"  # outputs yellow, the current value of target1.
+
+local state=""
+producer -S state
+consumer -S state
 ```

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -12,13 +12,13 @@
 source "${BASH_SOURCE%/*}/command_guard.sh"
 
 # Library usage:
-#   In an initialization function, call hs_persist_state with the names of local variables
+#   In an initialization function, call hs_persist_state_as_code with the names of local variables
 #   that need to be preserved for later use in a cleanup function.
 # Example:
 #   init_function() {
 #       local temp_file="/tmp/some_temp_file"
 #       local resource_id="resource_123"
-#       hs_persist_state temp_file resource_id
+#       hs_persist_state_as_code temp_file resource_id
 #       exit 0
 #   }
 #   cleanup() {
@@ -196,9 +196,9 @@ _hs_resolve_state_inputs() {
     printf -v "$__consumed_count_ref" '%s' "$__consumed_count"
 }
 
-# --- hs_persist_state ----------------------------------------------------------
+# --- hs_persist_state_as_code ----------------------------------------------------------
 # Function:
-#   hs_persist_state
+#   hs_persist_state_as_code
 # Description:
 #   Emits a bash code snippet that, when eval'd in the receiving scope,
 #   will recreate the specified local variables with their current values.
@@ -208,24 +208,25 @@ _hs_resolve_state_inputs() {
 #   an error message is printed and the assignment is skipped.
 # Arguments:
 #   -s <state> - optional; if provided, appends the emitted code to variable
-#                definitions found in <state> (bash code snippet).
+#                definitions found in <state> (bash code snippet - deprecated).
 #   -S <statevar> - optional; if provided, appends the emitted code to variable
 #                   definitions found in the variable <statevar>. The variable 
 #                   must be empty or uninitialized if -s is also used.
 #   $@ - names of local variables to persist.
 # Usage examples:
 #   # direct eval
-#   state=$(hs_persist_state var1 var2)
+#   local state
+#   hs_persist_state_as_code -S state var1 var2
 #   cleanup() {
 #       local var1 var2
 #       eval "$1"
 #       # vars are available here
 #   }
-hs_persist_state() {
+hs_persist_state_as_code() {
     local __existing_state=""
     local __output_state_var=""
     local __consumed_state_args=0
-    _hs_resolve_state_inputs hs_persist_state __existing_state __output_state_var __consumed_state_args "$@" || return $?
+    _hs_resolve_state_inputs hs_persist_state_as_code __existing_state __output_state_var __consumed_state_args "$@" || return $?
     shift "$__consumed_state_args"
     # Initialize output state string
     local __output=""
@@ -236,7 +237,7 @@ hs_persist_state() {
     for __var_name in "$@"; do
         # Check that the value of __var_name is neither "__var_name" nor "__existing_state"
         if [ "$__var_name" = "__var_name" ] || [ "$__var_name" = "__existing_state" ] || [ "$__var_name" = "__output_state_var" ] || [ "$__var_name" = "__output" ]; then
-            echo "[ERROR] hs_persist_state: refusing to persist reserved variable name '$__var_name'." >&2  
+            echo "[ERROR] hs_persist_state_as_code: refusing to persist reserved variable name '$__var_name'." >&2  
             return "$HS_ERR_RESERVED_VAR_NAME"
         fi
         # Detect name collisions if __existing_state is provided
@@ -245,7 +246,7 @@ hs_persist_state() {
             # and attempt to restore it from "$__existing_state".
             timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -elc "
                 command_not_found_handle() {
-                    echo \"[ERROR] hs_persist_state: command '\$1' not found.\" >&2
+                    echo \"[ERROR] hs_persist_state_as_code: command '\$1' not found.\" >&2
                     exit 127
                 }
                 test_collision() {
@@ -253,7 +254,7 @@ hs_persist_state() {
                     eval \"$__existing_state\" >/dev/null
                     # Check if the variable pointed to by __var_name has been initialized
                     if ! [ -z \"\${${__var_name}+x}\" ]; then
-                        echo \"[ERROR] hs_persist_state: variable '$__var_name' is already defined in the state, with value '\${${__var_name}}'.\" >&2
+                        echo \"[ERROR] hs_persist_state_as_code: variable '$__var_name' is already defined in the state, with value '\${${__var_name}}'.\" >&2
                         exit 1
                     fi
                 }
@@ -262,12 +263,12 @@ hs_persist_state() {
             local status=$?
             if [ $status -eq 124 ] || [ $status -eq 127 ] || [ $status -eq 137 ] || [ $status -eq 143 ]; then
                 # Status code snippet timed out: 124 (timeout), 137 (killed), 127 (command not found), 143 (sigterm)
-                echo "[ERROR] hs_persist_state: prior state is corrupted." >&2
+                echo "[ERROR] hs_persist_state_as_code: prior state is corrupted." >&2
                 return $((HS_ERR_CORRUPT_STATE))
             elif [ $status -eq 1 ]; then
                 return $((HS_ERR_VAR_NAME_COLLISION))
             elif [ $status -ne 0 ]; then
-                echo "[ERROR] hs_persist_state: internal error while checking for variable name collision for '$__var_name'." >&2
+                echo "[ERROR] hs_persist_state_as_code: internal error while checking for variable name collision for '$__var_name'." >&2
                 return $((HS_ERR_CORRUPT_STATE))
             fi
         fi
@@ -323,7 +324,7 @@ fi
 #   }
 hs_destroy_state() {
     # Step 1: resolve the input/output state sources using the same -s/-S
-    # parsing rules as hs_persist_state. After this call:
+    # parsing rules as hs_persist_state_as_code. After this call:
     #   - __existing_state contains the input state snippet to transform
     #   - __output_state_var names the destination variable, if -S was used
     #   - __consumed_state_args tells us how many option arguments to discard
@@ -358,7 +359,7 @@ hs_destroy_state() {
 
     # Step 4: scan the existing state snippet for persisted variable names.
     # We intentionally look only for the top-level headers emitted by
-    # hs_persist_state:
+    # hs_persist_state_as_code:
     #   if local -p VAR >/dev/null 2>&1; then
     # For each discovered variable:
     #   - record it in __state_var_names
@@ -409,10 +410,10 @@ hs_destroy_state() {
     # Instead of editing the text blocks in place, run a fresh Bash subprocess
     # that:
     #   1. defines the minimal helpers needed (_hs_resolve_state_inputs and
-    #      hs_persist_state plus their error-code constants),
+    #      hs_persist_state_as_code plus their error-code constants),
     #   2. declares every survivor variable local,
     #   3. evals the incoming state to restore those locals,
-    #   4. calls the stdout form of hs_persist_state on the survivor list.
+    #   4. calls the stdout form of hs_persist_state_as_code on the survivor list.
     #
     # This avoids depending on BASH_SOURCE or on re-sourcing this file from a
     # filesystem path, which would break when handle_state.sh was obtained via
@@ -431,7 +432,7 @@ hs_destroy_state() {
             readonly HS_ERR_CORRUPT_STATE='"$HS_ERR_CORRUPT_STATE"'
             readonly HS_ERR_INVALID_VAR_NAME='"$HS_ERR_INVALID_VAR_NAME"'
             '"$(declare -f _hs_resolve_state_inputs)"'
-            '"$(declare -f hs_persist_state)"'
+            '"$(declare -f hs_persist_state_as_code)"'
             _hs_destroy_state_rebuild() {
                 local __rebuild_state=$1
                 shift
@@ -440,7 +441,7 @@ hs_destroy_state() {
                     local "$__name"
                 done
                 eval "$__rebuild_state" >/dev/null
-                hs_persist_state "$@"
+                hs_persist_state_as_code "$@"
             }
             _hs_destroy_state_rebuild "$@"
         ' bash "$__existing_state" "${__keep_state_args[@]}")
@@ -458,7 +459,7 @@ hs_destroy_state() {
     fi
 
     # Step 9: emit the rebuilt state using the same stdout / -S convention as
-    # hs_persist_state.
+    # hs_persist_state_as_code.
     if [ -n "$__output_state_var" ]; then
         printf -v "$__output_state_var" '%s' "$__output"
     else
@@ -469,7 +470,7 @@ hs_destroy_state() {
 # Function: 
 #   hs_read_persisted_state
 # Description: 
-#   Emits the state string produced by `hs_persist_state` without evaluating it.
+#   Emits the state string produced by `hs_persist_state_as_code` without evaluating it.
 #   The state is passed by variable name and accessed via a nameref, so callers
 #   do not pass the snippet by value. This function still only returns the
 #   stored code snippet; callers should `eval "$(hs_read_persisted_state state)"`
@@ -478,7 +479,7 @@ hs_destroy_state() {
 #   The referenced state variable contains a bash code snippet that assigns
 #   values to existing local and empty variables in the current scope.
 # Arguments:
-#   $1 - name of the variable holding the state string produced by `hs_persist_state`
+#   $1 - name of the variable holding the state string produced by `hs_persist_state_as_code`
 # Usage examples:
 #   # direct eval
 #   cleanup() {

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -71,9 +71,15 @@ readonly HS_ERR_INVALID_ARGUMENT_TYPE=9
 #        Note that the value associated with the last given option will be mistaken
 #        for a variable unless `--` is used.
 # Errors:
-#   - Rejects a missing `-S` option.
-#   - Rejects an invalid variable name.
-#   - Rejects collisions with variables already present in the prior state.
+#   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing.
+#   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
+#     persisted variable name is not a valid Bash identifier.
+#   - `HS_ERR_RESERVED_VAR_NAME` if a requested persisted variable name is one
+#     of the helper's reserved internal names.
+#   - `HS_ERR_VAR_NAME_COLLISION` if one or more requested variable names are
+#     already defined in the prior state object.
+#   - `HS_ERR_CORRUPT_STATE` if the prior state object cannot be evaluated
+#     safely during collision checking.
 # Usage examples:
 #   local state
 #   init() {
@@ -193,9 +199,13 @@ fi
 #        Note that the value associated with the last given option will be mistaken
 #        for a variable unless `--` is used.
 # Errors:
-#   - Rejects a missing `-S` option.
-#   - Rejects an invalid variable name.
-#   - Rejects destroy requests for variables not present in the state object.
+#   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing.
+#   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
+#     destroy variable name is not a valid Bash identifier.
+#   - `HS_ERR_VAR_NAME_NOT_IN_STATE` if a requested destroy variable is not
+#     present in the input state object.
+#   - `HS_ERR_CORRUPT_STATE` if the input state object cannot be parsed or
+#     rebuilt safely.
 # Usage examples:
 #   cleanup_function() {
 #       hs_destroy_state "$@" -- mylib_statevar1 mylib_statevar2
@@ -327,9 +337,15 @@ hs_destroy_state() {
 #        Note that the detached value associated with the last given option will be mistaken
 #        for a variable unless that option is known or `--` is used.
 # Errors:
-#   - Rejects a missing `-S` option.
-#   - Rejects an invalid variable name.
-#   - Rejects a state variable that is missing, unset, or empty.
+#   - `HS_ERR_MISSING_ARGUMENT` if no state variable name is supplied at all.
+#   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
+#     restore variable name is not a valid Bash identifier.
+#   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing, or if
+#     the named state variable is unset or empty.
+#   - `HS_ERR_CORRUPT_STATE` if the state object cannot be evaluated safely
+#     while restoring requested variables.
+#   - Missing requested variables are warnings, one per variable, unless `-q`
+#     is supplied.
 # Usage examples:
 #   cleanup() {
 #       local state_var="$1"
@@ -477,27 +493,39 @@ _hs_is_valid_variable_name() {
 # Function:
 #   _hs_resolve_state_inputs
 # Description:
-#   Parses the `-S <statevar>` option for state-oriented helpers and resolves
-#   the current state from the named variable. Parsed results are returned to
-#   the caller through variable names passed as parameters.
+#   Parses helper options for state-oriented functions. Parsed results are
+#   returned to the caller through the array variables named in `$2` and `$4`.
+#   The helper recognizes `-S <statevar>` when requested by `$3`, optional
+#   helper flags such as `-q`, unknown forwarded options, and an optional
+#   final `--` separator before an explicit variable-name list.
 # Arguments:
 #   $1 - caller function name, used in error messages; must be a valid Bash name
-#   $2 - name of the array variable that will receive the unprocessed arguments; must be a valid Bash name
-#   $3 - getopts format string of accepted parameters; e.g. qS::
-#   $4 - name of the associative array variable that will receive the processed arguments; must be a valid Bash name
-#   $5 - first forwarded argument option
-#   $6... - additional forwarded arguments; if `--` is present, its last
-#           occurrence marks the start of the explicit variable-name list
+#   $2 - name of the indexed array variable that will receive forwarded,
+#        unprocessed arguments; must be a valid Bash name
+#   $3 - `getopts` format string of accepted helper options; e.g. `qS:`
+#   $4 - name of the associative array variable that will receive processed
+#        arguments; must be a valid Bash name
+#   $5... - forwarded arguments from the public helper caller; if `--` is
+#           present, its last occurrence marks the start of the explicit
+#           variable-name list
 # Returns:
 #   0 on success.
-#   `HS_ERR_MISSING_ARGUMENT` if fewer than 6 arguments are provided.
-#   `HS_ERR_INVALID_ARGUMENT_TYPE` if the output containers do not have the
-#   expected array types.
+#   On success, `$4` may contain:
+#     - `state`: the validated state variable name from `-S`
+#     - `quiet`: `true` or `false`
+#     - `vars`: the validated explicit variable-name list as a space-separated string
+#     - `separator`: set when an explicit `--` was seen
+#   `HS_ERR_MISSING_ARGUMENT` if a required option parameter such as the value
+#   for `-S` is missing.
+#   `HS_ERR_INVALID_ARGUMENT_TYPE` if `$2` is not an indexed array variable or
+#   if `$4` is not an associative array variable.
+#   `HS_ERR_INVALID_VAR_NAME` if the state variable name or an explicit
+#   variable-name token is not a valid Bash identifier.
 #   `HS_ERR_STATE_VAR_UNINITIALIZED` if no `-S <statevar>` option is provided.
-#   `HS_ERR_INVALID_VAR_NAME` if `-S` is followed by an invalid variable name.
 # Usage:
-#   local existing_state="" output_state_var="" consumed_state_args=0
-#   _hs_resolve_state_inputs my_helper existing_state output_state_var consumed_state_args "$@" || return $?
+#   local -a remaining_args=()
+#   local -A processed_args=()
+#   _hs_resolve_state_inputs my_helper remaining_args qS: processed_args "$@" || return $?
 _hs_resolve_state_inputs() {
     if [ $# -lt 4 ]; then
         echo "[ERROR] $1: missing required arguments; expected at least 4 parameters." >&2

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -469,21 +469,23 @@ hs_destroy_state() {
 # Function: 
 #   hs_read_persisted_state
 # Description: 
-#   Emits the state string produced by `hs_persist_state` without
-#   evaluating it. This avoids executing the state inside this function's scope
-#   (which would prevent assignments to `local` variables declared in the
-#   calling function). Callers should `eval "$(hs_read_persisted_state "$state")"`
+#   Emits the state string produced by `hs_persist_state` without evaluating it.
+#   The state is passed by variable name and accessed via a nameref, so callers
+#   do not pass the snippet by value. This function still only returns the
+#   stored code snippet; callers should `eval "$(hs_read_persisted_state state)"`
 #   or simply `eval "$state"` to recreate variables in the caller scope.
 #   Can be called several times to extract distinct variables.
-#   "$state" is a bash code snippet that assigns values to existing local and empty
-#   variables in the current scope.
+#   The referenced state variable contains a bash code snippet that assigns
+#   values to existing local and empty variables in the current scope.
 # Arguments:
-#   $1 - state string produced by `hs_persist_state`
+#   $1 - name of the variable holding the state string produced by `hs_persist_state`
 # Usage examples:
 #   # direct eval
 #   cleanup() {
+#       local state_var="$1"
+#       local -n state_ref="$state_var"
 #       local temp_file resource_id
-#       eval "$1"
+#       eval "$state_ref"
 #       # vars are available here
 #   }
 #
@@ -491,10 +493,10 @@ hs_destroy_state() {
 #   cleanup() {
 #       local state="$1"
 #       local temp_file resource_id
-#       eval "$(hs_read_persisted_state \"$state\")"
+#       eval "$(hs_read_persisted_state state)"
 #   }
 hs_read_persisted_state() {
-    local state_string="$1"
+    local -n state_string="$1"
     printf '%s' "$state_string"
 }
 

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -135,6 +135,66 @@ readonly HS_ERR_VAR_NAME_COLLISION=2
 readonly HS_ERR_MULTIPLE_STATE_INPUTS=3
 readonly HS_ERR_CORRUPT_STATE=4
 readonly HS_ERR_INVALID_VAR_NAME=5
+readonly HS_ERR_VAR_NAME_NOT_IN_STATE=6
+
+# _hs_resolve_state_inputs <caller_name> <existing_state_var> <output_state_var> <consumed_count_var> [args...]
+# Parses -s/-S options for state-oriented helpers and resolves the prior state
+# from either the explicit -s payload or the named -S variable. The caller
+# receives the parsed values via the variable names passed in arguments 2 and 3,
+# plus the number of consumed option arguments in argument 4.
+_hs_resolve_state_inputs() {
+    local __caller_name=$1
+    local __existing_state_ref=$2
+    local __output_state_var_ref=$3
+    local __consumed_count_ref=$4
+    local __consumed_count=0
+    local __output_state_var_name=""
+    shift 4
+
+    printf -v "$__existing_state_ref" '%s' ""
+    printf -v "$__output_state_var_ref" '%s' ""
+    printf -v "$__consumed_count_ref" '%s' "0"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -s)
+                shift
+                __consumed_count=$((__consumed_count + 1))
+                printf -v "$__existing_state_ref" '%s' "$1"
+                shift
+                __consumed_count=$((__consumed_count + 1))
+                ;;
+            -S)
+                shift
+                __consumed_count=$((__consumed_count + 1))
+                printf -v "$__output_state_var_ref" '%s' "$1"
+                __output_state_var_name="${!__output_state_var_ref}"
+                if ! [[ "$__output_state_var_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+                    echo "[ERROR] ${__caller_name}: invalid variable name '$__output_state_var_name' for -S option." >&2
+                    return "$HS_ERR_INVALID_VAR_NAME"
+                fi
+                shift
+                __consumed_count=$((__consumed_count + 1))
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    __output_state_var_name="${!__output_state_var_ref}"
+
+    if [ -n "$__output_state_var_name" ] && [ -n "${!__existing_state_ref}" ]; then
+        echo "[ERROR] ${__caller_name}: cannot pass prior state using both -s and -S options simultaneously." >&2
+        return "$HS_ERR_MULTIPLE_STATE_INPUTS"
+    fi
+
+    if [ -n "$__output_state_var_name" ]; then
+        printf -v "$__existing_state_ref" '%s' "${!__output_state_var_name}"
+    fi
+
+    printf -v "$__consumed_count_ref" '%s' "$__consumed_count"
+}
 
 # --- hs_persist_state ----------------------------------------------------------
 # Function:
@@ -149,6 +209,9 @@ readonly HS_ERR_INVALID_VAR_NAME=5
 # Arguments:
 #   -s <state> - optional; if provided, appends the emitted code to variable
 #                definitions found in <state> (bash code snippet).
+#   -S <statevar> - optional; if provided, appends the emitted code to variable
+#                   definitions found in the variable <statevar>. The variable 
+#                   must be empty or uninitialized if -s is also used.
 #   $@ - names of local variables to persist.
 # Usage examples:
 #   # direct eval
@@ -161,38 +224,9 @@ readonly HS_ERR_INVALID_VAR_NAME=5
 hs_persist_state() {
     local __existing_state=""
     local __output_state_var=""
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            -s)
-                shift
-                __existing_state="$1"
-                shift
-                ;;
-            -S)
-                shift
-                __output_state_var="$1"
-                # Check that __output_state_var is a valid variable name
-                if ! [[ "$__output_state_var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-                    echo "[ERROR] hs_persist_state: invalid variable name '$__output_state_var' for -S option." >&2
-                    return "$HS_ERR_INVALID_VAR_NAME"
-                fi
-                ;;
-            *)
-                break
-                ;;
-        esac
-    done
-    # If __output_stat_var is set, we have to check if __existing_state is set too,
-    # and enforce that ${!__output_state_var} is uninitialized or empty to ensure
-    # that we are not dealing with multiple prior state strings.
-    if [ -n "$__output_state_var" ] && [ -n "$__existing_state" ]; then
-        echo "[ERROR] hs_persist_state: cannot pass prior state using both -s and -S options simultaneously." >&2
-        return "$HS_ERR_MULTIPLE_STATE_INPUTS"
-    fi
-    # If __output_state_var is set, retrieve prior state from it
-    if [ -n "${__output_state_var}" ]; then
-        __existing_state="${!__output_state_var}"
-    fi
+    local __consumed_state_args=0
+    _hs_resolve_state_inputs hs_persist_state __existing_state __output_state_var __consumed_state_args "$@" || return $?
+    shift "$__consumed_state_args"
     # Initialize output state string
     local __output=""
     if [ -n "$__existing_state" ]; then
@@ -268,6 +302,169 @@ fi
     fi
 }
 
+# --- hs_destroy_state ---------------------------------------------------------------
+# Function:
+#   hs_destroy_state
+# Description:
+#   Purge the state string from the given definitions. In the cleanup function
+#   of a library, the state vector should be stripped of that library's state
+#   variables, so that the init function can be called again without triggering
+#   name collision errors.
+# Arguments:
+#   -s <state> - optional; if provided, appends the emitted code to variable
+#                definitions found in <state> (bash code snippet).
+#   -S <statevar> - optional; if provided, appends the emitted code to variable
+#                   definitions found in the variable <statevar>. The variable 
+#                   must be empty or uninitialized if -s is also used.
+#   $@ - names of local variables to destroy.
+# Usage examples:
+#   mylib_cleanup() {
+#       hs_destroystate "$@" mylib_statevar1 mylibstatevar2 
+#   }
+hs_destroy_state() {
+    # Step 1: resolve the input/output state sources using the same -s/-S
+    # parsing rules as hs_persist_state. After this call:
+    #   - __existing_state contains the input state snippet to transform
+    #   - __output_state_var names the destination variable, if -S was used
+    #   - __consumed_state_args tells us how many option arguments to discard
+    #     before "$@" contains only variable names to destroy.
+    local __existing_state=""
+    local __output_state_var=""
+    local __consumed_state_args=0
+    _hs_resolve_state_inputs hs_destroy_state __existing_state __output_state_var __consumed_state_args "$@" || return $?
+    shift "$__consumed_state_args"
+
+    # Step 2: set up working variables.
+    # __state_var_names will contain every variable name found in the incoming
+    # persisted state. __keep_state_names will contain only the survivors, i.e.
+    # variables that remain after removing the requested names.
+    local __output=""
+    local __var_name
+    local __line=""
+    local __state_var=""
+    local __state_var_found=false
+    local __keep_var=""
+    local __keep_state_names=""
+    local __state_var_names=""
+
+    # Step 3: validate the destroy list itself before touching the state.
+    # Each requested name must be a syntactically valid shell variable name.
+    for __var_name in "$@"; do
+        if ! [[ "$__var_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+            echo "[ERROR] hs_destroy_state: invalid variable name '$__var_name'." >&2
+            return "$HS_ERR_INVALID_VAR_NAME"
+        fi
+    done
+
+    # Step 4: scan the existing state snippet for persisted variable names.
+    # We intentionally look only for the top-level headers emitted by
+    # hs_persist_state:
+    #   if local -p VAR >/dev/null 2>&1; then
+    # For each discovered variable:
+    #   - record it in __state_var_names
+    #   - if it is NOT in the destroy list, add it to __keep_state_names
+    # We do not splice the blocks directly. We only discover the names here;
+    # the actual output state will be rebuilt from surviving variables later.
+    while IFS= read -r __line || [[ -n "$__line" ]]; do
+        if [[ "$__line" =~ ^if\ local\ -p\ ([a-zA-Z_][a-zA-Z0-9_]*)\ \>/dev/null\ 2\>\&1\;\ then$ ]]; then
+            __state_var="${BASH_REMATCH[1]}"
+            __state_var_names+="${__state_var}"$'\n'
+            __state_var_found=false
+            for __var_name in "$@"; do
+                if [[ "$__var_name" == "$__state_var" ]]; then
+                    __state_var_found=true
+                    break
+                fi
+            done
+            if [[ "$__state_var_found" == false ]]; then
+                __keep_state_names+="${__state_var}"$'\n'
+            fi
+        fi
+    done <<< "$__existing_state"
+
+    # Step 5: if we were given a non-empty state string but found no persisted
+    # variable headers at all, treat that state as corrupt.
+    if [[ -n "$__existing_state" && -z "$__state_var_names" ]]; then
+        echo "[ERROR] hs_destroy_state: prior state is corrupted." >&2
+        return "$HS_ERR_CORRUPT_STATE"
+    fi
+
+    # Step 6: every requested variable must actually exist in the incoming
+    # state. If a requested name is absent, return HS_ERR_INVALID_VAR_NAME.
+    for __var_name in "$@"; do
+        __state_var_found=false
+        while IFS= read -r __state_var || [[ -n "$__state_var" ]]; do
+            if [[ "$__state_var" == "$__var_name" ]]; then
+                __state_var_found=true
+                break
+            fi
+        done <<< "$__state_var_names"
+        if [[ "$__state_var_found" == false ]]; then
+            echo "[ERROR] hs_destroy_state: variable '$__var_name' is not defined in the state." >&2
+            return "$HS_ERR_VAR_NAME_NOT_IN_STATE"
+        fi
+    done
+
+    # Step 7: rebuild the state from scratch using only the survivor names.
+    # Instead of editing the text blocks in place, run a fresh Bash subprocess
+    # that:
+    #   1. defines the minimal helpers needed (_hs_resolve_state_inputs and
+    #      hs_persist_state plus their error-code constants),
+    #   2. declares every survivor variable local,
+    #   3. evals the incoming state to restore those locals,
+    #   4. calls the stdout form of hs_persist_state on the survivor list.
+    #
+    # This avoids depending on BASH_SOURCE or on re-sourcing this file from a
+    # filesystem path, which would break when handle_state.sh was obtained via
+    # remote_run's virtual source mechanism.
+    if [[ -n "$__keep_state_names" ]]; then
+        local -a __keep_state_args=()
+        while IFS= read -r __keep_var || [[ -n "$__keep_var" ]]; do
+            [[ -z "$__keep_var" ]] && continue
+            __keep_state_args+=("$__keep_var")
+        done <<< "$__keep_state_names"
+
+        __output=$(timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -lc '
+            readonly HS_ERR_RESERVED_VAR_NAME='"$HS_ERR_RESERVED_VAR_NAME"'
+            readonly HS_ERR_VAR_NAME_COLLISION='"$HS_ERR_VAR_NAME_COLLISION"'
+            readonly HS_ERR_MULTIPLE_STATE_INPUTS='"$HS_ERR_MULTIPLE_STATE_INPUTS"'
+            readonly HS_ERR_CORRUPT_STATE='"$HS_ERR_CORRUPT_STATE"'
+            readonly HS_ERR_INVALID_VAR_NAME='"$HS_ERR_INVALID_VAR_NAME"'
+            '"$(declare -f _hs_resolve_state_inputs)"'
+            '"$(declare -f hs_persist_state)"'
+            _hs_destroy_state_rebuild() {
+                local __rebuild_state=$1
+                shift
+                local __name
+                for __name in "$@"; do
+                    local "$__name"
+                done
+                eval "$__rebuild_state" >/dev/null
+                hs_persist_state "$@"
+            }
+            _hs_destroy_state_rebuild "$@"
+        ' bash "$__existing_state" "${__keep_state_args[@]}")
+        local __status=$?
+        # Step 8: map rebuild failures to the same "corrupt prior state"
+        # category used elsewhere in handle_state when we cannot safely process
+        # the supplied snippet.
+        if [ $__status -eq 124 ] || [ $__status -eq 127 ] || [ $__status -eq 137 ] || [ $__status -eq 143 ]; then
+            echo "[ERROR] hs_destroy_state: prior state is corrupted." >&2
+            return "$HS_ERR_CORRUPT_STATE"
+        elif [ $__status -ne 0 ]; then
+            echo "[ERROR] hs_destroy_state: internal error while rebuilding state." >&2
+            return "$HS_ERR_CORRUPT_STATE"
+        fi
+    fi
+
+    # Step 9: emit the rebuilt state using the same stdout / -S convention as
+    # hs_persist_state.
+    if [ -n "$__output_state_var" ]; then
+        printf -v "$__output_state_var" '%s' "$__output"
+    else
+        printf '%s\n' "$__output"
+    fi
+}
 # --- hs_read_persisted_state --------------------------------------------------------
 # Function: 
 #   hs_read_persisted_state
@@ -332,5 +529,3 @@ hs_get_pid_of_subshell() {
 hs_setup_output_to_stdout
 
 # Note: Remember to call hs_cleanup at the end of your main script to clean up resources.
-
-

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -136,64 +136,148 @@ readonly HS_ERR_MULTIPLE_STATE_INPUTS=3
 readonly HS_ERR_CORRUPT_STATE=4
 readonly HS_ERR_INVALID_VAR_NAME=5
 readonly HS_ERR_VAR_NAME_NOT_IN_STATE=6
+readonly HS_ERR_STATE_VAR_UNINITIALIZED=7
+readonly HS_ERR_MISSING_ARGUMENT=8
 
-# _hs_resolve_state_inputs <caller_name> <existing_state_var> <output_state_var> <consumed_count_var> [args...]
-# Parses -s/-S options for state-oriented helpers and resolves the prior state
-# from either the explicit -s payload or the named -S variable. The caller
-# receives the parsed values via the variable names passed in arguments 2 and 3,
-# plus the number of consumed option arguments in argument 4.
+# --- _hs_is_valid_variable_name -------------------------------------------------------
+# Function:
+#   _hs_is_valid_variable_name
+# Description:
+#   Returns success if the argument is a syntactically valid Bash variable name.
+# Arguments:
+#   $1 - candidate variable name
+# Returns:
+#   0 if the name is valid, 1 otherwise.
+_hs_is_valid_variable_name() {
+    [[ "${1-}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]
+}
+
+# --- _hs_resolve_state_inputs ---------------------------------------------------------
+# Function:
+#   _hs_resolve_state_inputs
+# Description:
+#   Parses the `-S <statevar>` option for state-oriented helpers and resolves
+#   the current state from the named variable. Parsed results are returned to
+#   the caller through variable names passed as parameters.
+# Arguments:
+#   $1 - caller function name, used in error messages; must be a valid Bash name
+#   $2 - name of the variable that will receive the current state value; must be a valid Bash name
+#   $3 - name of the variable that will receive the destination state variable name; must be a valid Bash name
+#   $4 - name of the variable that will receive the number of consumed option arguments; must be a valid Bash name
+#   $5 - first variable name to process or `-S`
+#   $6... - additional variable names to process, with `-S <statevar>` required somewhere in the argument list
+# Returns:
+#   0 on success.
+#   `HS_ERR_MISSING_ARGUMENT` if fewer than 6 arguments are provided.
+#   `HS_ERR_STATE_VAR_UNINITIALIZED` if no `-S <statevar>` option is provided.
+#   `HS_ERR_INVALID_VAR_NAME` if `-S` is followed by an invalid variable name.
+# Usage:
+#   local existing_state="" output_state_var="" consumed_state_args=0
+#   _hs_resolve_state_inputs my_helper existing_state output_state_var consumed_state_args "$@" || return $?
 _hs_resolve_state_inputs() {
+    if [ $# -lt 6 ]; then
+        echo "[ERROR] _hs_resolve_state_inputs: missing required arguments; expected at least 6 parameters." >&2
+        return "$HS_ERR_MISSING_ARGUMENT"
+    fi
+    local __arg
+    for __arg in "$1" "$2" "$3" "$4"; do
+        if ! _hs_is_valid_variable_name "$__arg"; then
+            echo "[ERROR] _hs_resolve_state_inputs: invalid variable name '$__arg'." >&2
+            return "$HS_ERR_INVALID_VAR_NAME"
+        fi
+    done
     local __caller_name=$1
-    local __existing_state_ref=$2
-    local __output_state_var_ref=$3
-    local __consumed_count_ref=$4
-    local __consumed_count=0
-    local __output_state_var_name=""
+    local -n __existing_state_ref=$2
+    local -n __output_state_var_ref=$3
+    local -n __consumed_count_ref=$4
     shift 4
 
-    printf -v "$__existing_state_ref" '%s' ""
-    printf -v "$__output_state_var_ref" '%s' ""
-    printf -v "$__consumed_count_ref" '%s' "0"
+    __existing_state_ref=""
+    __output_state_var_ref=""
+    __consumed_count_ref=0
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            -s)
-                shift
-                __consumed_count=$((__consumed_count + 1))
-                printf -v "$__existing_state_ref" '%s' "$1"
-                shift
-                __consumed_count=$((__consumed_count + 1))
-                ;;
             -S)
-                shift
-                __consumed_count=$((__consumed_count + 1))
-                printf -v "$__output_state_var_ref" '%s' "$1"
-                __output_state_var_name="${!__output_state_var_ref}"
-                if ! [[ "$__output_state_var_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-                    echo "[ERROR] ${__caller_name}: invalid variable name '$__output_state_var_name' for -S option." >&2
+                __output_state_var_ref="$2"
+                if ! _hs_is_valid_variable_name "$__output_state_var_ref"; then
+                    echo "[ERROR] ${__caller_name}: invalid variable name '$__output_state_var_ref' for -S option." >&2
+                    return "$HS_ERR_INVALID_VAR_NAME"
+                fi
+                shift 2
+                __consumed_count_ref=$((__consumed_count_ref + 2))
+                ;;
+            *)
+                if ! _hs_is_valid_variable_name "$1"; then
+                    echo "[ERROR] ${__caller_name}: invalid variable name '$1'." >&2
                     return "$HS_ERR_INVALID_VAR_NAME"
                 fi
                 shift
-                __consumed_count=$((__consumed_count + 1))
-                ;;
-            *)
-                break
                 ;;
         esac
     done
 
-    __output_state_var_name="${!__output_state_var_ref}"
-
-    if [ -n "$__output_state_var_name" ] && [ -n "${!__existing_state_ref}" ]; then
-        echo "[ERROR] ${__caller_name}: cannot pass prior state using both -s and -S options simultaneously." >&2
-        return "$HS_ERR_MULTIPLE_STATE_INPUTS"
+    if [ -z "$__output_state_var_ref" ]; then
+        echo "[ERROR] ${__caller_name}: state variable is uninitialized; missing required -S <statevar> option." >&2
+        return "$HS_ERR_STATE_VAR_UNINITIALIZED"
     fi
 
-    if [ -n "$__output_state_var_name" ]; then
-        printf -v "$__existing_state_ref" '%s' "${!__output_state_var_name}"
+    eval "__existing_state_ref=\${$__output_state_var_ref-}"
+}
+
+# --- _hs_extract_persisted_state_var_names -------------------------------------------
+# Function:
+#   _hs_extract_persisted_state_var_names
+# Description:
+#   Parses a code-snippet state produced by `hs_persist_state_as_code` and
+#   extracts the variable names declared by its guarded `if local -p VAR ...`
+#   blocks. Results are returned through an array nameref.
+# Arguments:
+#   $1 - caller function name, used in error messages
+#   $2 - state snippet string to inspect
+#   $3 - name of the array variable that will receive extracted variable names
+# Returns:
+#   0 on success.
+#   `HS_ERR_INVALID_VAR_NAME` if one of the first or third arguments is not a
+#   valid Bash variable name.
+#   `HS_ERR_CORRUPT_STATE` if the snippet contains an invalid persisted variable
+#   name or if the state is non-empty but contains no persisted variable blocks.
+# Usage:
+#   local -a state_var_names=()
+#   _hs_extract_persisted_state_var_names my_helper "$state" state_var_names || return $?
+_hs_extract_persisted_state_var_names() {
+    if [ $# -ne 3 ]; then
+        echo "[ERROR] _hs_extract_persisted_state_var_names: expected exactly 3 arguments." >&2
+        return "$HS_ERR_MISSING_ARGUMENT"
+    fi
+    if ! _hs_is_valid_variable_name "$1" || ! _hs_is_valid_variable_name "$3"; then
+        echo "[ERROR] _hs_extract_persisted_state_var_names: invalid variable name '$1' or '$3'." >&2
+        return "$HS_ERR_INVALID_VAR_NAME"
     fi
 
-    printf -v "$__consumed_count_ref" '%s' "$__consumed_count"
+    local __caller_name=$1
+    local __state=$2
+    local -n __out_names_ref=$3
+    local __line=""
+    local __state_var_name=""
+
+    __out_names_ref=()
+    while IFS= read -r __line || [[ -n "$__line" ]]; do
+        if [[ "$__line" == "if local -p "* ]]; then
+            __state_var_name=${__line#if local -p }
+            __state_var_name=${__state_var_name%% *}
+            if ! _hs_is_valid_variable_name "$__state_var_name"; then
+                echo "[ERROR] ${__caller_name}: prior state is corrupted." >&2
+                return "$HS_ERR_CORRUPT_STATE"
+            fi
+            __out_names_ref+=("$__state_var_name")
+        fi
+    done <<< "$__state"
+
+    if [[ -n "$__state" && ${#__out_names_ref[@]} -eq 0 ]]; then
+        echo "[ERROR] ${__caller_name}: prior state is corrupted." >&2
+        return "$HS_ERR_CORRUPT_STATE"
+    fi
 }
 
 # --- hs_persist_state_as_code ----------------------------------------------------------
@@ -207,14 +291,10 @@ _hs_resolve_state_inputs() {
 #   If the variable already exists and is non-empty in the receiving scope,
 #   an error message is printed and the assignment is skipped.
 # Arguments:
-#   -s <state> - optional; if provided, appends the emitted code to variable
-#                definitions found in <state> (bash code snippet - deprecated).
-#   -S <statevar> - optional; if provided, appends the emitted code to variable
-#                   definitions found in the variable <statevar>. The variable 
-#                   must be empty or uninitialized if -s is also used.
+#   -S <statevar> - required; appends the emitted code to variable
+#                   definitions found in the variable <statevar>.
 #   $@ - names of local variables to persist.
 # Usage examples:
-#   # direct eval
 #   local state
 #   hs_persist_state_as_code -S state var1 var2
 #   cleanup() {
@@ -296,11 +376,7 @@ fi
             __output="${__output}${__snippet}"
         fi
     done
-    if [ -n "$__output_state_var" ]; then
-        eval "$__output_state_var=\"\$__output\""
-    else
-        printf '%s\n' "$__output"
-    fi
+    printf -v "$__output_state_var" '%s' "$__output"
 }
 
 # --- hs_destroy_state ---------------------------------------------------------------
@@ -312,18 +388,15 @@ fi
 #   variables, so that the init function can be called again without triggering
 #   name collision errors.
 # Arguments:
-#   -s <state> - optional; if provided, appends the emitted code to variable
-#                definitions found in <state> (bash code snippet).
-#   -S <statevar> - optional; if provided, appends the emitted code to variable
-#                   definitions found in the variable <statevar>. The variable 
-#                   must be empty or uninitialized if -s is also used.
+#   -S <statevar> - required; reads and rewrites the state held in
+#                   the variable <statevar>.
 #   $@ - names of local variables to destroy.
 # Usage examples:
 #   mylib_cleanup() {
-#       hs_destroystate "$@" mylib_statevar1 mylibstatevar2 
+#       hs_destroy_state -S state mylib_statevar1 mylibstatevar2
 #   }
 hs_destroy_state() {
-    # Step 1: resolve the input/output state sources using the same -s/-S
+    # Step 1: resolve the input/output state sources using the same -S-only
     # parsing rules as hs_persist_state_as_code. After this call:
     #   - __existing_state contains the input state snippet to transform
     #   - __output_state_var names the destination variable, if -S was used
@@ -341,72 +414,48 @@ hs_destroy_state() {
     # variables that remain after removing the requested names.
     local __output=""
     local __var_name
-    local __line=""
     local __state_var=""
     local __state_var_found=false
     local __keep_var=""
     local __keep_state_names=""
-    local __state_var_names=""
+    local -a __state_var_names=()
 
-    # Step 3: validate the destroy list itself before touching the state.
-    # Each requested name must be a syntactically valid shell variable name.
-    for __var_name in "$@"; do
-        if ! [[ "$__var_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
-            echo "[ERROR] hs_destroy_state: invalid variable name '$__var_name'." >&2
-            return "$HS_ERR_INVALID_VAR_NAME"
+    # Step 3: scan the existing state snippet for persisted variable names.
+    # We intentionally look only for the top-level headers emitted by
+    # hs_persist_state_as_code. We do not splice the blocks directly. We only
+    # discover the names here; the actual output state will be rebuilt from
+    # surviving variables later.
+    _hs_extract_persisted_state_var_names hs_destroy_state "$__existing_state" __state_var_names || return $?
+    for __state_var in "${__state_var_names[@]}"; do
+        __state_var_found=false
+        for __var_name in "$@"; do
+            if [[ "$__var_name" == "$__state_var" ]]; then
+                __state_var_found=true
+                break
+            fi
+        done
+        if [[ "$__state_var_found" == false ]]; then
+            __keep_state_names+="${__state_var}"$'\n'
         fi
     done
 
-    # Step 4: scan the existing state snippet for persisted variable names.
-    # We intentionally look only for the top-level headers emitted by
-    # hs_persist_state_as_code:
-    #   if local -p VAR >/dev/null 2>&1; then
-    # For each discovered variable:
-    #   - record it in __state_var_names
-    #   - if it is NOT in the destroy list, add it to __keep_state_names
-    # We do not splice the blocks directly. We only discover the names here;
-    # the actual output state will be rebuilt from surviving variables later.
-    while IFS= read -r __line || [[ -n "$__line" ]]; do
-        if [[ "$__line" =~ ^if\ local\ -p\ ([a-zA-Z_][a-zA-Z0-9_]*)\ \>/dev/null\ 2\>\&1\;\ then$ ]]; then
-            __state_var="${BASH_REMATCH[1]}"
-            __state_var_names+="${__state_var}"$'\n'
-            __state_var_found=false
-            for __var_name in "$@"; do
-                if [[ "$__var_name" == "$__state_var" ]]; then
-                    __state_var_found=true
-                    break
-                fi
-            done
-            if [[ "$__state_var_found" == false ]]; then
-                __keep_state_names+="${__state_var}"$'\n'
-            fi
-        fi
-    done <<< "$__existing_state"
-
-    # Step 5: if we were given a non-empty state string but found no persisted
-    # variable headers at all, treat that state as corrupt.
-    if [[ -n "$__existing_state" && -z "$__state_var_names" ]]; then
-        echo "[ERROR] hs_destroy_state: prior state is corrupted." >&2
-        return "$HS_ERR_CORRUPT_STATE"
-    fi
-
-    # Step 6: every requested variable must actually exist in the incoming
+    # Step 5: every requested variable must actually exist in the incoming
     # state. If a requested name is absent, return HS_ERR_INVALID_VAR_NAME.
     for __var_name in "$@"; do
         __state_var_found=false
-        while IFS= read -r __state_var || [[ -n "$__state_var" ]]; do
+        for __state_var in "${__state_var_names[@]}"; do
             if [[ "$__state_var" == "$__var_name" ]]; then
                 __state_var_found=true
                 break
             fi
-        done <<< "$__state_var_names"
+        done
         if [[ "$__state_var_found" == false ]]; then
             echo "[ERROR] hs_destroy_state: variable '$__var_name' is not defined in the state." >&2
             return "$HS_ERR_VAR_NAME_NOT_IN_STATE"
         fi
     done
 
-    # Step 7: rebuild the state from scratch using only the survivor names.
+    # Step 6: rebuild the state from scratch using only the survivor names.
     # Instead of editing the text blocks in place, run a fresh Bash subprocess
     # that:
     #   1. defines the minimal helpers needed (_hs_resolve_state_inputs and
@@ -437,16 +486,18 @@ hs_destroy_state() {
                 local __rebuild_state=$1
                 shift
                 local __name
+                local __rebuilt_state=""
                 for __name in "$@"; do
                     local "$__name"
                 done
                 eval "$__rebuild_state" >/dev/null
-                hs_persist_state_as_code "$@"
+                hs_persist_state_as_code -S __rebuilt_state "$@"
+                printf '%s' "$__rebuilt_state"
             }
             _hs_destroy_state_rebuild "$@"
         ' bash "$__existing_state" "${__keep_state_args[@]}")
         local __status=$?
-        # Step 8: map rebuild failures to the same "corrupt prior state"
+        # Step 7: map rebuild failures to the same "corrupt prior state"
         # category used elsewhere in handle_state when we cannot safely process
         # the supplied snippet.
         if [ $__status -eq 124 ] || [ $__status -eq 127 ] || [ $__status -eq 137 ] || [ $__status -eq 143 ]; then
@@ -458,13 +509,8 @@ hs_destroy_state() {
         fi
     fi
 
-    # Step 9: emit the rebuilt state using the same stdout / -S convention as
-    # hs_persist_state_as_code.
-    if [ -n "$__output_state_var" ]; then
-        printf -v "$__output_state_var" '%s' "$__output"
-    else
-        printf '%s\n' "$__output"
-    fi
+    # Step 8: write the rebuilt state back into the named state variable.
+    printf -v "$__output_state_var" '%s' "$__output"
 }
 # --- hs_read_persisted_state --------------------------------------------------------
 # Function: 
@@ -475,11 +521,19 @@ hs_destroy_state() {
 #   do not pass the snippet by value. This function still only returns the
 #   stored code snippet; callers should `eval "$(hs_read_persisted_state state)"`
 #   or simply `eval "$state"` to recreate variables in the caller scope.
+#   For convenience, callers may pass either `state` or `-S state`.
 #   Can be called several times to extract distinct variables.
 #   The referenced state variable contains a bash code snippet that assigns
 #   values to existing local and empty variables in the current scope.
 # Arguments:
-#   $1 - name of the variable holding the state string produced by `hs_persist_state_as_code`
+#   $1 - name of the variable holding the state string produced by `hs_persist_state_as_code`,
+#        or `-S`
+#   $2 - state variable name when `$1` is `-S`
+# Errors:
+#   - Rejects a missing first argument.
+#   - Rejects an invalid variable name.
+#   - Rejects a valid variable name that does not refer to an existing,
+#     non-empty state variable.
 # Usage examples:
 #   # direct eval
 #   cleanup() {
@@ -497,8 +551,108 @@ hs_destroy_state() {
 #       eval "$(hs_read_persisted_state state)"
 #   }
 hs_read_persisted_state() {
-    local -n state_string="$1"
-    printf '%s' "$state_string"
+    # Step 1: parse hs_read_persisted_state-specific flags before delegating
+    # the shared state-input handling to _hs_resolve_state_inputs.
+    local __quiet=false
+    while [ $# -gt 0 ] && [ "${1-}" = "-q" ]; do
+        __quiet=true
+        shift
+    done
+
+    if [ $# -eq 0 ]; then
+        echo "[ERROR] hs_read_persisted_state: missing required state variable name." >&2
+        return "$HS_ERR_MISSING_ARGUMENT"
+    fi
+
+    if [ "${1-}" != "-S" ]; then
+        set -- -S "$@"
+    fi
+
+    # Step 2: resolve the named state variable and capture its current payload.
+    # The helper validates names, enforces the presence of -S, and returns:
+    #   - __existing_state: the current serialized state snippet
+    #   - __output_state_var: the caller-visible variable name holding that state
+    #   - __consumed_state_args: how many leading arguments belong to state input
+    local __existing_state=""
+    local __output_state_var=""
+    local __consumed_state_args=0
+    _hs_resolve_state_inputs hs_read_persisted_state __existing_state __output_state_var __consumed_state_args "$@" || return $?
+
+    if [ -z "$__existing_state" ]; then
+        echo "[ERROR] hs_read_persisted_state: state variable '$__output_state_var' is not set or is empty." >&2
+        return "$HS_ERR_STATE_VAR_UNINITIALIZED"
+    fi
+
+    # Step 3: if the caller listed variable names after the state input, restore
+    # only those variables directly into the caller scope. This is the explicit
+    # selective-restore API.
+    if [ $# -ne "$__consumed_state_args" ]; then
+        shift "$__consumed_state_args"
+
+        local __requested_var
+        local __restored_value=""
+        local __restore_status=0
+        for __requested_var in "$@"; do
+            # Evaluate the persisted state in a short-lived Bash subprocess,
+            # scoped to one requested variable, then print the resulting value
+            # back to this function. The subprocess is isolated and time-bounded
+            # because the persisted format is still executable Bash code.
+            __restored_value=$(timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -lc '
+                _hs_read_requested_state_var() {
+                    local __state=$1
+                    local __requested_var=$2
+                    local "$__requested_var"
+                    eval "$__state" >/dev/null 2>&1 || return $?
+                    if [ "${!__requested_var+x}" ]; then
+                        printf "%s" "${!__requested_var}"
+                        return 0
+                    fi
+                    return 10
+                }
+                _hs_read_requested_state_var "$@"
+            ' bash "$__existing_state" "$__requested_var")
+            __restore_status=$?
+
+            if [ $__restore_status -eq 124 ] || [ $__restore_status -eq 127 ] || [ $__restore_status -eq 137 ] || [ $__restore_status -eq 143 ]; then
+                echo "[ERROR] hs_read_persisted_state: prior state is corrupted." >&2
+                return "$HS_ERR_CORRUPT_STATE"
+            elif [ $__restore_status -eq 10 ]; then
+                if [ "$__quiet" = false ]; then
+                    echo "[WARNING] hs_read_persisted_state: variable '$__requested_var' is not defined in the state." >&2
+                fi
+                continue
+            elif [ $__restore_status -ne 0 ]; then
+                echo "[ERROR] hs_read_persisted_state: internal error while restoring '$__requested_var'." >&2
+                return "$HS_ERR_CORRUPT_STATE"
+            fi
+
+            # Write the restored value back into the caller's variable by name.
+            local -n __requested_var_ref="$__requested_var"
+            __requested_var_ref="$__restored_value"
+        done
+        return 0
+    fi
+
+    # Step 4: otherwise, generate a safe, local probe snippet instead of
+    # returning the raw persisted code. The snippet checks which matching local
+    # variables are currently declared and unset in the caller, then reenters
+    # hs_read_persisted_state with an explicit variable list. This avoids asking
+    # callers to eval arbitrary transmitted state directly in the common case.
+    local -a __probe_state_names=()
+    _hs_extract_persisted_state_var_names hs_read_persisted_state "$__existing_state" __probe_state_names || return $?
+
+    # Emit a compact Bash snippet that rebuilds the requested-variable list from
+    # the caller's local scope and then reenters this function in quiet mode.
+    local __probe_snippet=$'local -a __hs_read_requested_vars=()\n'
+    local __probe_var
+    for __probe_var in "${__probe_state_names[@]}"; do
+        printf -v __probe_snippet '%sif local -p %s >/dev/null 2>&1 && [ -z "${%s}" ]; then __hs_read_requested_vars+=(%s); fi\n' \
+            "$__probe_snippet" "$__probe_var" "$__probe_var" "$__probe_var"
+    done
+    printf -v __probe_snippet '%sif [ ${#__hs_read_requested_vars[@]} -gt 0 ]; then\n  hs_read_persisted_state -S %q "${__hs_read_requested_vars[@]}"\nfi\n' \
+        "$__probe_snippet" "$__output_state_var"
+
+    printf '%s' "$__probe_snippet"
 }
 
 # --- Utility functions --------------------------------------------------------

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -364,6 +364,7 @@ hs_read_persisted_state() {
     local __quiet="${__processed_args[quiet]}"
     local __output_state_var="${__processed_args[state]}"
     local __existing_state="${!__output_state_var-}"
+    local __has_separator="${__processed_args[separator]-}"
     local -a __requested_var_args=()
     read -r -a __requested_var_args <<< "${__processed_args[vars]-}"
 
@@ -434,23 +435,27 @@ hs_read_persisted_state() {
         return 0
     fi
 
-    # Step 4: otherwise, generate a generic local-scope probe snippet instead
+    # Step 4: if the caller used an explicit `--` but provided no variable
+    # names after it, do not emit the auto-probe snippet. This lets callers
+    # disable the stdout/eval path intentionally.
+    if [[ -n "$__has_separator" ]]; then
+        return 0
+    fi
+
+    # Step 5: otherwise, generate a generic local-scope probe snippet instead
     # of returning the raw persisted code. The snippet inspects the current
     # function's locals with `local -p`, selects unset scalar locals, and
     # reenters hs_read_persisted_state with -q so unrelated locals stay quiet.
     IFS= read -r -d '' __probe_snippet <<EOF || true
-local -a __hs_read_requested_vars=()
-local __hs_local_decl="" __hs_local_name=""
-while IFS= read -r __hs_local_decl; do
-  [[ "\$__hs_local_decl" == *=* ]] && continue
-  [[ "\$__hs_local_decl" =~ ^declare\ -[^[:space:]]*[aA] ]] && continue
-  __hs_local_name=\${__hs_local_decl##* }
-  [[ "\$__hs_local_name" == __hs_* ]] && continue
-  __hs_read_requested_vars+=("\$__hs_local_name")
-done < <(local -p)
-if [ \${#__hs_read_requested_vars[@]} -gt 0 ]; then
-  hs_read_persisted_state -q -S $(printf '%q' "$__output_state_var") "\${__hs_read_requested_vars[@]}"
-fi
+hs_read_persisted_state -q -S $(printf '%q' "$__output_state_var") -- \$(
+  local -p | while IFS= read -r __hs_local_decl; do
+    [[ "\$__hs_local_decl" == *=* ]] && continue
+    [[ "\$__hs_local_decl" =~ ^declare\ -[^[:space:]]*[aA] ]] && continue
+    __hs_local_name=\${__hs_local_decl##* }
+    [[ "\$__hs_local_name" == __hs_* ]] && continue
+    printf '%s ' "\$__hs_local_name"
+  done
+) >/dev/null
 EOF
     printf '%s' "$__probe_snippet"
 }
@@ -506,8 +511,6 @@ _hs_resolve_state_inputs() {
         fi
     done
     local __caller_name=$1
-    local __remaining_args_name=$2
-    local __processed_args_name=$4
     local -n __remaining_args_ref=$2
     local __options=$3
     local -n __processed_args_ref=$4
@@ -515,11 +518,11 @@ _hs_resolve_state_inputs() {
 
     # Validate the types of passed arrays using ${...@a}
     if ! _hs_is_array __remaining_args_ref; then
-        echo "[ERROR] ${__caller_name}: '$__remaining_args_name' must name an indexed array variable." >&2
+        echo "[ERROR] ${__caller_name}: '${!__remaining_args_ref}' must name an indexed array variable." >&2
         return "$HS_ERR_INVALID_ARGUMENT_TYPE"
     fi
     if ! _hs_is_array -A __processed_args_ref; then
-        echo "[ERROR] ${__caller_name}: '$__processed_args_name' must name an associative array variable." >&2
+        echo "[ERROR] ${__caller_name}: '${!__processed_args_ref}' must name an associative array variable." >&2
         return "$HS_ERR_INVALID_ARGUMENT_TYPE"
     fi
 

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -45,6 +45,7 @@ readonly HS_ERR_INVALID_VAR_NAME=5
 readonly HS_ERR_VAR_NAME_NOT_IN_STATE=6
 readonly HS_ERR_STATE_VAR_UNINITIALIZED=7
 readonly HS_ERR_MISSING_ARGUMENT=8
+readonly HS_ERR_INVALID_ARGUMENT_TYPE=9
 
 # --- hs_persist_state_as_code ----------------------------------------------------------
 # Function:
@@ -95,43 +96,56 @@ hs_persist_state_as_code() {
         __output="$__existing_state"
     fi
     local __var_name
+    if [[ -n "$__existing_state" && ${#__persist_var_args[@]} -gt 0 ]]; then
+        timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -lc '
+            command_not_found_handle() {
+                echo "[ERROR] hs_persist_state_as_code: command '"'"'$1'"'"' not found." >&2
+                exit 127
+            }
+            _hs_detect_state_collisions() {
+                local __state=$1
+                shift
+                local __name
+                local -a __collisions=()
+
+                # Declare every candidate as a local shell variable, but leave
+                # it uninitialized so a later [[ -v name ]] test only becomes
+                # true for variables that were actually restored from state.
+                for __name in "$@"; do
+                    local "$__name"
+                done
+
+                eval "$__state" >/dev/null || return $?
+
+                for __name in "$@"; do
+                    if [ "${!__name+x}" ]; then
+                        __collisions+=("$__name")
+                    fi
+                done
+
+                if (( ${#__collisions[@]} > 0 )); then
+                    echo "[ERROR] hs_persist_state_as_code: variables already defined in the state: ${__collisions[*]}." >&2
+                    return 1
+                fi
+            }
+            _hs_detect_state_collisions "$@"
+        ' bash "$__existing_state" "${__persist_var_args[@]}"
+        local status=$?
+        if [ $status -eq 124 ] || [ $status -eq 127 ] || [ $status -eq 137 ] || [ $status -eq 143 ]; then
+            echo "[ERROR] hs_persist_state_as_code: prior state is corrupted." >&2
+            return $((HS_ERR_CORRUPT_STATE))
+        elif [ $status -eq 1 ]; then
+            return $((HS_ERR_VAR_NAME_COLLISION))
+        elif [ $status -ne 0 ]; then
+            echo "[ERROR] hs_persist_state_as_code: internal error while checking for variable name collisions." >&2
+            return $((HS_ERR_CORRUPT_STATE))
+        fi
+    fi
     for __var_name in "${__persist_var_args[@]}"; do
         # Check that the value of __var_name is neither "__var_name" nor "__existing_state"
         if [ "$__var_name" = "__var_name" ] || [ "$__var_name" = "__existing_state" ] || [ "$__var_name" = "__output_state_var" ] || [ "$__var_name" = "__output" ]; then
             echo "[ERROR] hs_persist_state_as_code: refusing to persist reserved variable name '$__var_name'." >&2  
             return "$HS_ERR_RESERVED_VAR_NAME"
-        fi
-        # Detect name collisions if __existing_state is provided
-        if [ -n "$__existing_state" ]; then
-            # In a time-constrained subshell, declare "$__var_name" as local to capture its value
-            # and attempt to restore it from "$__existing_state".
-            timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -elc "
-                command_not_found_handle() {
-                    echo \"[ERROR] hs_persist_state_as_code: command '\$1' not found.\" >&2
-                    exit 127
-                }
-                test_collision() {
-                    local \"$__var_name\"
-                    eval \"$__existing_state\" >/dev/null
-                    # Check if the variable pointed to by __var_name has been initialized
-                    if ! [ -z \"\${${__var_name}+x}\" ]; then
-                        echo \"[ERROR] hs_persist_state_as_code: variable '$__var_name' is already defined in the state, with value '\${${__var_name}}'.\" >&2
-                        exit 1
-                    fi
-                }
-                test_collision
-            " 
-            local status=$?
-            if [ $status -eq 124 ] || [ $status -eq 127 ] || [ $status -eq 137 ] || [ $status -eq 143 ]; then
-                # Status code snippet timed out: 124 (timeout), 137 (killed), 127 (command not found), 143 (sigterm)
-                echo "[ERROR] hs_persist_state_as_code: prior state is corrupted." >&2
-                return $((HS_ERR_CORRUPT_STATE))
-            elif [ $status -eq 1 ]; then
-                return $((HS_ERR_VAR_NAME_COLLISION))
-            elif [ $status -ne 0 ]; then
-                echo "[ERROR] hs_persist_state_as_code: internal error while checking for variable name collision for '$__var_name'." >&2
-                return $((HS_ERR_CORRUPT_STATE))
-            fi
         fi
         # Check if the variable exists in the caller (local or global). We avoid
         # using `local -p` here because that only inspects locals of this
@@ -363,68 +377,81 @@ hs_read_persisted_state() {
     # selective-restore API.
     if [ ${#__requested_var_args[@]} -gt 0 ]; then
         local __requested_var
-        local __restored_value=""
+        local __restored_payload=""
         local __restore_status=0
-        for __requested_var in "${__requested_var_args[@]}"; do
-            # Evaluate the persisted state in a short-lived Bash subprocess,
-            # scoped to one requested variable, then print the resulting value
-            # back to this function. The subprocess is isolated and time-bounded
-            # because the persisted format is still executable Bash code.
-            __restored_value=$(timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -lc '
-                _hs_read_requested_state_var() {
-                    local __state=$1
-                    local __requested_var=$2
+        # Evaluate the persisted state in a single short-lived Bash subprocess,
+        # restore all requested variables there, and return one
+        # associative-array initializer of restored string values. Missing
+        # variables are reported directly on stderr from that subprocess.
+        __restored_payload=$(timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -lc '
+            _hs_read_requested_state_vars() {
+                local __state=$1
+                local __quiet_mode=$2
+                shift
+                shift
+                local __requested_var
+                local __restored_entries=""
+
+                for __requested_var in "$@"; do
                     local "$__requested_var"
-                    eval "$__state" >/dev/null 2>&1 || return $?
+                done
+
+                eval "$__state" >/dev/null 2>&1 || return $?
+
+                for __requested_var in "$@"; do
                     if [ "${!__requested_var+x}" ]; then
-                        printf "%s" "${!__requested_var}"
-                        return 0
+                        printf -v __restored_entries "%s[%q]=%q " "$__restored_entries" "$__requested_var" "${!__requested_var}"
+                    else
+                        if [ "$__quiet_mode" = false ]; then
+                            printf "[WARNING] hs_read_persisted_state: variable '"'"'%s'"'"' is not defined in the state.\n" "$__requested_var" >&2
+                        fi
                     fi
-                    return 10
-                }
-                _hs_read_requested_state_var "$@"
-            ' bash "$__existing_state" "$__requested_var")
-            __restore_status=$?
+                done
 
-            if [ $__restore_status -eq 124 ] || [ $__restore_status -eq 127 ] || [ $__restore_status -eq 137 ] || [ $__restore_status -eq 143 ]; then
-                echo "[ERROR] hs_read_persisted_state: prior state is corrupted." >&2
-                return "$HS_ERR_CORRUPT_STATE"
-            elif [ $__restore_status -eq 10 ]; then
-                if [ "$__quiet" = false ]; then
-                    echo "[WARNING] hs_read_persisted_state: variable '$__requested_var' is not defined in the state." >&2
-                fi
-                continue
-            elif [ $__restore_status -ne 0 ]; then
-                echo "[ERROR] hs_read_persisted_state: internal error while restoring '$__requested_var'." >&2
-                return "$HS_ERR_CORRUPT_STATE"
-            fi
+                printf "%s" "$__restored_entries"
+            }
+            _hs_read_requested_state_vars "$@"
+        ' bash "$__existing_state" "$__quiet" "${__requested_var_args[@]}")
+        __restore_status=$?
 
-            # Write the restored value back into the caller's variable by name.
+        if [ $__restore_status -eq 124 ] || [ $__restore_status -eq 127 ] || [ $__restore_status -eq 137 ] || [ $__restore_status -eq 143 ]; then
+            echo "[ERROR] hs_read_persisted_state: prior state is corrupted." >&2
+            return "$HS_ERR_CORRUPT_STATE"
+        elif [ $__restore_status -ne 0 ]; then
+            echo "[ERROR] hs_read_persisted_state: internal error while restoring requested variables." >&2
+            return "$HS_ERR_CORRUPT_STATE"
+        fi
+
+        local -A __restored_map=()
+        if [[ -n "$__restored_payload" ]]; then
+            eval "__restored_map=($__restored_payload)"
+        fi
+
+        for __requested_var in "${!__restored_map[@]}"; do
             local -n __requested_var_ref="$__requested_var"
-            __requested_var_ref="$__restored_value"
+            __requested_var_ref="${__restored_map[$__requested_var]}"
         done
         return 0
     fi
 
-    # Step 4: otherwise, generate a safe, local probe snippet instead of
-    # returning the raw persisted code. The snippet checks which matching local
-    # variables are currently declared and unset in the caller, then reenters
-    # hs_read_persisted_state with an explicit variable list. This avoids asking
-    # callers to eval arbitrary transmitted state directly in the common case.
-    local -a __probe_state_names=()
-    _hs_extract_persisted_state_var_names hs_read_persisted_state "$__existing_state" __probe_state_names || return $?
-
-    # Emit a compact Bash snippet that rebuilds the requested-variable list from
-    # the caller's local scope and then reenters this function in quiet mode.
-    local __probe_snippet=$'local -a __hs_read_requested_vars=()\n'
-    local __probe_var
-    for __probe_var in "${__probe_state_names[@]}"; do
-        printf -v __probe_snippet '%sif local -p %s >/dev/null 2>&1 && [ -z "${%s}" ]; then __hs_read_requested_vars+=(%s); fi\n' \
-            "$__probe_snippet" "$__probe_var" "$__probe_var" "$__probe_var"
-    done
-    printf -v __probe_snippet '%sif [ ${#__hs_read_requested_vars[@]} -gt 0 ]; then\n  hs_read_persisted_state -S %q "${__hs_read_requested_vars[@]}"\nfi\n' \
-        "$__probe_snippet" "$__output_state_var"
-
+    # Step 4: otherwise, generate a generic local-scope probe snippet instead
+    # of returning the raw persisted code. The snippet inspects the current
+    # function's locals with `local -p`, selects unset scalar locals, and
+    # reenters hs_read_persisted_state with -q so unrelated locals stay quiet.
+    IFS= read -r -d '' __probe_snippet <<EOF || true
+local -a __hs_read_requested_vars=()
+local __hs_local_decl="" __hs_local_name=""
+while IFS= read -r __hs_local_decl; do
+  [[ "\$__hs_local_decl" == *=* ]] && continue
+  [[ "\$__hs_local_decl" =~ ^declare\ -[^[:space:]]*[aA] ]] && continue
+  __hs_local_name=\${__hs_local_decl##* }
+  [[ "\$__hs_local_name" == __hs_* ]] && continue
+  __hs_read_requested_vars+=("\$__hs_local_name")
+done < <(local -p)
+if [ \${#__hs_read_requested_vars[@]} -gt 0 ]; then
+  hs_read_persisted_state -q -S $(printf '%q' "$__output_state_var") "\${__hs_read_requested_vars[@]}"
+fi
+EOF
     printf '%s' "$__probe_snippet"
 }
 
@@ -459,6 +486,8 @@ _hs_is_valid_variable_name() {
 # Returns:
 #   0 on success.
 #   `HS_ERR_MISSING_ARGUMENT` if fewer than 6 arguments are provided.
+#   `HS_ERR_INVALID_ARGUMENT_TYPE` if the output containers do not have the
+#   expected array types.
 #   `HS_ERR_STATE_VAR_UNINITIALIZED` if no `-S <statevar>` option is provided.
 #   `HS_ERR_INVALID_VAR_NAME` if `-S` is followed by an invalid variable name.
 # Usage:
@@ -477,6 +506,8 @@ _hs_resolve_state_inputs() {
         fi
     done
     local __caller_name=$1
+    local __remaining_args_name=$2
+    local __processed_args_name=$4
     local -n __remaining_args_ref=$2
     local __options=$3
     local -n __processed_args_ref=$4
@@ -484,12 +515,12 @@ _hs_resolve_state_inputs() {
 
     # Validate the types of passed arrays using ${...@a}
     if ! _hs_is_array __remaining_args_ref; then
-        echo "[ERROR] ${__caller_name}: '$2' must name an indexed array variable." >&2
-        return "$HS_ERR_MISSING_ARGUMENT"
+        echo "[ERROR] ${__caller_name}: '$__remaining_args_name' must name an indexed array variable." >&2
+        return "$HS_ERR_INVALID_ARGUMENT_TYPE"
     fi
     if ! _hs_is_array -A __processed_args_ref; then
-        echo "[ERROR] ${__caller_name}: '$4' must name an associative array variable." >&2
-        return "$HS_ERR_MISSING_ARGUMENT"
+        echo "[ERROR] ${__caller_name}: '$__processed_args_name' must name an associative array variable." >&2
+        return "$HS_ERR_INVALID_ARGUMENT_TYPE"
     fi
 
     

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -18,116 +18,23 @@ source "${BASH_SOURCE%/*}/command_guard.sh"
 #   init_function() {
 #       local temp_file="/tmp/some_temp_file"
 #       local resource_id="resource_123"
-#       hs_persist_state_as_code temp_file resource_id
-#       exit 0
+#       hs_persist_state_as_code "$@" temp_file resource_id
+#       return 0
 #   }
 #   cleanup() {
 #       local temp_file
 #       local resource_id
-#       eval "$1"  # Recreate local variables from the state string
+#       hs_read_persisted_state "$@" temp_file resource_id  # Recreate local variables from the state string
 #       # Now temp_file and resource_id are available for cleanup operations
 #       rm -f "$temp_file"
 #       echo "Cleaned up resource: $resource_id"
+#       hs_destroy_state "$@" -- temp_file resource_id  # Ensure the state variable can be reused.
 #   }
 #
 # Upper level usage: state=$(init_function)
 #                    cleanup "$state"
 
-guard mkfifo rm timeout
-
-# --- logging from $(command) using a FIFO ---------------------------------------
-# This section sets up a FIFO and a background reader process to allow functions
-# to log messages to the main script's stdout/stderr even when they are called
-# from subshells (e.g., inside `$(...)` command substitutions). Functions can
-# use `hs_echo "message"` to send messages to the main script's output.
-
-# Function: 
-#   _hs_set_up_logging
-# Description:
-#   Sets up a FIFO and background reader process for logging.
-#   The background reader must start before any I/O redirection occurs. This
-#   is why it is called at the end of this file, so that when this file is sourced,
-#   the logging is set up.
-# Usage:
-#   Do not call directly; called automatically when this file is sourced.
-#   When done with the library, call `hs_cleanup_output` to terminate the background reader
-#   or else a 5 seconds idle timeout will occur.
-hs_setup_output_to_stdout() {
-    # Test if already set up
-    if hs_get_pid_of_subshell >/dev/null 2>&1; then
-        echo "[WARN] hs_setup_output_to_stdout: already set up; skipping." >&2
-        return 0
-    fi
-    # Create a FIFO using a proper temporary file and file descriptor 3 
-    fifo_file=$(mktemp -u)
-    mkfifo "$fifo_file"
-    # Redirect fd 3 into the FIFO
-    exec {_hs_fifo_fd}<> "$fifo_file"
-    # Make file disappear immediately. The FIFO remains accessible via fd 3.
-    rm "$fifo_file"
-    # Kill token
-    _hs_fifo_kill_token="hs_kill_${$}_$RANDOM_$RANDOM"
-    _hs_fifo_idle_limit=5  # seconds before self-termination
-
-    # Run a background task that reads from the FIFO and displays messages
-    (
-        idle=0
-
-        while true; do
-            line=''
-
-            if IFS= read -t 1 -r line <&"${_hs_fifo_fd}"; then
-                # Received a line; reset idle counter
-                idle=0
-                # Self-terminate on the exact magic token
-                if [ "${line:-}" = "${_hs_fifo_kill_token}" ]; then
-                    break
-                fi
-                echo "$line"
-            else
-                # read timed out or encountered EOF/error - increment idle counter
-                idle=$((idle + 1))
-                if [ "$idle" -ge "$_hs_fifo_idle_limit" ]; then
-                    break
-                fi
-                # continue to wait
-            fi
-        done
-        # Dismantle FIFO: close fd
-        exec {_hs_fifo_fd}>&-
-    ) & _hs_fifo_reader_pid=$!
- 
-    # Function:
-    #   hs_cleanup_output, or redefined globally with the kill token embedded.
-    # Description:
-    #   Sends the magic kill token to the logging FIFO to terminate the background reader.
-    #   Waits for the background reader to exit and redefines itself to a no-op.
-    #   Redefines hs_echo to a simple echo.
-    # Parameters:
-    #   None
-    printf -v _hs_qtoken '%q' "$_hs_fifo_kill_token"
-    eval "hs_cleanup_output() {
-        if hs_echo $_hs_qtoken ; then
-            wait $_hs_fifo_reader_pid 2>/dev/null
-            hs_cleanup_output() { :; }
-            hs_echo() { echo \"\$*\" ; }
-        fi
-        return 0
-    }"
-        
-    # Function:
-    #   hs_echo
-    # Description:
-    #   Writes messages to the logging FIFO for display in the main script's stdout.
-    #   Specifically designed to work inside subshells called via `$(...)`.
-    #   Mimic Bash echo argument concatenation behavior.
-    #   Here IFS acts on "$*" expansion to insert spaces between arguments.
-    # Arguments:
-    #   $* - echo options -neE or message parts to echo
-    eval "hs_echo() {
-        IFS=\" \" echo \"\$*\" >&\"${_hs_fifo_fd}\"
-    }"
-}
+guard timeout
 
 # --- Public error codes --------------------------------------------------------
 readonly HS_ERR_RESERVED_VAR_NAME=1
@@ -138,147 +45,6 @@ readonly HS_ERR_INVALID_VAR_NAME=5
 readonly HS_ERR_VAR_NAME_NOT_IN_STATE=6
 readonly HS_ERR_STATE_VAR_UNINITIALIZED=7
 readonly HS_ERR_MISSING_ARGUMENT=8
-
-# --- _hs_is_valid_variable_name -------------------------------------------------------
-# Function:
-#   _hs_is_valid_variable_name
-# Description:
-#   Returns success if the argument is a syntactically valid Bash variable name.
-# Arguments:
-#   $1 - candidate variable name
-# Returns:
-#   0 if the name is valid, 1 otherwise.
-_hs_is_valid_variable_name() {
-    [[ "${1-}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]
-}
-
-# --- _hs_resolve_state_inputs ---------------------------------------------------------
-# Function:
-#   _hs_resolve_state_inputs
-# Description:
-#   Parses the `-S <statevar>` option for state-oriented helpers and resolves
-#   the current state from the named variable. Parsed results are returned to
-#   the caller through variable names passed as parameters.
-# Arguments:
-#   $1 - caller function name, used in error messages; must be a valid Bash name
-#   $2 - name of the variable that will receive the current state value; must be a valid Bash name
-#   $3 - name of the variable that will receive the destination state variable name; must be a valid Bash name
-#   $4 - name of the variable that will receive the number of consumed option arguments; must be a valid Bash name
-#   $5 - first variable name to process or `-S`
-#   $6... - additional variable names to process, with `-S <statevar>` required somewhere in the argument list
-# Returns:
-#   0 on success.
-#   `HS_ERR_MISSING_ARGUMENT` if fewer than 6 arguments are provided.
-#   `HS_ERR_STATE_VAR_UNINITIALIZED` if no `-S <statevar>` option is provided.
-#   `HS_ERR_INVALID_VAR_NAME` if `-S` is followed by an invalid variable name.
-# Usage:
-#   local existing_state="" output_state_var="" consumed_state_args=0
-#   _hs_resolve_state_inputs my_helper existing_state output_state_var consumed_state_args "$@" || return $?
-_hs_resolve_state_inputs() {
-    if [ $# -lt 6 ]; then
-        echo "[ERROR] _hs_resolve_state_inputs: missing required arguments; expected at least 6 parameters." >&2
-        return "$HS_ERR_MISSING_ARGUMENT"
-    fi
-    local __arg
-    for __arg in "$1" "$2" "$3" "$4"; do
-        if ! _hs_is_valid_variable_name "$__arg"; then
-            echo "[ERROR] _hs_resolve_state_inputs: invalid variable name '$__arg'." >&2
-            return "$HS_ERR_INVALID_VAR_NAME"
-        fi
-    done
-    local __caller_name=$1
-    local -n __existing_state_ref=$2
-    local -n __output_state_var_ref=$3
-    local -n __consumed_count_ref=$4
-    shift 4
-
-    __existing_state_ref=""
-    __output_state_var_ref=""
-    __consumed_count_ref=0
-
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            -S)
-                __output_state_var_ref="$2"
-                if ! _hs_is_valid_variable_name "$__output_state_var_ref"; then
-                    echo "[ERROR] ${__caller_name}: invalid variable name '$__output_state_var_ref' for -S option." >&2
-                    return "$HS_ERR_INVALID_VAR_NAME"
-                fi
-                shift 2
-                __consumed_count_ref=$((__consumed_count_ref + 2))
-                ;;
-            *)
-                if ! _hs_is_valid_variable_name "$1"; then
-                    echo "[ERROR] ${__caller_name}: invalid variable name '$1'." >&2
-                    return "$HS_ERR_INVALID_VAR_NAME"
-                fi
-                shift
-                ;;
-        esac
-    done
-
-    if [ -z "$__output_state_var_ref" ]; then
-        echo "[ERROR] ${__caller_name}: state variable is uninitialized; missing required -S <statevar> option." >&2
-        return "$HS_ERR_STATE_VAR_UNINITIALIZED"
-    fi
-
-    eval "__existing_state_ref=\${$__output_state_var_ref-}"
-}
-
-# --- _hs_extract_persisted_state_var_names -------------------------------------------
-# Function:
-#   _hs_extract_persisted_state_var_names
-# Description:
-#   Parses a code-snippet state produced by `hs_persist_state_as_code` and
-#   extracts the variable names declared by its guarded `if local -p VAR ...`
-#   blocks. Results are returned through an array nameref.
-# Arguments:
-#   $1 - caller function name, used in error messages
-#   $2 - state snippet string to inspect
-#   $3 - name of the array variable that will receive extracted variable names
-# Returns:
-#   0 on success.
-#   `HS_ERR_INVALID_VAR_NAME` if one of the first or third arguments is not a
-#   valid Bash variable name.
-#   `HS_ERR_CORRUPT_STATE` if the snippet contains an invalid persisted variable
-#   name or if the state is non-empty but contains no persisted variable blocks.
-# Usage:
-#   local -a state_var_names=()
-#   _hs_extract_persisted_state_var_names my_helper "$state" state_var_names || return $?
-_hs_extract_persisted_state_var_names() {
-    if [ $# -ne 3 ]; then
-        echo "[ERROR] _hs_extract_persisted_state_var_names: expected exactly 3 arguments." >&2
-        return "$HS_ERR_MISSING_ARGUMENT"
-    fi
-    if ! _hs_is_valid_variable_name "$1" || ! _hs_is_valid_variable_name "$3"; then
-        echo "[ERROR] _hs_extract_persisted_state_var_names: invalid variable name '$1' or '$3'." >&2
-        return "$HS_ERR_INVALID_VAR_NAME"
-    fi
-
-    local __caller_name=$1
-    local __state=$2
-    local -n __out_names_ref=$3
-    local __line=""
-    local __state_var_name=""
-
-    __out_names_ref=()
-    while IFS= read -r __line || [[ -n "$__line" ]]; do
-        if [[ "$__line" == "if local -p "* ]]; then
-            __state_var_name=${__line#if local -p }
-            __state_var_name=${__state_var_name%% *}
-            if ! _hs_is_valid_variable_name "$__state_var_name"; then
-                echo "[ERROR] ${__caller_name}: prior state is corrupted." >&2
-                return "$HS_ERR_CORRUPT_STATE"
-            fi
-            __out_names_ref+=("$__state_var_name")
-        fi
-    done <<< "$__state"
-
-    if [[ -n "$__state" && ${#__out_names_ref[@]} -eq 0 ]]; then
-        echo "[ERROR] ${__caller_name}: prior state is corrupted." >&2
-        return "$HS_ERR_CORRUPT_STATE"
-    fi
-}
 
 # --- hs_persist_state_as_code ----------------------------------------------------------
 # Function:
@@ -480,6 +246,7 @@ hs_destroy_state() {
             readonly HS_ERR_MULTIPLE_STATE_INPUTS='"$HS_ERR_MULTIPLE_STATE_INPUTS"'
             readonly HS_ERR_CORRUPT_STATE='"$HS_ERR_CORRUPT_STATE"'
             readonly HS_ERR_INVALID_VAR_NAME='"$HS_ERR_INVALID_VAR_NAME"'
+            '"$(declare -f _hs_is_valid_variable_name)"'
             '"$(declare -f _hs_resolve_state_inputs)"'
             '"$(declare -f hs_persist_state_as_code)"'
             _hs_destroy_state_rebuild() {
@@ -656,6 +423,173 @@ hs_read_persisted_state() {
 }
 
 # --- Utility functions --------------------------------------------------------
+
+# Function:
+#   _hs_is_valid_variable_name
+# Description:
+#   Returns success if the argument is a syntactically valid Bash variable name.
+# Arguments:
+#   $1 - candidate variable name
+# Returns:
+#   0 if the name is valid, 1 otherwise.
+_hs_is_valid_variable_name() {
+    [[ "${1-}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]
+}
+
+# Function:
+#   _hs_resolve_state_inputs
+# Description:
+#   Parses the `-S <statevar>` option for state-oriented helpers and resolves
+#   the current state from the named variable. Parsed results are returned to
+#   the caller through variable names passed as parameters.
+# Arguments:
+#   $1 - caller function name, used in error messages; must be a valid Bash name
+#   $2 - name of the variable that will receive the current state value; must be a valid Bash name
+#   $3 - name of the variable that will receive the destination state variable name; must be a valid Bash name
+#   $4 - name of the variable that will receive the number of consumed option arguments; must be a valid Bash name
+#   $5 - first variable name to process or `-S`
+#   $6... - additional variable names to process, with `-S <statevar>` required somewhere in the argument list
+# Returns:
+#   0 on success.
+#   `HS_ERR_MISSING_ARGUMENT` if fewer than 6 arguments are provided.
+#   `HS_ERR_STATE_VAR_UNINITIALIZED` if no `-S <statevar>` option is provided.
+#   `HS_ERR_INVALID_VAR_NAME` if `-S` is followed by an invalid variable name.
+# Usage:
+#   local existing_state="" output_state_var="" consumed_state_args=0
+#   _hs_resolve_state_inputs my_helper existing_state output_state_var consumed_state_args "$@" || return $?
+_hs_resolve_state_inputs() {
+    if [ $# -lt 6 ]; then
+        echo "[ERROR] _hs_resolve_state_inputs: missing required arguments; expected at least 6 parameters." >&2
+        return "$HS_ERR_MISSING_ARGUMENT"
+    fi
+    local __arg
+    for __arg in "$1" "$2" "$3" "$4"; do
+        if ! _hs_is_valid_variable_name "$__arg"; then
+            echo "[ERROR] _hs_resolve_state_inputs: invalid variable name '$__arg'." >&2
+            return "$HS_ERR_INVALID_VAR_NAME"
+        fi
+    done
+    local __caller_name=$1
+    local -n __existing_state_ref=$2
+    local -n __output_state_var_ref=$3
+    local -n __consumed_count_ref=$4
+    shift 4
+
+    __existing_state_ref=""
+    __output_state_var_ref=""
+    __consumed_count_ref=0
+
+    local -a __args=("$@")
+    local __arg_count=${#__args[@]}
+    local __last_separator_index=-1
+    local __i=0
+    local __parse_limit=$__arg_count
+
+    # If one or more `--` markers are present, the last one separates the
+    # forwarded helper options from the explicit list of variable names.
+    for ((__i = 0; __i < __arg_count; __i++)); do
+        if [[ "${__args[__i]}" == "--" ]]; then
+            __last_separator_index=$__i
+        fi
+    done
+
+    if (( __last_separator_index >= 0 )); then
+        __consumed_count_ref=$((__last_separator_index + 1))
+        __parse_limit=$__last_separator_index
+    else
+        __consumed_count_ref=2
+    fi
+
+    # Before the effective separator, only helper options are recognized.
+    # Any other forwarded arguments belong to the caller and are ignored here.
+    for ((__i = 0; __i < __parse_limit; __i++)); do
+        case "${__args[__i]}" in
+            -S)
+                if (( __i + 1 >= __parse_limit )); then
+                    echo "[ERROR] ${__caller_name}: missing required state variable name for -S option." >&2
+                    return "$HS_ERR_MISSING_ARGUMENT"
+                fi
+                __output_state_var_ref="${__args[__i + 1]}"
+                if ! _hs_is_valid_variable_name "$__output_state_var_ref"; then
+                    echo "[ERROR] ${__caller_name}: invalid variable name '$__output_state_var_ref' for -S option." >&2
+                    return "$HS_ERR_INVALID_VAR_NAME"
+                fi
+                ((__i++))
+                ;;
+        esac
+    done
+
+    # After the effective separator, every token is part of the variable list.
+    # Without a separator, this validates the traditional trailing "$@" list.
+    for ((__i = __consumed_count_ref; __i < __arg_count; __i++)); do
+        if ! _hs_is_valid_variable_name "${__args[__i]}"; then
+            echo "[ERROR] ${__caller_name}: invalid variable name '${__args[__i]}'." >&2
+            return "$HS_ERR_INVALID_VAR_NAME"
+        fi
+    done
+
+    if [ -z "$__output_state_var_ref" ]; then
+        echo "[ERROR] ${__caller_name}: state variable is uninitialized; missing required -S <statevar> option." >&2
+        return "$HS_ERR_STATE_VAR_UNINITIALIZED"
+    fi
+
+    eval "__existing_state_ref=\${$__output_state_var_ref-}"
+}
+
+# Function:
+#   _hs_extract_persisted_state_var_names
+# Description:
+#   Parses a code-snippet state produced by `hs_persist_state_as_code` and
+#   extracts the variable names declared by its guarded `if local -p VAR ...`
+#   blocks. Results are returned through an array nameref.
+# Arguments:
+#   $1 - caller function name, used in error messages
+#   $2 - state snippet string to inspect
+#   $3 - name of the array variable that will receive extracted variable names
+# Returns:
+#   0 on success.
+#   `HS_ERR_INVALID_VAR_NAME` if one of the first or third arguments is not a
+#   valid Bash variable name.
+#   `HS_ERR_CORRUPT_STATE` if the snippet contains an invalid persisted variable
+#   name or if the state is non-empty but contains no persisted variable blocks.
+# Usage:
+#   local -a state_var_names=()
+#   _hs_extract_persisted_state_var_names my_helper "$state" state_var_names || return $?
+_hs_extract_persisted_state_var_names() {
+    if [ $# -ne 3 ]; then
+        echo "[ERROR] _hs_extract_persisted_state_var_names: expected exactly 3 arguments." >&2
+        return "$HS_ERR_MISSING_ARGUMENT"
+    fi
+    if ! _hs_is_valid_variable_name "$1" || ! _hs_is_valid_variable_name "$3"; then
+        echo "[ERROR] _hs_extract_persisted_state_var_names: invalid variable name '$1' or '$3'." >&2
+        return "$HS_ERR_INVALID_VAR_NAME"
+    fi
+
+    local __caller_name=$1
+    local __state=$2
+    local -n __out_names_ref=$3
+    local __line=""
+    local __state_var_name=""
+
+    __out_names_ref=()
+    while IFS= read -r __line || [[ -n "$__line" ]]; do
+        if [[ "$__line" == "if local -p "* ]]; then
+            __state_var_name=${__line#if local -p }
+            __state_var_name=${__state_var_name%% *}
+            if ! _hs_is_valid_variable_name "$__state_var_name"; then
+                echo "[ERROR] ${__caller_name}: prior state is corrupted." >&2
+                return "$HS_ERR_CORRUPT_STATE"
+            fi
+            __out_names_ref+=("$__state_var_name")
+        fi
+    done <<< "$__state"
+
+    if [[ -n "$__state" && ${#__out_names_ref[@]} -eq 0 ]]; then
+        echo "[ERROR] ${__caller_name}: prior state is corrupted." >&2
+        return "$HS_ERR_CORRUPT_STATE"
+    fi
+}
+
 # Function:
 #    hs_get_pid_of_subshell
 # Description:
@@ -681,8 +615,5 @@ hs_get_pid_of_subshell() {
     pid=${pid%%[^0-9]*}
     printf '%s' "$pid"
 }
-
-# Initialize logging when the script is sourced
-hs_setup_output_to_stdout
 
 # Note: Remember to call hs_cleanup at the end of your main script to clean up resources.

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -203,15 +203,14 @@ hs_destroy_state() {
 
     # Step 2: set up working variables.
     # __state_var_names will contain every variable name found in the incoming
-    # persisted state. __keep_state_names will contain only the survivors, i.e.
-    # variables that remain after removing the requested names.
+    # persisted state. __state_var_set mirrors that list as an associative set
+    # so destroy-name lookups and removals stay in Bash builtins instead of
+    # nested shell loops.
     local __output=""
     local __var_name
     local __state_var=""
-    local __state_var_found=false
-    local __keep_var=""
-    local __keep_state_names=""
     local -a __state_var_names=()
+    local -A __state_var_set=()
 
     # Step 3: scan the existing state snippet for persisted variable names.
     # We intentionally look only for the top-level headers emitted by
@@ -220,35 +219,21 @@ hs_destroy_state() {
     # surviving variables later.
     _hs_extract_persisted_state_var_names hs_destroy_state "$__existing_state" __state_var_names || return $?
     for __state_var in "${__state_var_names[@]}"; do
-        __state_var_found=false
-        for __var_name in "${__destroy_var_args[@]}"; do
-            if [[ "$__var_name" == "$__state_var" ]]; then
-                __state_var_found=true
-                break
-            fi
-        done
-        if [[ "$__state_var_found" == false ]]; then
-            __keep_state_names+="${__state_var}"$'\n'
-        fi
+        __state_var_set["$__state_var"]=1
     done
 
-    # Step 5: every requested variable must actually exist in the incoming
-    # state. If a requested name is absent, return HS_ERR_INVALID_VAR_NAME.
+    # Step 4: every requested variable must actually exist in the incoming
+    # state. If it does, remove it from the survivor set immediately so the
+    # final key list is exactly the set of variables to keep.
     for __var_name in "${__destroy_var_args[@]}"; do
-        __state_var_found=false
-        for __state_var in "${__state_var_names[@]}"; do
-            if [[ "$__state_var" == "$__var_name" ]]; then
-                __state_var_found=true
-                break
-            fi
-        done
-        if [[ "$__state_var_found" == false ]]; then
+        if [[ -z "${__state_var_set["$__var_name"]-}" ]]; then
             echo "[ERROR] hs_destroy_state: variable '$__var_name' is not defined in the state." >&2
             return "$HS_ERR_VAR_NAME_NOT_IN_STATE"
         fi
+        unset '__state_var_set[$__var_name]'
     done
 
-    # Step 6: rebuild the state from scratch using only the survivor names.
+    # Step 5: rebuild the state from scratch using only the survivor names.
     # Instead of editing the text blocks in place, run a fresh Bash subprocess
     # that:
     #   1. defines the minimal helpers needed (_hs_resolve_state_inputs and
@@ -260,12 +245,8 @@ hs_destroy_state() {
     # This avoids depending on BASH_SOURCE or on re-sourcing this file from a
     # filesystem path, which would break when handle_state.sh was obtained via
     # remote_run's virtual source mechanism.
-    if [[ -n "$__keep_state_names" ]]; then
-        local -a __keep_state_args=()
-        while IFS= read -r __keep_var || [[ -n "$__keep_var" ]]; do
-            [[ -z "$__keep_var" ]] && continue
-            __keep_state_args+=("$__keep_var")
-        done <<< "$__keep_state_names"
+    local -a __keep_state_args=("${!__state_var_set[@]}")
+    if (( ${#__keep_state_args[@]} > 0 )); then
 
         __output=$(timeout --preserve-status -k 2 1 "${BASH:-bash}" --noprofile -lc '
             readonly HS_ERR_RESERVED_VAR_NAME='"$HS_ERR_RESERVED_VAR_NAME"'
@@ -291,7 +272,7 @@ hs_destroy_state() {
             _hs_destroy_state_rebuild "$@"
         ' bash "$__existing_state" "${__keep_state_args[@]}")
         local __status=$?
-        # Step 7: map rebuild failures to the same "corrupt prior state"
+        # Step 6: map rebuild failures to the same "corrupt prior state"
         # category used elsewhere in handle_state when we cannot safely process
         # the supplied snippet.
         if [ $__status -eq 124 ] || [ $__status -eq 127 ] || [ $__status -eq 137 ] || [ $__status -eq 143 ]; then
@@ -303,7 +284,7 @@ hs_destroy_state() {
         fi
     fi
 
-    # Step 8: write the rebuilt state back into the named state variable.
+    # Step 7: write the rebuilt state back into the named state variable.
     printf -v "$__output_state_var" '%s' "$__output"
 }
 # --- hs_read_persisted_state --------------------------------------------------------
@@ -347,81 +328,26 @@ hs_destroy_state() {
 #       hs_read_persisted_state -q "$@" -- temp_file resource_id
 #   }
 hs_read_persisted_state() {
-    # Step 1: parse hs_read_persisted_state-specific flags before delegating
-    # the shared state-input handling to _hs_resolve_state_inputs.
-    local __quiet=false
+    # Step 1: normalize the convenience form `hs_read_persisted_state state`
+    # into the regular `-S state` form, then delegate all option parsing to
+    # _hs_resolve_state_inputs.
     if [ $# -eq 0 ]; then
         echo "[ERROR] hs_read_persisted_state: missing required state variable name." >&2
         return "$HS_ERR_MISSING_ARGUMENT"
     fi
 
-    local -a __args=("$@")
-    local -a __prefix_args=()
-    local -a __suffix_args=()
-    local -a __filtered_prefix_args=()
-    local __arg_count=${#__args[@]}
-    local __last_separator_index=-1
-    local __i=0
-
-    for ((__i = 0; __i < __arg_count; __i++)); do
-        if [[ "${__args[__i]}" == "--" ]]; then
-            __last_separator_index=$__i
-        fi
-    done
-
-    if (( __last_separator_index >= 0 )); then
-        __prefix_args=("${__args[@]:0:__last_separator_index}")
-        __suffix_args=("${__args[@]:__last_separator_index+1}")
-    else
-        __prefix_args=("${__args[@]}")
-    fi
-
-    set -- "${__prefix_args[@]}"
-    local OPTIND=1
-    local opt
-    while (( OPTIND <= $# )); do
-        if getopts ":qS:" opt; then
-            case "$opt" in
-                q)
-                    __quiet=true
-                    ;;
-                :)
-                    if [[ "$OPTARG" == "S" ]]; then
-                        echo "[ERROR] hs_read_persisted_state: missing required state variable name for -S option." >&2
-                        return "$HS_ERR_MISSING_ARGUMENT"
-                    fi
-                    ;;
-                \?)
-                    :
-                    ;;
-            esac
-        else
-            OPTIND=$((OPTIND + 1))
-        fi
-    done
-
-    local __prefix_arg=""
-    for __prefix_arg in "${__prefix_args[@]}"; do
-        if [[ "$__prefix_arg" != "-q" ]]; then
-            __filtered_prefix_args+=("$__prefix_arg")
-        fi
-    done
-
-    set -- "${__filtered_prefix_args[@]}"
-    if (( __last_separator_index >= 0 )); then
-        set -- "$@" -- "${__suffix_args[@]}"
-    fi
-    if [ "${1-}" != "-S" ]; then
+    if [[ "${1-}" != -* ]]; then
         set -- -S "$@"
     fi
     # Step 2: resolve the named state variable and capture its current payload.
     # The helper validates names, enforces the presence of -S, and returns:
-    #   - __existing_state: the current serialized state snippet
     #   - __output_state_var: the caller-visible variable name holding that state
-    #   - __consumed_state_args: how many leading arguments belong to state input
+    #   - __processed_args[quiet]: whether -q was provided
+    #   - __processed_args[vars]: the validated requested-variable list
     local -a __remaining_args=()
     local -A __processed_args=()
-    _hs_resolve_state_inputs hs_read_persisted_state __remaining_args S: __processed_args "$@" || return $?
+    _hs_resolve_state_inputs hs_read_persisted_state __remaining_args qS: __processed_args "$@" || return $?
+    local __quiet="${__processed_args[quiet]}"
     local __output_state_var="${__processed_args[state]}"
     local __existing_state="${!__output_state_var-}"
     local -a __requested_var_args=()

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -48,39 +48,54 @@ readonly HS_ERR_MISSING_ARGUMENT=8
 
 # --- hs_persist_state_as_code ----------------------------------------------------------
 # Function:
-#   hs_persist_state_as_code
+#   hs_persist_state_as_code [options] [--] [state_variable ...]
 # Description:
-#   Emits a bash code snippet that, when eval'd in the receiving scope,
-#   will recreate the specified local variables with their current values.
-#   The emitted code checks if the variable is declared `local` in the receiving
-#   scope before assigning to it, to avoid polluting global scope.
-#   If the variable already exists and is non-empty in the receiving scope,
-#   an error message is printed and the assignment is skipped.
+#   Produces an opaque state object that preserves the current values of the
+#   specified local variables for later restoration via
+#   `hs_read_persisted_state`.
+#   The current implementation stores that state as guarded Bash code, but
+#   callers should treat the resulting value as internal transport data rather
+#   than as a public snippet format.
+#   Restoration only initializes matching `local` variables in the receiving
+#   scope and skips variables that are already non-empty there.
+# Options:
+#   -S <state> - pass the state object by name, mandatory.
+#   Other options are ignored up to the last --, so this function is usually able
+#   to directly process its caller's argument list, future-proofing it against
+#   new hs_persist_state_as_code options.
+#   -- - marks the end of options and the beginning of the list of variable names.
 # Arguments:
-#   -S <statevar> - required; appends the emitted code to variable
-#                   definitions found in the variable <statevar>.
-#   $@ - names of local variables to persist.
+#   $@ - names of local variables to persist. Without `--`, the trailing
+#        arguments that are valid Bash identifiers are treated as the variable list.
+#        Note that the value associated with the last given option will be mistaken
+#        for a variable unless `--` is used.
+# Errors:
+#   - Rejects a missing `-S` option.
+#   - Rejects an invalid variable name.
+#   - Rejects collisions with variables already present in the prior state.
 # Usage examples:
 #   local state
-#   hs_persist_state_as_code -S state var1 var2
-#   cleanup() {
+#   init() {
 #       local var1 var2
-#       eval "$1"
-#       # vars are available here
+#       hs_persist_state_as_code "$@" -- var1 var2
 #   }
+#
+#   init -S state
 hs_persist_state_as_code() {
-    local __existing_state=""
-    local __output_state_var=""
-    local __consumed_state_args=0
-    _hs_resolve_state_inputs hs_persist_state_as_code __existing_state __output_state_var __consumed_state_args "$@" || return $?
-    shift "$__consumed_state_args"
+    local -a __remaining_args=()
+    local -A __processed_args=()
+    _hs_resolve_state_inputs hs_persist_state_as_code __remaining_args S: __processed_args "$@" || return $?
+    local __output_state_var="${__processed_args[state]}"
+    local __existing_state="${!__output_state_var-}"
+    local -a __persist_var_args=()
+    read -r -a __persist_var_args <<< "${__processed_args[vars]-}"
     # Initialize output state string
     local __output=""
     if [ -n "$__existing_state" ]; then
         __output="$__existing_state"
     fi
     local __var_name
-    for __var_name in "$@"; do
+    for __var_name in "${__persist_var_args[@]}"; do
         # Check that the value of __var_name is neither "__var_name" nor "__existing_state"
         if [ "$__var_name" = "__var_name" ] || [ "$__var_name" = "__existing_state" ] || [ "$__var_name" = "__output_state_var" ] || [ "$__var_name" = "__output" ]; then
             echo "[ERROR] hs_persist_state_as_code: refusing to persist reserved variable name '$__var_name'." >&2  
@@ -147,19 +162,29 @@ fi
 
 # --- hs_destroy_state ---------------------------------------------------------------
 # Function:
-#   hs_destroy_state
+#   hs_destroy_state [options] [--] [state_variable ...]
 # Description:
-#   Purge the state string from the given definitions. In the cleanup function
-#   of a library, the state vector should be stripped of that library's state
-#   variables, so that the init function can be called again without triggering
-#   name collision errors.
+#   Removes the specified local variables from an opaque state object.
+#   In a cleanup function, this allows the same state variable to be reused by
+#   a later init call without triggering name-collision errors.
+# Options:
+#   -S <state> - pass the state object by name, mandatory.
+#   Other options are ignored up to the last --, so this function is usually able
+#   to directly process its caller's argument list, future-proofing it against
+#   new hs_destroy_state options.
+#   -- - marks the end of options and the beginning of the list of variable names.
 # Arguments:
-#   -S <statevar> - required; reads and rewrites the state held in
-#                   the variable <statevar>.
-#   $@ - names of local variables to destroy.
+#   $@ - names of local variables to destroy. Without `--`, the trailing
+#        arguments that are valid Bash identifiers are treated as the variable list.
+#        Note that the value associated with the last given option will be mistaken
+#        for a variable unless `--` is used.
+# Errors:
+#   - Rejects a missing `-S` option.
+#   - Rejects an invalid variable name.
+#   - Rejects destroy requests for variables not present in the state object.
 # Usage examples:
-#   mylib_cleanup() {
-#       hs_destroy_state -S state mylib_statevar1 mylibstatevar2
+#   cleanup_function() {
+#       hs_destroy_state "$@" -- mylib_statevar1 mylib_statevar2
 #   }
 hs_destroy_state() {
     # Step 1: resolve the input/output state sources using the same -S-only
@@ -168,11 +193,13 @@ hs_destroy_state() {
     #   - __output_state_var names the destination variable, if -S was used
     #   - __consumed_state_args tells us how many option arguments to discard
     #     before "$@" contains only variable names to destroy.
-    local __existing_state=""
-    local __output_state_var=""
-    local __consumed_state_args=0
-    _hs_resolve_state_inputs hs_destroy_state __existing_state __output_state_var __consumed_state_args "$@" || return $?
-    shift "$__consumed_state_args"
+    local -a __remaining_args=()
+    local -A __processed_args=()
+    _hs_resolve_state_inputs hs_destroy_state __remaining_args S: __processed_args "$@" || return $?
+    local __output_state_var="${__processed_args[state]}"
+    local __existing_state="${!__output_state_var-}"
+    local -a __destroy_var_args=()
+    read -r -a __destroy_var_args <<< "${__processed_args[vars]-}"
 
     # Step 2: set up working variables.
     # __state_var_names will contain every variable name found in the incoming
@@ -194,7 +221,7 @@ hs_destroy_state() {
     _hs_extract_persisted_state_var_names hs_destroy_state "$__existing_state" __state_var_names || return $?
     for __state_var in "${__state_var_names[@]}"; do
         __state_var_found=false
-        for __var_name in "$@"; do
+        for __var_name in "${__destroy_var_args[@]}"; do
             if [[ "$__var_name" == "$__state_var" ]]; then
                 __state_var_found=true
                 break
@@ -207,7 +234,7 @@ hs_destroy_state() {
 
     # Step 5: every requested variable must actually exist in the incoming
     # state. If a requested name is absent, return HS_ERR_INVALID_VAR_NAME.
-    for __var_name in "$@"; do
+    for __var_name in "${__destroy_var_args[@]}"; do
         __state_var_found=false
         for __state_var in "${__state_var_names[@]}"; do
             if [[ "$__state_var" == "$__var_name" ]]; then
@@ -281,69 +308,124 @@ hs_destroy_state() {
 }
 # --- hs_read_persisted_state --------------------------------------------------------
 # Function: 
-#   hs_read_persisted_state
+#   hs_read_persisted_state [options] [--] [state_variable ...]
 # Description: 
-#   Emits the state string produced by `hs_persist_state_as_code` without evaluating it.
-#   The state is passed by variable name and accessed via a nameref, so callers
-#   do not pass the snippet by value. This function still only returns the
-#   stored code snippet; callers should `eval "$(hs_read_persisted_state state)"`
-#   or simply `eval "$state"` to recreate variables in the caller scope.
+#   Restores values from the opaque state object produced by
+#   `hs_persist_state_as_code`.
 #   For convenience, callers may pass either `state` or `-S state`.
-#   Can be called several times to extract distinct variables.
-#   The referenced state variable contains a bash code snippet that assigns
-#   values to existing local and empty variables in the current scope.
+#   When explicit variable names are provided, those named locals are restored
+#   directly into the current caller scope.
+#   Without an explicit list, the function emits a safe, locally generated probe
+#   snippet that reenters `hs_read_persisted_state` with the names of matching
+#   empty locals found in the immediate caller scope.
+# Options:
+#   -q - suppresses the warning that is normally emitted when a requested
+#        state variable is not present in the state object.
+#   -S <state> - pass the state object by name, mandatory.
+#   Other options are ignored up to the last --, so this function is usually able
+#   to directly process its caller's argument list, future-prooving it against
+#   new hs_read_persisted_state options.
+#   -- - marks the end of options and the beginning of the list of variable names.
 # Arguments:
-#   $1 - name of the variable holding the state string produced by `hs_persist_state_as_code`,
-#        or `-S`
-#   $2 - state variable name when `$1` is `-S`
+#   $@ - names of local variables to restore. Without `--`, the trailing
+#        arguments that are valid Bash identifiers are treated as the variable list.
+#        Note that the detached value associated with the last given option will be mistaken
+#        for a variable unless that option is known or `--` is used.
 # Errors:
-#   - Rejects a missing first argument.
+#   - Rejects a missing `-S` option.
 #   - Rejects an invalid variable name.
-#   - Rejects a valid variable name that does not refer to an existing,
-#     non-empty state variable.
+#   - Rejects a state variable that is missing, unset, or empty.
 # Usage examples:
-#   # direct eval
 #   cleanup() {
 #       local state_var="$1"
-#       local -n state_ref="$state_var"
 #       local temp_file resource_id
-#       eval "$state_ref"
-#       # vars are available here
+#       hs_read_persisted_state -S "$state_var" -- temp_file resource_id
 #   }
-#
-#   # helper wrapper form (prints state; caller evals it in its own scope)
+#   # Better: keeps -S convention for cleanup().
 #   cleanup() {
-#       local state="$1"
 #       local temp_file resource_id
-#       eval "$(hs_read_persisted_state state)"
+#       hs_read_persisted_state -q "$@" -- temp_file resource_id
 #   }
 hs_read_persisted_state() {
     # Step 1: parse hs_read_persisted_state-specific flags before delegating
     # the shared state-input handling to _hs_resolve_state_inputs.
     local __quiet=false
-    while [ $# -gt 0 ] && [ "${1-}" = "-q" ]; do
-        __quiet=true
-        shift
-    done
-
     if [ $# -eq 0 ]; then
         echo "[ERROR] hs_read_persisted_state: missing required state variable name." >&2
         return "$HS_ERR_MISSING_ARGUMENT"
     fi
 
+    local -a __args=("$@")
+    local -a __prefix_args=()
+    local -a __suffix_args=()
+    local -a __filtered_prefix_args=()
+    local __arg_count=${#__args[@]}
+    local __last_separator_index=-1
+    local __i=0
+
+    for ((__i = 0; __i < __arg_count; __i++)); do
+        if [[ "${__args[__i]}" == "--" ]]; then
+            __last_separator_index=$__i
+        fi
+    done
+
+    if (( __last_separator_index >= 0 )); then
+        __prefix_args=("${__args[@]:0:__last_separator_index}")
+        __suffix_args=("${__args[@]:__last_separator_index+1}")
+    else
+        __prefix_args=("${__args[@]}")
+    fi
+
+    set -- "${__prefix_args[@]}"
+    local OPTIND=1
+    local opt
+    while (( OPTIND <= $# )); do
+        if getopts ":qS:" opt; then
+            case "$opt" in
+                q)
+                    __quiet=true
+                    ;;
+                :)
+                    if [[ "$OPTARG" == "S" ]]; then
+                        echo "[ERROR] hs_read_persisted_state: missing required state variable name for -S option." >&2
+                        return "$HS_ERR_MISSING_ARGUMENT"
+                    fi
+                    ;;
+                \?)
+                    :
+                    ;;
+            esac
+        else
+            OPTIND=$((OPTIND + 1))
+        fi
+    done
+
+    local __prefix_arg=""
+    for __prefix_arg in "${__prefix_args[@]}"; do
+        if [[ "$__prefix_arg" != "-q" ]]; then
+            __filtered_prefix_args+=("$__prefix_arg")
+        fi
+    done
+
+    set -- "${__filtered_prefix_args[@]}"
+    if (( __last_separator_index >= 0 )); then
+        set -- "$@" -- "${__suffix_args[@]}"
+    fi
     if [ "${1-}" != "-S" ]; then
         set -- -S "$@"
     fi
-
     # Step 2: resolve the named state variable and capture its current payload.
     # The helper validates names, enforces the presence of -S, and returns:
     #   - __existing_state: the current serialized state snippet
     #   - __output_state_var: the caller-visible variable name holding that state
     #   - __consumed_state_args: how many leading arguments belong to state input
-    local __existing_state=""
-    local __output_state_var=""
-    local __consumed_state_args=0
-    _hs_resolve_state_inputs hs_read_persisted_state __existing_state __output_state_var __consumed_state_args "$@" || return $?
+    local -a __remaining_args=()
+    local -A __processed_args=()
+    _hs_resolve_state_inputs hs_read_persisted_state __remaining_args S: __processed_args "$@" || return $?
+    local __output_state_var="${__processed_args[state]}"
+    local __existing_state="${!__output_state_var-}"
+    local -a __requested_var_args=()
+    read -r -a __requested_var_args <<< "${__processed_args[vars]-}"
 
     if [ -z "$__existing_state" ]; then
         echo "[ERROR] hs_read_persisted_state: state variable '$__output_state_var' is not set or is empty." >&2
@@ -353,13 +435,11 @@ hs_read_persisted_state() {
     # Step 3: if the caller listed variable names after the state input, restore
     # only those variables directly into the caller scope. This is the explicit
     # selective-restore API.
-    if [ $# -ne "$__consumed_state_args" ]; then
-        shift "$__consumed_state_args"
-
+    if [ ${#__requested_var_args[@]} -gt 0 ]; then
         local __requested_var
         local __restored_value=""
         local __restore_status=0
-        for __requested_var in "$@"; do
+        for __requested_var in "${__requested_var_args[@]}"; do
             # Evaluate the persisted state in a short-lived Bash subprocess,
             # scoped to one requested variable, then print the resulting value
             # back to this function. The subprocess is isolated and time-bounded
@@ -444,11 +524,12 @@ _hs_is_valid_variable_name() {
 #   the caller through variable names passed as parameters.
 # Arguments:
 #   $1 - caller function name, used in error messages; must be a valid Bash name
-#   $2 - name of the variable that will receive the current state value; must be a valid Bash name
-#   $3 - name of the variable that will receive the destination state variable name; must be a valid Bash name
-#   $4 - name of the variable that will receive the number of consumed option arguments; must be a valid Bash name
-#   $5 - first variable name to process or `-S`
-#   $6... - additional variable names to process, with `-S <statevar>` required somewhere in the argument list
+#   $2 - name of the array variable that will receive the unprocessed arguments; must be a valid Bash name
+#   $3 - getopts format string of accepted parameters; e.g. qS::
+#   $4 - name of the associative array variable that will receive the processed arguments; must be a valid Bash name
+#   $5 - first forwarded argument option
+#   $6... - additional forwarded arguments; if `--` is present, its last
+#           occurrence marks the start of the explicit variable-name list
 # Returns:
 #   0 on success.
 #   `HS_ERR_MISSING_ARGUMENT` if fewer than 6 arguments are provided.
@@ -458,82 +539,112 @@ _hs_is_valid_variable_name() {
 #   local existing_state="" output_state_var="" consumed_state_args=0
 #   _hs_resolve_state_inputs my_helper existing_state output_state_var consumed_state_args "$@" || return $?
 _hs_resolve_state_inputs() {
-    if [ $# -lt 6 ]; then
-        echo "[ERROR] _hs_resolve_state_inputs: missing required arguments; expected at least 6 parameters." >&2
+    if [ $# -lt 4 ]; then
+        echo "[ERROR] $1: missing required arguments; expected at least 4 parameters." >&2
         return "$HS_ERR_MISSING_ARGUMENT"
     fi
     local __arg
-    for __arg in "$1" "$2" "$3" "$4"; do
+    for __arg in "$1" "$2" "$4"; do
         if ! _hs_is_valid_variable_name "$__arg"; then
-            echo "[ERROR] _hs_resolve_state_inputs: invalid variable name '$__arg'." >&2
+            echo "[ERROR] $1: invalid variable name '$__arg'." >&2
             return "$HS_ERR_INVALID_VAR_NAME"
         fi
     done
     local __caller_name=$1
-    local -n __existing_state_ref=$2
-    local -n __output_state_var_ref=$3
-    local -n __consumed_count_ref=$4
+    local -n __remaining_args_ref=$2
+    local __options=$3
+    local -n __processed_args_ref=$4
     shift 4
 
-    __existing_state_ref=""
-    __output_state_var_ref=""
-    __consumed_count_ref=0
-
-    local -a __args=("$@")
-    local __arg_count=${#__args[@]}
-    local __last_separator_index=-1
-    local __i=0
-    local __parse_limit=$__arg_count
-
-    # If one or more `--` markers are present, the last one separates the
-    # forwarded helper options from the explicit list of variable names.
-    for ((__i = 0; __i < __arg_count; __i++)); do
-        if [[ "${__args[__i]}" == "--" ]]; then
-            __last_separator_index=$__i
-        fi
-    done
-
-    if (( __last_separator_index >= 0 )); then
-        __consumed_count_ref=$((__last_separator_index + 1))
-        __parse_limit=$__last_separator_index
-    else
-        __consumed_count_ref=2
+    # Validate the types of passed arrays using ${...@a}
+    if ! _hs_is_array __remaining_args_ref; then
+        echo "[ERROR] ${__caller_name}: '$2' must name an indexed array variable." >&2
+        return "$HS_ERR_MISSING_ARGUMENT"
+    fi
+    if ! _hs_is_array -A __processed_args_ref; then
+        echo "[ERROR] ${__caller_name}: '$4' must name an associative array variable." >&2
+        return "$HS_ERR_MISSING_ARGUMENT"
     fi
 
-    # Before the effective separator, only helper options are recognized.
-    # Any other forwarded arguments belong to the caller and are ignored here.
-    for ((__i = 0; __i < __parse_limit; __i++)); do
-        case "${__args[__i]}" in
-            -S)
-                if (( __i + 1 >= __parse_limit )); then
-                    echo "[ERROR] ${__caller_name}: missing required state variable name for -S option." >&2
+    
+    # Initialize processed options
+    __processed_args_ref=(["quiet"]=false)
+
+    # Process options
+    # Increments OPTIND scanning for known options.
+    __remaining_args_ref=()
+    local -i OPTIND=1
+    local opt
+    local -i index
+    
+    # Force a colon in front of $__options to record unknown options in $OPTARG
+    while (( "$#" >= "$OPTIND" )); do
+        index=${OPTIND}
+        if getopts ":$__options" opt; then
+            # Returns OK if known or unknown option -X [val]
+            # value is assigned to $OPTARG for known options
+            # value can be attached -Svarname or detached -S varname
+            case "$opt" in
+                \?)
+                    # Unknown option
+                    __remaining_args_ref+=("-$OPTARG")
+                    ;;
+                S)
+                    if ! _hs_is_valid_variable_name "$OPTARG"; then
+                        echo "[ERROR] ${__caller_name}: invalid variable name '${OPTARG}'." >&2
+                        return "$HS_ERR_INVALID_VAR_NAME"
+                    fi
+                    __processed_args_ref["state"]="$OPTARG"
+                    ;;
+                q)
+                    __processed_args_ref["quiet"]=true
+                    ;;
+                :)
+                    # Only triggered by -S in the last position since getopts accepts
+                    # -q or -- as the value of -S if it encounters ... -S -q or ... -S -- ...
+                    echo "[ERROR] ${__caller_name}: missing required parameter to option -${OPTARG}." >&2
                     return "$HS_ERR_MISSING_ARGUMENT"
-                fi
-                __output_state_var_ref="${__args[__i + 1]}"
-                if ! _hs_is_valid_variable_name "$__output_state_var_ref"; then
-                    echo "[ERROR] ${__caller_name}: invalid variable name '$__output_state_var_ref' for -S option." >&2
+                    ;;
+            esac
+        elif (( "$index" == "$OPTIND" )); then
+            # It was a word (parameter to some unknown option)
+            __remaining_args_ref+=("${!OPTIND}")
+            OPTIND=$(( OPTIND + 1 ))
+        else
+            # Hit --. Stop decoding options.
+            __processed_args_ref["separator"]=true
+            while (( "$#" >= "$OPTIND" )); do 
+                if ! _hs_is_valid_variable_name "${!OPTIND}"; then
+                    echo "[ERROR] ${__caller_name}: invalid variable name '${!OPTIND}'." >&2
                     return "$HS_ERR_INVALID_VAR_NAME"
                 fi
-                ((__i++))
-                ;;
-        esac
-    done
-
-    # After the effective separator, every token is part of the variable list.
-    # Without a separator, this validates the traditional trailing "$@" list.
-    for ((__i = __consumed_count_ref; __i < __arg_count; __i++)); do
-        if ! _hs_is_valid_variable_name "${__args[__i]}"; then
-            echo "[ERROR] ${__caller_name}: invalid variable name '${__args[__i]}'." >&2
-            return "$HS_ERR_INVALID_VAR_NAME"
+                printf -v __processed_args_ref["vars"] "%s %s" "${!OPTIND}" "${__processed_args_ref['vars']}"
+                OPTIND=$(( OPTIND + 1 ))
+            done
         fi
     done
 
-    if [ -z "$__output_state_var_ref" ]; then
+    # Pull variable names from the end
+    : "${__processed_args_ref["vars"]:=}"
+    if [[ -z "${__processed_args_ref[separator]-}" ]]; then
+        while (( ${#__remaining_args_ref[@]} > 0 )) && _hs_is_valid_variable_name "${__remaining_args_ref[-1]}"; do
+            printf -v __processed_args_ref["vars"] "%s %s" "${__remaining_args_ref[-1]}" "${__processed_args_ref['vars']}"
+            unset "__remaining_args_ref[-1]"
+        done
+
+        local __remaining_arg
+        for __remaining_arg in "${__remaining_args_ref[@]}"; do
+            if [[ "$__remaining_arg" != -* ]]; then
+                echo "[ERROR] ${__caller_name}: invalid variable name '${__remaining_arg}'." >&2
+                return "$HS_ERR_INVALID_VAR_NAME"
+            fi
+        done
+    fi
+    
+    if [[ -z "${__processed_args_ref[state]-}" ]]; then
         echo "[ERROR] ${__caller_name}: state variable is uninitialized; missing required -S <statevar> option." >&2
         return "$HS_ERR_STATE_VAR_UNINITIALIZED"
     fi
-
-    eval "__existing_state_ref=\${$__output_state_var_ref-}"
 }
 
 # Function:
@@ -590,30 +701,14 @@ _hs_extract_persisted_state_var_names() {
     fi
 }
 
-# Function:
-#    hs_get_pid_of_subshell
-# Description:
-#    Returns the PID of the current subshell that works in conjunction with hs_echo to
-#    ensure output is properly captured and redirected to whatever stdout was when the
-#    library was sourced.
-# Usage:
-#    pid=$(hs_get_pid_of_subshell)
-# Return status:
-#    0 - Success
-#    1 - Internal error: hs_cleanup_output not defined or doesn't have the expected format.
-hs_get_pid_of_subshell() {
-    # Extract the PID of the background reader process from the function definition
-    local func_def
-    func_def=$(declare -f hs_cleanup_output)
-    local pid
-    pid=${func_def##*wait }
-    # The above string substitution will just return $func_det without an error if "wait " is not found.
-    if [ "$pid" = "$func_def" ]; then
-        echo "hs_cleanup_output function not found or has unexpected format" >&2
-        return 1
+_hs_is_array() {
+    local arraytypes="a"
+    if [[ "$1" == "-A" ]]; then
+        arraytypes="A"
+        shift
     fi
-    pid=${pid%%[^0-9]*}
-    printf '%s' "$pid"
+    local -n vname=$1 
+    local attrs
+    attrs=${vname@a}
+    [[ "$attrs" == *[$arraytypes]* ]]
 }
-
-# Note: Remember to call hs_cleanup at the end of your main script to clean up resources.

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -152,16 +152,72 @@ The alternate solution is to keep and eval separate state snippets for each libr
 .. warning::
   The function cannot currently properly capture arrays, namerefs, associative arrays nor
   functions. Only scalar string variables are supported.
+
+hs_destroy_state
+~~~~~~~~~~~~~~~~
+
+Rebuilds a persisted state snippet while removing specific variable
+definitions from it. This is intended for cleanup paths that need to strip a
+library's own variables from a shared state vector so the same init function
+can later be called again without triggering name-collision errors in
+``hs_persist_state``.
+
+The function accepts optional ``-s`` or ``-S`` arguments:
+
+- ``-s <state>``: treats ``<state>`` as the input state snippet and prints the
+  rebuilt state to stdout.
+- ``-S <var>``: reads the input state from variable ``<var>``, removes the
+  listed variables, and writes the rebuilt state back into ``<var>``.
+
+The arguments after the options are the variable names to destroy. Each name
+must be a valid shell variable name and must already exist in the input state.
+
+- Usage: ``hs_destroy_state [-s <state> | -S <var>] var1 var2 ...``
+- Output: a rebuilt Bash state snippet with the requested variables removed
+  (when not assigning to a variable via ``-S``).
+- Errors:
+  - Detects an invalid variable name passed either to ``-S`` or in the destroy list.
+  - Fails if a requested variable is not defined in the input state.
+  - Detects corrupt prior state when the input cannot be interpreted as a
+    state snippet emitted by ``hs_persist_state``.
+- Guarantees:
+  - Rebuilds the resulting state from the surviving variables rather than
+    mutating the original text blocks in place.
+
+This is the typical pattern:
+
+.. code-block:: bash
+
+   init_function() {
+       local temp_file="/tmp/some_temp_file"
+       local resource_id="resource_123"
+       hs_persist_state -S state temp_file resource_id
+   }
+
+   cleanup_function() {
+       local temp_file resource_id
+       eval "$state"
+       rm -f "$temp_file"
+       hs_destroy_state -S state temp_file resource_id
+   }
+
+After ``cleanup_function`` has removed its own variables from ``state``, a
+later call to ``init_function`` can reuse the same state variable without
+colliding with stale entries from the previous cycle.
+
 hs_read_persisted_state
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-This function is a simple wrapper around `echo`. There is no way in Bash to
-set variables in the caller scope without `eval`ing code, so this function
-is only provided for symmetry with `hs_persist_state`. Its output must be
-`eval`'d by the caller to restore state anyway and the effect is identical to
-`eval "$state"`. Code readability is slightly improved by using this function.
+This function is a simple wrapper around `echo`. `hs_read_persisted_state`
+accepts the name of the variable holding the persisted state and reads it via a
+nameref. It currently requires eval because the persisted state is stored as a Bash code
+snippet. This is a property of the chosen format, not a fundamental limitation
+of Bash for restoring values into already-declared caller-local variables.
+The output must be `eval`'d by the caller to restore state anyway and the
+effect is identical to `eval "$state"`. Code readability is slightly improved
+by using this function, and code is future proven against format changes.
 
-- Usage: `eval "$(hs_read_persisted_state "$state")"`
+- Usage: `eval "$(hs_read_persisted_state state)"`
 
 hs_get_pid_of_subshell
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -198,6 +254,15 @@ State Persistence
 in a guarded assignment snippet, and prints that snippet. The guards ensure that
 only `local` variables are populated in the receiving scope and that non-empty
 locals are not overwritten.
+
+State Destruction
+~~~~~~~~~~~~~~~~~
+
+`hs_destroy_state` scans a persisted state snippet for the variable headers
+emitted by `hs_persist_state`, computes the survivor list, then rebuilds the
+state from those survivors. This keeps the removal logic centralized in
+`handle_state.sh` and gives libraries a way to reuse a shared state variable
+across several init/cleanup cycles.
 
 Supported Variables
 -------------------
@@ -237,8 +302,9 @@ Workarounds
   encoded=$(printf '%s\0' "${myarray[@]}" | base64 -w0)
   hs_persist_state encoded
   # In the cleanup function
+  local state="$1"
   local encoded
-  eval "$(hs_read_persisted_state "$1")"
+  eval "$(hs_read_persisted_state state)"
   declare -a newarray
   mapfile -d '' -t newarray < <(printf '%s' "$encoded" | base64 -d)
 Caveats

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -104,6 +104,8 @@ The emitted snippet only assigns values if the target variable is declared
 The function requires the `-S` argument:
 
 - `-S <var>`: Assigns the state (appended to any existing content in `<var>`) to the variable named `<var>`.
+- ``--``: optional separator; if present, the last occurrence marks the start
+  of the explicit list of local variable names.
 
 .. warning::
    When using `-S` with a variable name, the function will `eval` the current contents of that variable during collision checking. Callers must ensure the variable contains only safe, trusted Bash code or is empty/unset to avoid execution of harmful code.
@@ -122,7 +124,7 @@ and refuses to overwrite existing variables. Some library combinations can be
 incompatible with the chaining approach because they use overlapping variable names.
 The alternate solution is to keep separate state variables for each library.
 
-- Usage: `hs_persist_state_as_code -S <var> var1 var2 ...`
+- Usage: `hs_persist_state_as_code -S <var> -- var1 var2 ...`
 - Output: writes a string of Bash code intended to be `eval`'d by the caller into `<var>`.
 - Errors:
   - Detects an invalid variable name passed to option `-S`.
@@ -149,11 +151,14 @@ The function requires the ``-S`` argument:
 
 - ``-S <var>``: reads the input state from variable ``<var>``, removes the
   listed variables, and writes the rebuilt state back into ``<var>``.
+- ``--``: optional separator; if present, the last occurrence marks the start
+  of the explicit list of local variable names.
 
-The arguments after the options are the variable names to destroy. Each name
-must be a valid shell variable name and must already exist in the input state.
+The arguments after the effective separator are the variable names to destroy.
+Each name must be a valid shell variable name and must already exist in the
+input state.
 
-- Usage: ``hs_destroy_state -S <var> var1 var2 ...``
+- Usage: ``hs_destroy_state -S <var> -- var1 var2 ...``
 - Output: rewrites ``<var>`` with a rebuilt Bash state snippet with the requested variables removed.
 - Errors:
   - Detects an invalid variable name passed either to ``-S`` or in the destroy list.
@@ -171,14 +176,14 @@ This is the typical pattern:
    init_function() {
        local temp_file="/tmp/some_temp_file"
        local resource_id="resource_123"
-       hs_persist_state_as_code -S state temp_file resource_id
+       hs_persist_state_as_code -S state -- temp_file resource_id
    }
 
    cleanup_function() {
        local temp_file resource_id
        eval "$state"
        rm -f "$temp_file"
-       hs_destroy_state -S state temp_file resource_id
+       hs_destroy_state -S state -- temp_file resource_id
    }
 
 After ``cleanup_function`` has removed its own variables from ``state``, a
@@ -191,8 +196,8 @@ hs_read_persisted_state
 `hs_read_persisted_state` reads state from a named state variable. It supports
 two modes:
 
-- Explicit restore: ``hs_read_persisted_state state foo bar``
-- Probe-snippet generation: ``eval "$(hs_read_persisted_state state)"``
+- Explicit restore: ``hs_read_persisted_state -S state -- foo bar``
+- Probe-snippet generation: ``eval "$(hs_read_persisted_state -S state)"``
 
 Explicit restore is the preferred API. The caller names exactly which variables
 must be restored, and `hs_read_persisted_state` writes those values into the
@@ -275,8 +280,8 @@ State Restoration
 
 `hs_read_persisted_state` should usually be used in one of these forms:
 
-- ``hs_read_persisted_state state foo bar``
-- ``eval "$(hs_read_persisted_state state)"``
+- ``hs_read_persisted_state -S state -- foo bar``
+- ``eval "$(hs_read_persisted_state -S state)"``
 
 The first form is preferred because it is explicit and does not require the
 caller to execute the transmitted state snippet. The second form exists for the
@@ -323,14 +328,14 @@ Workarounds
   # In the cleanup function
   local state_var="$1"
   local encoded
-  hs_read_persisted_state "$state_var" encoded
+  hs_read_persisted_state -S "$state_var" -- encoded
   declare -a newarray
   mapfile -d '' -t newarray < <(printf '%s' "$encoded" | base64 -d)
 Caveats
 -------
 
-- Prefer ``hs_read_persisted_state state var1 var2`` over direct ``eval``.
-- If you use ``eval "$(hs_read_persisted_state state)"``, declare target
+- Prefer ``hs_read_persisted_state -S state -- var1 var2`` over direct ``eval``.
+- If you use ``eval "$(hs_read_persisted_state -S state)"``, declare target
   variables ``local`` first and remember that only the immediate caller scope
   is probed automatically.
 - Direct ``eval "$state"`` should be avoided in library code unless you are

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -12,10 +12,9 @@ Purpose
 This library provides two core capabilities for Bash libraries:
 
 - Persisting local variable state from one function to another (typically
-  initialization to cleanup) via a generated snippet that can be `eval`'d.
-- As its state persistence functions output code on stdout, the library allows
-  provides the means to display messages to stdout from within initialization 
-  functions using a logging FIFO and background reader process.
+  initialization to cleanup) via a generated snippet stored in a named state variable.
+- Providing a logging FIFO and background reader process for cases where
+  subshell output still needs to be surfaced in the main script output.
 
 Dependencies
 ------------
@@ -28,8 +27,7 @@ Quick Start
 -----------
 
 Source the file once, then use `hs_persist_state_as_code` in the init function and
-`eval` the state in cleanup. For cleaner code, assign to a variable instead of
-capturing stdout.
+`hs_read_persisted_state` in cleanup.
 
 .. code-block:: bash
 
@@ -42,13 +40,13 @@ capturing stdout.
        # Define some opaque library resources
        local temp_file="/tmp/some_temp_file"
        local resource_id="resource_123"
-       hs_persist_state_as_code "$@" temp_file resource_id
+       hs_persist_state_as_code -S state temp_file resource_id
    }
 
    cleanup() {
-       local state="$1"
+       local state_var="$1"
        local temp_file resource_id
-       eval "$state"
+       hs_read_persisted_state "$state_var" temp_file resource_id
        rm -f "$temp_file"
        echo "Cleaned up resource: $resource_id"
    }
@@ -58,14 +56,6 @@ capturing stdout.
    init_function -S my_state
    # Your main script logic here
    cleanup "$my_state"
-
-For backward compatibility, the old stdout capture method still works:
-
-.. code-block:: bash
-
-   # Capture the opaque state snippet emitted on stdout
-   state=$(init_function)  
-   cleanup "$state"
 
 Public API
 ----------
@@ -111,15 +101,9 @@ Emits Bash code that restores specified local variables in a receiving scope.
 The emitted snippet only assigns values if the target variable is declared
 `local` in the receiving scope and is still empty.
 
-The function accepts optional `-s` or `-S` arguments:
+The function requires the `-S` argument:
 
-- `-s <state>`: Treats `<state>` as an existing state snippet to append to.
-- `-S <var>`: Assigns the state (appended to any existing content in `<var>`) to the variable named `<var>` instead of printing to stdout.
-
-These options can be used together; when both are provided, `<var>` is used for output and must be empty or uninitialized.
-
-This allows avoiding stdout output for opaque data when assigning to a variable,
-while maintaining backward compatibility for appending to state strings or state vars.
+- `-S <var>`: Assigns the state (appended to any existing content in `<var>`) to the variable named `<var>`.
 
 .. warning::
    When using `-S` with a variable name, the function will `eval` the current contents of that variable during collision checking. Callers must ensure the variable contains only safe, trusted Bash code or is empty/unset to avoid execution of harmful code.
@@ -130,18 +114,17 @@ checking, and only if the variable is not empty. Corrupted state code is detecte
 it calls undefined commands during this evaluation, and when the evaluation takes more
 than one second (to prevent hangs).
 
-Libraries are encouraged to provide the same ``-s`` and ``-S`` options to their initialization
-functions to allow callers to chain state snippets together.
+Libraries are encouraged to provide the same ``-S`` option to their initialization
+functions so callers can keep state transport explicit and by-name.
 
 When appending to an existing state snippet, the function checks for name collisions
-and refuses to overwrite existing variables. Some library combinations can be 
+and refuses to overwrite existing variables. Some library combinations can be
 incompatible with the chaining approach because they use overlapping variable names.
-The alternate solution is to keep and eval separate state snippets for each library.
+The alternate solution is to keep separate state variables for each library.
 
-- Usage: `hs_persist_state_as_code [-s <state> | -S <var>] var1 var2 ...`
-- Output: a string of Bash code intended to be `eval`'d by the caller (when not assigning to variable).
+- Usage: `hs_persist_state_as_code -S <var> var1 var2 ...`
+- Output: writes a string of Bash code intended to be `eval`'d by the caller into `<var>`.
 - Errors:
-  - Refuses to take into account more than one prior state.
   - Detects an invalid variable name passed to option `-S`.
   - Refuses to persist reserved names `__var_name`, `__existing_state`, `__output_state_var` and `__output`.
   - Rejects collisions when a variable already exists in the provided prior state.
@@ -162,19 +145,16 @@ library's own variables from a shared state vector so the same init function
 can later be called again without triggering name-collision errors in
 ``hs_persist_state_as_code``.
 
-The function accepts optional ``-s`` or ``-S`` arguments:
+The function requires the ``-S`` argument:
 
-- ``-s <state>``: treats ``<state>`` as the input state snippet and prints the
-  rebuilt state to stdout.
 - ``-S <var>``: reads the input state from variable ``<var>``, removes the
   listed variables, and writes the rebuilt state back into ``<var>``.
 
 The arguments after the options are the variable names to destroy. Each name
 must be a valid shell variable name and must already exist in the input state.
 
-- Usage: ``hs_destroy_state [-s <state> | -S <var>] var1 var2 ...``
-- Output: a rebuilt Bash state snippet with the requested variables removed
-  (when not assigning to a variable via ``-S``).
+- Usage: ``hs_destroy_state -S <var> var1 var2 ...``
+- Output: rewrites ``<var>`` with a rebuilt Bash state snippet with the requested variables removed.
 - Errors:
   - Detects an invalid variable name passed either to ``-S`` or in the destroy list.
   - Fails if a requested variable is not defined in the input state.
@@ -208,16 +188,42 @@ colliding with stale entries from the previous cycle.
 hs_read_persisted_state
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-This function is a simple wrapper around `echo`. `hs_read_persisted_state`
-accepts the name of the variable holding the persisted state and reads it via a
-nameref. It currently requires eval because the persisted state is stored as a Bash code
-snippet. This is a property of the chosen format, not a fundamental limitation
-of Bash for restoring values into already-declared caller-local variables.
-The output must be `eval`'d by the caller to restore state anyway and the
-effect is identical to `eval "$state"`. Code readability is slightly improved
-by using this function, and code is future proven against format changes.
+`hs_read_persisted_state` reads state from a named state variable. It supports
+two modes:
 
-- Usage: `eval "$(hs_read_persisted_state state)"`
+- Explicit restore: ``hs_read_persisted_state state foo bar``
+- Probe-snippet generation: ``eval "$(hs_read_persisted_state state)"``
+
+Explicit restore is the preferred API. The caller names exactly which variables
+must be restored, and `hs_read_persisted_state` writes those values into the
+current caller scope.
+
+When no explicit variable list is given, `hs_read_persisted_state` does not
+return the raw persisted state snippet. Instead, it emits a locally generated
+probe snippet. When that snippet is `eval`'d, it checks the immediate caller
+scope for matching ``local`` variables that are currently empty, then reenters
+`hs_read_persisted_state` with that explicit list.
+
+This design is safer than `eval "$state"` because the caller executes only the
+local probe snippet, not the transmitted persisted state directly. Direct
+``eval`` of the raw state is discouraged outside early unit tests of the library.
+
+.. warning::
+
+   Without an explicit variable list, every empty ``local`` variable in the
+   immediate caller scope whose name also exists in the state may be restored
+   automatically. This may be unwanted if the caller manages several unrelated
+   state variables or reuses the same local names for different purposes.
+   Prefer explicit variable lists in non-trivial cleanup functions.
+
+Automatic probing only inspects the immediate caller scope. Locals declared in
+the caller's caller are not restored automatically, but they can still be
+restored if an intermediate function knows their name and names them explicitly.
+
+The optional ``-q`` flag suppresses warnings for explicitly requested variables
+that are not present in the state. It is intended for explicit
+caller-supplied variable lists. When probing automatically, only variables 
+present in the state are probed.
 
 hs_get_pid_of_subshell
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -264,6 +270,19 @@ state from those survivors. This keeps the removal logic centralized in
 `handle_state.sh` and gives libraries a way to reuse a shared state variable
 across several init/cleanup cycles.
 
+State Restoration
+~~~~~~~~~~~~~~~~~
+
+`hs_read_persisted_state` should usually be used in one of these forms:
+
+- ``hs_read_persisted_state state foo bar``
+- ``eval "$(hs_read_persisted_state state)"``
+
+The first form is preferred because it is explicit and does not require the
+caller to execute the transmitted state snippet. The second form exists for the
+common case where the caller simply wants all matching empty locals in its own
+scope restored.
+
 Supported Variables
 -------------------
 
@@ -300,18 +319,22 @@ Workarounds
   # In the init function
   local -a myarray=("value1" "value2" "value with spaces"
   encoded=$(printf '%s\0' "${myarray[@]}" | base64 -w0)
-  hs_persist_state_as_code encoded
+  hs_persist_state_as_code -S state encoded
   # In the cleanup function
-  local state="$1"
+  local state_var="$1"
   local encoded
-  eval "$(hs_read_persisted_state state)"
+  hs_read_persisted_state "$state_var" encoded
   declare -a newarray
   mapfile -d '' -t newarray < <(printf '%s' "$encoded" | base64 -d)
 Caveats
 -------
 
-- Always declare target variables `local` before `eval`'ing the state snippet;
-  otherwise assignments are skipped to avoid leaking globals.
+- Prefer ``hs_read_persisted_state state var1 var2`` over direct ``eval``.
+- If you use ``eval "$(hs_read_persisted_state state)"``, declare target
+  variables ``local`` first and remember that only the immediate caller scope
+  is probed automatically.
+- Direct ``eval "$state"`` should be avoided in library code unless you are
+  deliberately handling the raw persisted snippet yourself.
 - The library uses `eval` internally; treat state strings as trusted input.
 - Call `hs_cleanup_output` when you are done to stop the background reader.
 

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -27,7 +27,7 @@ resolved when the library is sourced.
 Quick Start
 -----------
 
-Source the file once, then use `hs_persist_state` in the init function and
+Source the file once, then use `hs_persist_state_as_code` in the init function and
 `eval` the state in cleanup. For cleaner code, assign to a variable instead of
 capturing stdout.
 
@@ -42,7 +42,7 @@ capturing stdout.
        # Define some opaque library resources
        local temp_file="/tmp/some_temp_file"
        local resource_id="resource_123"
-       hs_persist_state "$@" temp_file resource_id
+       hs_persist_state_as_code "$@" temp_file resource_id
    }
 
    cleanup() {
@@ -104,7 +104,7 @@ so they appear in the main script stdout even when stdout of a subshell is being
 - Usage: `hs_echo "message"`
 - Notes: preserves Bash echo argument concatenation behavior.
 
-hs_persist_state
+hs_persist_state_as_code
 ~~~~~~~~~~~~~~~~
 
 Emits Bash code that restores specified local variables in a receiving scope.
@@ -138,7 +138,7 @@ and refuses to overwrite existing variables. Some library combinations can be
 incompatible with the chaining approach because they use overlapping variable names.
 The alternate solution is to keep and eval separate state snippets for each library.
 
-- Usage: `hs_persist_state [-s <state> | -S <var>] var1 var2 ...`
+- Usage: `hs_persist_state_as_code [-s <state> | -S <var>] var1 var2 ...`
 - Output: a string of Bash code intended to be `eval`'d by the caller (when not assigning to variable).
 - Errors:
   - Refuses to take into account more than one prior state.
@@ -160,7 +160,7 @@ Rebuilds a persisted state snippet while removing specific variable
 definitions from it. This is intended for cleanup paths that need to strip a
 library's own variables from a shared state vector so the same init function
 can later be called again without triggering name-collision errors in
-``hs_persist_state``.
+``hs_persist_state_as_code``.
 
 The function accepts optional ``-s`` or ``-S`` arguments:
 
@@ -179,7 +179,7 @@ must be a valid shell variable name and must already exist in the input state.
   - Detects an invalid variable name passed either to ``-S`` or in the destroy list.
   - Fails if a requested variable is not defined in the input state.
   - Detects corrupt prior state when the input cannot be interpreted as a
-    state snippet emitted by ``hs_persist_state``.
+    state snippet emitted by ``hs_persist_state_as_code``.
 - Guarantees:
   - Rebuilds the resulting state from the surviving variables rather than
     mutating the original text blocks in place.
@@ -191,7 +191,7 @@ This is the typical pattern:
    init_function() {
        local temp_file="/tmp/some_temp_file"
        local resource_id="resource_123"
-       hs_persist_state -S state temp_file resource_id
+       hs_persist_state_as_code -S state temp_file resource_id
    }
 
    cleanup_function() {
@@ -229,7 +229,7 @@ Error Codes
 -----------
 
 - `HS_ERR_RESERVED_VAR_NAME=1`: a reserved variable name was passed to
-  `hs_persist_state`.
+  `hs_persist_state_as_code`.
 - `HS_ERR_VAR_NAME_COLLISION=2`: the requested variable was already defined in
   the state string when persisting.
 
@@ -250,7 +250,7 @@ spawns a background reader that:
 State Persistence
 ~~~~~~~~~~~~~~~~~
 
-`hs_persist_state` captures caller-local variables by name, embeds their values
+`hs_persist_state_as_code` captures caller-local variables by name, embeds their values
 in a guarded assignment snippet, and prints that snippet. The guards ensure that
 only `local` variables are populated in the receiving scope and that non-empty
 locals are not overwritten.
@@ -259,7 +259,7 @@ State Destruction
 ~~~~~~~~~~~~~~~~~
 
 `hs_destroy_state` scans a persisted state snippet for the variable headers
-emitted by `hs_persist_state`, computes the survivor list, then rebuilds the
+emitted by `hs_persist_state_as_code`, computes the survivor list, then rebuilds the
 state from those survivors. This keeps the removal logic centralized in
 `handle_state.sh` and gives libraries a way to reuse a shared state variable
 across several init/cleanup cycles.
@@ -267,7 +267,7 @@ across several init/cleanup cycles.
 Supported Variables
 -------------------
 
-`hs_persist_state` reliably preserves local scalar variables (strings or numbers)
+`hs_persist_state_as_code` reliably preserves local scalar variables (strings or numbers)
 that are defined in the calling scope and re-declared as `local` in the receiving
 scope.
 
@@ -300,7 +300,7 @@ Workarounds
   # In the init function
   local -a myarray=("value1" "value2" "value with spaces"
   encoded=$(printf '%s\0' "${myarray[@]}" | base64 -w0)
-  hs_persist_state encoded
+  hs_persist_state_as_code encoded
   # In the cleanup function
   local state="$1"
   local encoded

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -4,344 +4,291 @@ Handle State Library
 Location
 --------
 
-- `config/handle_state.sh`
+- ``config/handle_state.sh``
 
 Purpose
 -------
 
-This library provides two core capabilities for Bash libraries:
+``handle_state.sh`` helps Bash libraries carry cleanup state by name.
 
-- Persisting local variable state from one function to another (typically
-  initialization to cleanup) via a generated snippet stored in a named state variable.
-- Providing a logging FIFO and background reader process for cases where
-  subshell output still needs to be surfaced in the main script output.
+The current public API is built around a named state variable passed with
+``-S <statevar>``. The state value is opaque. The current implementation stores
+that value as guarded Bash code, but callers should not depend on that internal
+representation.
 
 Dependencies
 ------------
 
-This library depends on the Command Guard Library (`config/command_guard.sh`)
-for secure execution of external commands. The dependency is automatically
-resolved when the library is sourced.
+This library depends on the Command Guard Library
+(``config/command_guard.sh``). The dependency is resolved automatically when
+``handle_state.sh`` is sourced.
 
 Quick Start
 -----------
 
-Source the file once, then use `hs_persist_state_as_code` in the init function and
-`hs_read_persisted_state` in cleanup.
-
 .. code-block:: bash
 
-   # Source once in the main script of your library
    source "$(dirname "$0")/config/handle_state.sh"
 
    init_function() {
-       # Direct output to stdout would mess up the state snippet, so use hs_echo if needed
-       hs_echo "Initializing..."
-       # Define some opaque library resources
        local temp_file="/tmp/some_temp_file"
        local resource_id="resource_123"
-       hs_persist_state_as_code -S state temp_file resource_id
-   }
-
-   cleanup() {
-       local state_var="$1"
-       local temp_file resource_id
-       hs_read_persisted_state "$state_var" temp_file resource_id
-       rm -f "$temp_file"
-       echo "Cleaned up resource: $resource_id"
-   }
-
-   # State is assigned to the variable, no stdout capture needed
-   local my_state
-   init_function -S my_state
-   # Your main script logic here
-   cleanup "$my_state"
-
-Public API
-----------
-
-hs_setup_output_to_stdout
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Sets up a FIFO and background reader process that forwards log lines from
-subshells to the main script output. The function initializes internal state,
-creates `hs_cleanup_output`, and defines `hs_echo` for use inside subshells.
-
-- Behavior: no-op if logging is already set up (detected via
-  `hs_get_pid_of_subshell`).
-- Side effects: creates a FIFO via a temporary file, opens it on a file
-  descriptor, and removes the FIFO path while the descriptor remains open.
-
-  .. warning::
-    This library allocates a new, unused file descriptor for internal job operations.
-    While this descriptor will not interfere with any file descriptors already in use,
-    please note that file descriptors are a global resource. The library will break down
-    if downstream code attempts to use or manipulate its private file descriptor.
-
-hs_cleanup_output
-~~~~~~~~~~~~~~~~~
-
-Defined dynamically by `hs_setup_output_to_stdout`. Sends the kill token to the
-FIFO, waits for the background reader to exit, and redefines itself as a no-op
-while resetting `hs_echo` to a plain `echo`.
-
-hs_echo
-~~~~~~~
-
-Defined dynamically by `hs_setup_output_to_stdout`. Writes messages to the FIFO
-so they appear in the main script stdout even when stdout of a subshell is being captured.
-
-- Usage: `hs_echo "message"`
-- Notes: preserves Bash echo argument concatenation behavior.
-
-hs_persist_state_as_code
-~~~~~~~~~~~~~~~~
-
-Emits Bash code that restores specified local variables in a receiving scope.
-The emitted snippet only assigns values if the target variable is declared
-`local` in the receiving scope and is still empty.
-
-The function requires the `-S` argument:
-
-- `-S <var>`: Assigns the state (appended to any existing content in `<var>`) to the variable named `<var>`.
-- ``--``: optional separator; if present, the last occurrence marks the start
-  of the explicit list of local variable names.
-
-.. warning::
-   When using `-S` with a variable name, the function will `eval` the current contents of that variable during collision checking. Callers must ensure the variable contains only safe, trusted Bash code or is empty/unset to avoid execution of harmful code.
-   
-
-Code protections ensure that prior state is only evaluated when necessary for collision 
-checking, and only if the variable is not empty. Corrupted state code is detected when
-it calls undefined commands during this evaluation, and when the evaluation takes more
-than one second (to prevent hangs).
-
-Libraries are encouraged to provide the same ``-S`` option to their initialization
-functions so callers can keep state transport explicit and by-name.
-
-When appending to an existing state snippet, the function checks for name collisions
-and refuses to overwrite existing variables. Some library combinations can be
-incompatible with the chaining approach because they use overlapping variable names.
-The alternate solution is to keep separate state variables for each library.
-
-- Usage: `hs_persist_state_as_code -S <var> -- var1 var2 ...`
-- Output: writes a string of Bash code intended to be `eval`'d by the caller into `<var>`.
-- Errors:
-  - Detects an invalid variable name passed to option `-S`.
-  - Refuses to persist reserved names `__var_name`, `__existing_state`, `__output_state_var` and `__output`.
-  - Rejects collisions when a variable already exists in the provided prior state.
-  - Detects some the most severe forms of corrupted prior state code (hangs or undefined commands).
-- Guarantees:
-  - Errors out or succeeds in an atomic manner; no partial state is emitted on error.
-
-.. warning::
-  The function cannot currently properly capture arrays, namerefs, associative arrays nor
-  functions. Only scalar string variables are supported.
-
-hs_destroy_state
-~~~~~~~~~~~~~~~~
-
-Rebuilds a persisted state snippet while removing specific variable
-definitions from it. This is intended for cleanup paths that need to strip a
-library's own variables from a shared state vector so the same init function
-can later be called again without triggering name-collision errors in
-``hs_persist_state_as_code``.
-
-The function requires the ``-S`` argument:
-
-- ``-S <var>``: reads the input state from variable ``<var>``, removes the
-  listed variables, and writes the rebuilt state back into ``<var>``.
-- ``--``: optional separator; if present, the last occurrence marks the start
-  of the explicit list of local variable names.
-
-The arguments after the effective separator are the variable names to destroy.
-Each name must be a valid shell variable name and must already exist in the
-input state.
-
-- Usage: ``hs_destroy_state -S <var> -- var1 var2 ...``
-- Output: rewrites ``<var>`` with a rebuilt Bash state snippet with the requested variables removed.
-- Errors:
-  - Detects an invalid variable name passed either to ``-S`` or in the destroy list.
-  - Fails if a requested variable is not defined in the input state.
-  - Detects corrupt prior state when the input cannot be interpreted as a
-    state snippet emitted by ``hs_persist_state_as_code``.
-- Guarantees:
-  - Rebuilds the resulting state from the surviving variables rather than
-    mutating the original text blocks in place.
-
-This is the typical pattern:
-
-.. code-block:: bash
-
-   init_function() {
-       local temp_file="/tmp/some_temp_file"
-       local resource_id="resource_123"
-       hs_persist_state_as_code -S state -- temp_file resource_id
+       hs_persist_state_as_code "$@" -- temp_file resource_id
    }
 
    cleanup_function() {
        local temp_file resource_id
-       eval "$state"
+       hs_read_persisted_state "$@" -- temp_file resource_id
        rm -f "$temp_file"
-       hs_destroy_state -S state -- temp_file resource_id
+       printf 'Cleaned up resource: %s\n' "$resource_id"
+       hs_destroy_state "$@" -- temp_file resource_id
    }
 
-After ``cleanup_function`` has removed its own variables from ``state``, a
-later call to ``init_function`` can reuse the same state variable without
-colliding with stale entries from the previous cycle.
+   local state=""
+   init_function -S state
+   cleanup_function -S state
+
+Public API
+----------
+
+hs_persist_state_as_code
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``hs_persist_state_as_code`` appends the current values of selected local
+variables to the opaque state object named by ``-S``.
+
+- Usage: ``hs_persist_state_as_code [forwarded args] -S <statevar> [--] var1 var2 ...``
+- Preferred usage: ``hs_persist_state_as_code "$@" -- var1 var2 ...``
+- State transport is by name only. Stdout is not part of this API.
+- If ``--`` is present, its last occurrence starts the explicit variable list.
+- Without ``--``, the trailing valid Bash identifiers are treated as the
+  variable list.
+- Unknown forwarded options before the effective separator are ignored by this
+  helper so wrappers can pass ``"$@"`` directly.
+
+Behavior:
+
+- Requested variables that are unset are skipped.
+- Unknown names and function names are ignored.
+- Indexed arrays currently persist only their first element.
+- Associative arrays are ignored.
+- Namerefs are persisted as scalar values.
+- If the destination state already contains persisted variables with the same
+  names, the function fails before writing anything.
+
+Errors:
+
+- ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``.
+- ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
+  requested variable name.
+- ``HS_ERR_RESERVED_VAR_NAME=1``: requested name collides with an internal
+  helper variable name.
+- ``HS_ERR_VAR_NAME_COLLISION=2``: one or more requested names already exist in
+  the prior state.
+- ``HS_ERR_CORRUPT_STATE=4``: the prior state could not be evaluated safely
+  during collision checking.
+
+hs_destroy_state
+~~~~~~~~~~~~~~~~
+
+``hs_destroy_state`` removes selected variable names from an existing opaque
+state object and writes the rebuilt state back to the same named variable.
+
+- Usage: ``hs_destroy_state [forwarded args] -S <statevar> [--] var1 var2 ...``
+- Preferred usage: ``hs_destroy_state "$@" -- var1 var2 ...``
+- If ``--`` is present, its last occurrence starts the explicit destroy list.
+- Without ``--``, the trailing valid Bash identifiers are treated as the
+  destroy list.
+
+Behavior:
+
+- Every requested destroy variable must already exist in the input state.
+- The output state is rebuilt from the surviving variables instead of editing
+  the original text in place.
+- After cleanup has destroyed a library's own entries, the same named state
+  variable can be reused by a later init call without tripping the collision
+  checks in ``hs_persist_state_as_code``.
+
+Errors:
+
+- ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``.
+- ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
+  requested destroy name.
+- ``HS_ERR_VAR_NAME_NOT_IN_STATE=6``: requested destroy name is not present in
+  the input state.
+- ``HS_ERR_CORRUPT_STATE=4``: the input state cannot be parsed or rebuilt
+  safely.
 
 hs_read_persisted_state
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-`hs_read_persisted_state` reads state from a named state variable. It supports
-two modes:
+``hs_read_persisted_state`` restores values from a named opaque state object.
 
-- Explicit restore: ``hs_read_persisted_state -S state -- foo bar``
-- Probe-snippet generation: ``eval "$(hs_read_persisted_state -S state)"``
+- Usage: ``hs_read_persisted_state [forwarded args] [-q] -S <statevar> [--] [var1 var2 ...]``
+- Convenience form: ``hs_read_persisted_state state ...`` is normalized to
+  ``-S state ...``.
+- Preferred usage: ``hs_read_persisted_state "$@" -- var1 var2 ...``
 
-Explicit restore is the preferred API. The caller names exactly which variables
-must be restored, and `hs_read_persisted_state` writes those values into the
-current caller scope.
+Explicit restore
+^^^^^^^^^^^^^^^^
 
-When no explicit variable list is given, `hs_read_persisted_state` does not
-return the raw persisted state snippet. Instead, it emits a locally generated
-probe snippet. When that snippet is `eval`'d, it checks the immediate caller
-scope for matching ``local`` variables that are currently empty, then reenters
-`hs_read_persisted_state` with that explicit list.
+When variable names are supplied, the function restores only those names into
+the current caller scope.
 
-This design is safer than `eval "$state"` because the caller executes only the
-local probe snippet, not the transmitted persisted state directly. Direct
-``eval`` of the raw state is discouraged outside early unit tests of the library.
+.. code-block:: bash
+
+   cleanup_function() {
+       local temp_file resource_id
+       hs_read_persisted_state "$@" -- temp_file resource_id
+   }
+
+Behavior:
+
+- Restoration is by name into already-declared locals in the caller scope.
+- Requested names missing from the state are warnings, one per variable.
+- ``-q`` suppresses those warnings.
+- The current implementation restores scalar string values only.
+
+Probe-snippet mode
+^^^^^^^^^^^^^^^^^^
+
+When no explicit variable names are supplied and no explicit ``--`` is present,
+``hs_read_persisted_state`` emits a small locally generated probe snippet. The
+caller may ``eval`` that snippet.
+
+The generated snippet:
+
+- scans ``local -p`` in the immediate caller scope,
+- keeps only unset scalar locals,
+- ignores locals whose names start with ``__hs_``,
+- reenters ``hs_read_persisted_state -q -S <statevar> -- ...``,
+- redirects that reentrant call's stdout to ``/dev/null``.
+
+This is safer than directly evaluating the opaque state object because the
+caller only evaluates the locally generated probe code.
 
 .. warning::
 
-   Without an explicit variable list, every empty ``local`` variable in the
-   immediate caller scope whose name also exists in the state may be restored
-   automatically. This may be unwanted if the caller manages several unrelated
-   state variables or reuses the same local names for different purposes.
-   Prefer explicit variable lists in non-trivial cleanup functions.
+   Without an explicit variable list, every unset scalar local in the immediate
+   caller scope may be considered for restoration. This can be the wrong
+   behavior if the caller manages several unrelated state variables or reuses
+   common local names. Prefer explicit variable lists in non-trivial cleanup
+   paths.
 
-Automatic probing only inspects the immediate caller scope. Locals declared in
-the caller's caller are not restored automatically, but they can still be
-restored if an intermediate function knows their name and names them explicitly.
+.. warning::
 
-The optional ``-q`` flag suppresses warnings for explicitly requested variables
-that are not present in the state. It is intended for explicit
-caller-supplied variable lists. When probing automatically, only variables 
-present in the state are probed.
+   Automatic probing only inspects the immediate caller scope. Locals in the
+   caller's caller are not restored automatically. They can still be restored
+   if an intermediate function names them explicitly.
 
-hs_get_pid_of_subshell
-~~~~~~~~~~~~~~~~~~~~~~
+If ``--`` is present and no variable names follow it, the function emits no
+probe snippet and returns success.
 
-Parses the `hs_cleanup_output` function definition to extract the background
-reader PID. This is used to detect whether logging setup has already occurred.
+Errors:
+
+- ``HS_ERR_MISSING_ARGUMENT=8``: no state variable name was supplied at all.
+- ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
+  requested restore name.
+- ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``, or the named
+  state variable is unset or empty.
+- ``HS_ERR_CORRUPT_STATE=4``: the state cannot be evaluated safely while
+  restoring explicitly requested variables.
+
+Helper API
+----------
+
+_hs_resolve_state_inputs
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``_hs_resolve_state_inputs`` is the shared option parser used by the public
+entry points.
+
+- It fills an indexed array of unprocessed forwarded arguments.
+- It fills an associative array of processed values:
+
+  - ``state``: validated state variable name from ``-S``
+  - ``quiet``: ``true`` or ``false``
+  - ``vars``: explicit variable-name list, serialized as a space-separated string
+  - ``separator``: present when an explicit ``--`` was seen
+
+Errors:
+
+- ``HS_ERR_MISSING_ARGUMENT=8``: required option parameter missing.
+- ``HS_ERR_INVALID_ARGUMENT_TYPE=9``: output containers passed by name are not
+  an indexed array and an associative array respectively.
+- ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
+  explicit variable-name token.
+- ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``.
 
 Error Codes
 -----------
 
-- `HS_ERR_RESERVED_VAR_NAME=1`: a reserved variable name was passed to
-  `hs_persist_state_as_code`.
-- `HS_ERR_VAR_NAME_COLLISION=2`: the requested variable was already defined in
-  the state string when persisting.
+- ``HS_ERR_RESERVED_VAR_NAME=1``
+- ``HS_ERR_VAR_NAME_COLLISION=2``
+- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``
+- ``HS_ERR_CORRUPT_STATE=4``
+- ``HS_ERR_INVALID_VAR_NAME=5``
+- ``HS_ERR_VAR_NAME_NOT_IN_STATE=6``
+- ``HS_ERR_STATE_VAR_UNINITIALIZED=7``
+- ``HS_ERR_MISSING_ARGUMENT=8``
+- ``HS_ERR_INVALID_ARGUMENT_TYPE=9``
 
-Behavior Details
-----------------
+Known Limitations
+-----------------
 
-Logging FIFO
-~~~~~~~~~~~~
+The tests currently demonstrate these limitations:
 
-When sourced, the library calls `hs_setup_output_to_stdout` automatically. It
-spawns a background reader that:
+- unknown variable names passed to ``hs_persist_state_as_code`` are ignored
+- function names passed to ``hs_persist_state_as_code`` are ignored
+- indexed arrays preserve only their first element
+- associative arrays are ignored
+- namerefs are restored as scalar values
 
-- reads lines from the FIFO with a timeout loop,
-- echoes them to stdout,
-- exits after a magic kill token or an idle timeout,
-- closes the FIFO descriptor before exiting.
+Examples
+--------
 
-State Persistence
-~~~~~~~~~~~~~~~~~
-
-`hs_persist_state_as_code` captures caller-local variables by name, embeds their values
-in a guarded assignment snippet, and prints that snippet. The guards ensure that
-only `local` variables are populated in the receiving scope and that non-empty
-locals are not overwritten.
-
-State Destruction
-~~~~~~~~~~~~~~~~~
-
-`hs_destroy_state` scans a persisted state snippet for the variable headers
-emitted by `hs_persist_state_as_code`, computes the survivor list, then rebuilds the
-state from those survivors. This keeps the removal logic centralized in
-`handle_state.sh` and gives libraries a way to reuse a shared state variable
-across several init/cleanup cycles.
-
-State Restoration
-~~~~~~~~~~~~~~~~~
-
-`hs_read_persisted_state` should usually be used in one of these forms:
-
-- ``hs_read_persisted_state -S state -- foo bar``
-- ``eval "$(hs_read_persisted_state -S state)"``
-
-The first form is preferred because it is explicit and does not require the
-caller to execute the transmitted state snippet. The second form exists for the
-common case where the caller simply wants all matching empty locals in its own
-scope restored.
-
-Supported Variables
--------------------
-
-`hs_persist_state_as_code` reliably preserves local scalar variables (strings or numbers)
-that are defined in the calling scope and re-declared as `local` in the receiving
-scope.
-
-Known Limitations (Tracked)
----------------------------
-
-The following behaviors are tracked in GitHub and should be considered when
-using this library:
-
-- Unknown variable names are silently ignored instead of erroring:
-  `Issue #1 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/1>`_.
-- Function names are silently ignored instead of erroring:
-  `Issue #2 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/2>`_.
-- Indexed arrays only preserve the first element (marked major):
-  `Issue #3 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/3>`_.
-- Associative arrays are silently ignored:
-  `Issue #4 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/4>`_.
-- Namerefs are persisted as scalars (indirection is lost):
-  `Issue #5 <https://github.com/CriticalOptimisation/bash-deploy-libs/issues/5>`_.
-
-Workarounds
------------
-
-- Associative arrays can be represented as two indexed arrays (keys and values).
-- Indexed arrays can be represented as a string with encoding.
-- Other complex constructs can sometimes be replaced by scalar strings or rebuilt
-  from scalars using custom logic.
+Persisting and restoring a scalar:
 
 .. code-block:: bash
-  # In the init function
-  local -a myarray=("value1" "value2" "value with spaces"
-  encoded=$(printf '%s\0' "${myarray[@]}" | base64 -w0)
-  hs_persist_state_as_code -S state encoded
-  # In the cleanup function
-  local state_var="$1"
-  local encoded
-  hs_read_persisted_state -S "$state_var" -- encoded
-  declare -a newarray
-  mapfile -d '' -t newarray < <(printf '%s' "$encoded" | base64 -d)
+
+   init_function() {
+       local token='a b "c" $d'
+       hs_persist_state_as_code "$@" -- token
+   }
+
+   cleanup_function() {
+       local token
+       hs_read_persisted_state "$@" -- token
+       printf '%s\n' "$token"
+   }
+
+Representing an array manually through a scalar encoding:
+
+.. code-block:: bash
+
+   init_function() {
+       local -a items=("value1" "value2" "value with spaces")
+       local encoded
+       encoded=$(printf '%s\0' "${items[@]}" | base64 -w0)
+       hs_persist_state_as_code "$@" -- encoded
+   }
+
+   cleanup_function() {
+       local encoded
+       local -a items
+       hs_read_persisted_state "$@" -- encoded
+       mapfile -d '' -t items < <(printf '%s' "$encoded" | base64 -d)
+   }
+
 Caveats
 -------
 
-- Prefer ``hs_read_persisted_state -S state -- var1 var2`` over direct ``eval``.
-- If you use ``eval "$(hs_read_persisted_state -S state)"``, declare target
-  variables ``local`` first and remember that only the immediate caller scope
-  is probed automatically.
-- Direct ``eval "$state"`` should be avoided in library code unless you are
-  deliberately handling the raw persisted snippet yourself.
-- The library uses `eval` internally; treat state strings as trusted input.
-- Call `hs_cleanup_output` when you are done to stop the background reader.
+- Prefer explicit restore lists over probe-snippet mode.
+- Do not rely on the opaque state format being executable code forever.
+- Early unit tests still use raw ``eval`` against the current code-based state
+  representation, but library code should prefer ``hs_read_persisted_state``.
+- The current implementation uses ``eval`` internally; state should therefore
+  be treated as trusted input.
 
 Source Listing
 --------------

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -14,30 +14,15 @@ setup_file() {
   export BATS_TEST_TMPDIR
   # shellcheck source=config/handle_state.sh
   # shellcheck disable=SC1091
-  source "$LIB"  # run hs_setup_output_to_stdout
-  hs_cleanup_output  # ensure clean state at start
-  export -f hs_setup_output_to_stdout hs_cleanup_output hs_get_pid_of_subshell\
-            _hs_is_valid_variable_name \
+  source "$LIB"
+  export -f _hs_is_valid_variable_name \
             _hs_resolve_state_inputs _hs_extract_persisted_state_var_names \
-            hs_persist_state_as_code hs_destroy_state hs_read_persisted_state hs_echo
+            hs_persist_state_as_code hs_destroy_state hs_read_persisted_state
   export HS_ERR_RESERVED_VAR_NAME HS_ERR_VAR_NAME_COLLISION HS_ERR_VAR_NAME_NOT_IN_STATE
   export HS_ERR_MULTIPLE_STATE_INPUTS HS_ERR_CORRUPT_STATE HS_ERR_INVALID_VAR_NAME \
          HS_ERR_STATE_VAR_UNINITIALIZED HS_ERR_MISSING_ARGUMENT
   # Accelerate test failure
   export BATS_TEST_TIMEOUT=30
-}
-# setup and teardown are skipped if the test has '[no-setup]' in its name.
-# This allows the capture of hs_echo output by bats.
-setup() {
-  if [[ "$BATS_TEST_NAME" != *"-5bno-2dsetup-5d"* ]]; then
-    # Most test depend on this setup, and output via hs_echo is not captured.
-    hs_setup_output_to_stdout
-  fi
-}
-teardown() {
-  if [[ "$BATS_TEST_NAME" != *"-5bno-2dsetup-5d"* ]]; then
-    hs_cleanup_output
-  fi
 }
 # Define a helper to create a fake simplified persisted state
 make_state() {
@@ -72,54 +57,6 @@ corrupt_state() {
   esac
 }
 export -f make_state corrupt_state # makes it available in bash --noprofile -lc calls
-
-# bats test_tags=hs_setup_output_to_stdout, hs_echo
-@test "hs_setup_output_to_stdout sets up output redirection [no-setup]" {
-  # shellcheck disable=SC2016
-  run -0 bash --noprofile -lc '
-  hs_setup_output_to_stdout;  # in "run" ensure bats captures output
-  init(){ hs_echo "bypasses stdout capture"; };
-  state=$(init);
-  hs_cleanup_output;
-  '
-  printf 'output=%s\n' "$output" >&2
-  [[ "$output" == *"bypasses stdout capture"* ]]
-}
-
-# bats test_tags=hs_setup_output_to_stdout
-@test "hs_setup_output_to_stdout is idempotent [no-setup]" {
-  # shellcheck disable=SC2016
-  run -0 --separate-stderr bash --noprofile -lc '
-    hs_setup_output_to_stdout
-    first_pid=$(hs_get_pid_of_subshell)
-    hs_setup_output_to_stdout #>>"$out_file"
-    second_pid=$(hs_get_pid_of_subshell)
-    if [ "$first_pid" != "$second_pid" ]; then
-      printf "pid changed %s -> %s" "$first_pid" "$second_pid"
-      exit 1
-    fi
-    hs_cleanup_output
-  '
-  [[ "$stderr" == *"hs_setup_output_to_stdout: already set up; skipping."* ]]
-  [ -z "$output" ]
-}
-
-# bats test_tags=hs_setup_output_to_stdout
-@test "hs_setup_output_to_stdout idempotent warning does not leak to stdout" {
-  export out_file="$BATS_TEST_TMPDIR/stdout"
-  : >"$out_file"
-  # shellcheck disable=SC2016
-  run -0 bash --noprofile -lc '
-    hs_setup_output_to_stdout >>"$out_file"
-  '
-  # $output contains only stderr
-  [[ "$output" == *"hs_setup_output_to_stdout: already set up; skipping."* ]]
-  # out_file should be empty
-  run cat "$out_file"
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
-  rm "$out_file"
-}
 
 # bats test_tags=hs_persist_state_as_code
 @test "eval without local should succeed and leave globals unchanged" {
@@ -162,7 +99,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc ' 
   init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state_as_code -S "$1" foo bar baz; }; 
-  cleanup(){ local state="$1"; local foo bar baz; eval "$(hs_read_persisted_state state)"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
+  cleanup(){ local state="$1"; local foo bar baz; eval "$(hs_read_persisted_state -S state)"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
   set -x
   state="";
   init state
@@ -192,7 +129,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     cleanup(){
       local state_var="$1"
       local foo="" bar="" baz=""
-      hs_read_persisted_state "$state_var" foo baz
+      hs_read_persisted_state -S "$state_var" foo baz
       printf "%s:%s:%s" "$foo" "${bar:-}" "$baz"
     }
     state=""
@@ -217,10 +154,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
       printf "%s" "$foo"
     }
     inner_auto(){
-      eval "$(hs_read_persisted_state state)"
+      eval "$(hs_read_persisted_state -S state)"
     }
     inner_explicit(){
-      hs_read_persisted_state state foo
+      hs_read_persisted_state -S state foo
     }
     state=""
     init state
@@ -238,7 +175,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     cleanup(){
       local state_var="$1"
       local foo="" bar=""
-      hs_read_persisted_state "$state_var" foo bar
+      hs_read_persisted_state -S "$state_var" foo bar
       printf "%s:%s" "$foo" "${bar:-}"
     }
     state=""
@@ -257,7 +194,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     cleanup(){
       local state_var="$1"
       local foo="" bar=""
-      hs_read_persisted_state -q "$state_var" foo bar
+      hs_read_persisted_state -q -S "$state_var" foo bar
       printf "%s:%s" "$foo" "${bar:-}"
     }
     state=""
@@ -282,7 +219,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_read_persisted_state rejects an invalid state variable name" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
-    hs_read_persisted_state "1invalid-var-name" >/dev/null
+    hs_read_persisted_state -S "1invalid-var-name" >/dev/null
   '
   [[ "$stderr" == *"invalid variable name '1invalid-var-name'"* ]]
   [ -z "$output" ]
@@ -293,7 +230,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # shellcheck disable=SC2016
   run -"$HS_ERR_STATE_VAR_UNINITIALIZED" --separate-stderr bash --noprofile -lc '
     state=""
-    hs_read_persisted_state state >/dev/null
+    hs_read_persisted_state -S state >/dev/null
   '
   [[ "$stderr" == *"state variable 'state' is not set or is empty"* ]]
   [ -z "$output" ]
@@ -405,7 +342,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
   init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }; 
-  cleanup(){ local foo=""; eval "$1"; printf "%s" "$foo"; hs_cleanup_output; }; 
+  cleanup(){ local foo=""; eval "$1"; printf "%s" "$foo"; }; 
   state="";
   init state;
   cleanup "$state"'
@@ -417,28 +354,12 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
   init(){ local foo='\''a b "c" $d'\''; hs_persist_state_as_code -S "$1" foo; }; 
-  cleanup(){ local foo; eval "$1"; printf "%s" "$foo"; hs_cleanup_output; }; 
+  cleanup(){ local foo; eval "$1"; printf "%s" "$foo"; }; 
   state="";
   init state;
   cleanup "$state"'
   [ "$output" = "a b \"c\" \$d" ]
 }
-
-# This test uses kill -0 to check if a PID exists
-# bats test_tags=hs_get_pid_of_subshell
-@test "hs_get_pid_of_subshell returns a valid PID" {
-  # shellcheck disable=SC2016
-  run -0 bash --noprofile -lc '
-    pid=$(hs_get_pid_of_subshell)
-    if ! kill -0 "$pid" 2>/dev/null; then
-      printf "No such PID %s" "$pid"
-      exit 1
-    fi
-    hs_cleanup_output
-    printf "%s" "$pid"
-  '
-  [[ "$output" =~ ^[0-9]+$ ]]
-} 
 
 # bats test_tags=hs_persist_state_as_code
 @test "hs_persist_state_as_code with -S detects an invalid variable name" {
@@ -448,6 +369,27 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   '
   [[ "$stderr" == *"invalid variable name '1invalid-var-name' for -S option"* ]]
   [ -z "$output" ]
+}
+
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code ignores forwarded args before final --" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init() {
+      local foo=two
+      hs_persist_state_as_code bad -S "$1" -- foo
+    }
+    cleanup() {
+      local foo=""
+      eval "$state"
+      printf "%s" "$foo"
+    }
+    state=""
+    init state
+    cleanup
+  '
+  [ "$output" = "two" ]
+  [ -z "$stderr" ]
 }
 
 # bats test_tags=hs_persist_state_as_code
@@ -578,7 +520,6 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
     source "$LIB" 2>/dev/null
-    hs_cleanup_output
     init() {
       local foo=one bar=two
       hs_persist_state_as_code -S "$1" foo bar
@@ -602,7 +543,6 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # shellcheck disable=SC2016
   run -"$HS_ERR_STATE_VAR_UNINITIALIZED" --separate-stderr bash --noprofile -lc '
     source "$LIB" 2>/dev/null
-    hs_cleanup_output
     hs_destroy_state foo bar >/dev/null
   '
   [[ "$stderr" == *"missing required -S <statevar> option"* ]]
@@ -614,7 +554,6 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # shellcheck disable=SC2016
   run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
     source "$LIB" 2>/dev/null
-    hs_cleanup_output
     state="if local -p foo >/dev/null 2>&1; then
   foo=one
 fi"
@@ -625,11 +564,33 @@ fi"
 }
 
 # bats test_tags=hs_destroy_state
+@test "hs_destroy_state ignores forwarded args before final --" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    source "$LIB" 2>/dev/null
+    init() {
+      local foo=one bar=two
+      hs_persist_state_as_code -S "$1" foo bar
+    }
+    cleanup() {
+      local foo="" bar=""
+      eval "$state"
+      printf "%s:%s" "${foo:-}" "${bar:-}"
+    }
+    state=""
+    init state
+    hs_destroy_state bad -S state -- foo
+    cleanup
+  '
+  [ "$output" = ":two" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_destroy_state
 @test "hs_destroy_state fails when asked to remove a variable not present in the state" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_VAR_NAME_NOT_IN_STATE" --separate-stderr bash --noprofile -lc '
     source "$LIB" 2>/dev/null
-    hs_cleanup_output
     init() {
       local foo=one
       hs_persist_state_as_code -S "$1" foo
@@ -647,7 +608,6 @@ fi"
   # shellcheck disable=SC2016
   run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
     source "$LIB" 2>/dev/null
-    hs_cleanup_output
     local state
     state="$(corrupt_state error)"
     hs_destroy_state -S state foo >/dev/null

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -375,7 +375,8 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     printf "%s" "$(hs_read_persisted_state -S state)"
   '
   [[ "$output" == *'hs_read_persisted_state -q -S state'* ]]
-  [[ "$output" == *'done < <(local -p)'* ]]
+  [[ "$output" == *'local -p | while IFS= read -r __hs_local_decl; do'* ]]
+  [[ "$output" == *') >/dev/null'* ]]
   [ -z "$stderr" ]
 }
 
@@ -395,6 +396,19 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     cleanup state
   '
   [ "$output" = "secret::new" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state with explicit -- and no variable names emits no probe snippet" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }
+    state=""
+    init state
+    hs_read_persisted_state -S state --
+  '
+  [ -z "$output" ]
   [ -z "$stderr" ]
 }
 

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-# Bats tests for hs_persist_state
-# Run with: bats test/test-hs_persist_state.bats
+# Bats tests for hs_persist_state_as_code
+# Run with: bats test/test-hs_persist_state_as_code.bats
 
 setup_file() {
   bats_require_minimum_version 1.5.0
@@ -17,11 +17,11 @@ setup_file() {
   source "$LIB"  # run hs_setup_output_to_stdout
   hs_cleanup_output  # ensure clean state at start
   export -f hs_setup_output_to_stdout hs_cleanup_output hs_get_pid_of_subshell\
-            _hs_resolve_state_inputs hs_persist_state hs_destroy_state hs_read_persisted_state hs_echo
+            _hs_resolve_state_inputs hs_persist_state_as_code hs_destroy_state hs_read_persisted_state hs_echo
   export HS_ERR_RESERVED_VAR_NAME HS_ERR_VAR_NAME_COLLISION HS_ERR_VAR_NAME_NOT_IN_STATE
   export HS_ERR_MULTIPLE_STATE_INPUTS HS_ERR_CORRUPT_STATE HS_ERR_INVALID_VAR_NAME
   # Accelerate test failure
-  export BATS_TEST_TIMEOUT=2
+  export BATS_TEST_TIMEOUT=30
 }
 # setup and teardown are skipped if the test has '[no-setup]' in its name.
 # This allows the capture of hs_echo output by bats.
@@ -118,11 +118,11 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   rm "$out_file"
 }
 
-# bats test_tags=hs_persist_state
+# bats test_tags=hs_persist_state_as_code
 @test "eval without local should succeed and leave globals unchanged" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init() { local bar=v2; local baz=new; hs_persist_state bar baz; }; 
+  init() { local bar=v2; local baz=new; hs_persist_state_as_code bar baz; }; 
   state=$(init); 
   baz=old; 
   eval "$state"; 
@@ -132,18 +132,18 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # ensure globals were not created or overwritten
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local bar=v2; local baz=new; hs_persist_state bar baz; }; 
+  init(){ local bar=v2; local baz=new; hs_persist_state_as_code bar baz; }; 
   state=$(init); 
   baz=old; 
   eval "$state" 2>/dev/null || true; 
   [ -z "${bar+set}" ] && [ "${baz}" = "old" ]'
 }
 
-# bats test_tags=hs_persist_state
+# bats test_tags=hs_persist_state_as_code
 @test "cleanup declares local and eval restores values onto new locals" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state foo bar baz; };
+  init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state_as_code foo bar baz; };
   cleanup(){ local foo bar baz; eval "$1"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
   state=$(init); 
   cleanup "$state";
@@ -152,10 +152,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 }
 
 # bats test_tags=hs_read_persisted_state
-@test "eval \$(hs_read_persisted_state ...) in caller scope restores values" {
+@test "eval the output of (hs_read_persisted_state ...) in caller scope restores values" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc ' 
-  init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state foo bar baz; }; 
+  init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state_as_code foo bar baz; }; 
   cleanup(){ local state="$1"; local foo bar baz; eval "$(hs_read_persisted_state state)"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
   set -x
   state=$(init) 
@@ -163,33 +163,33 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ "$output" = "secret:v2:new" ]
 }
 
-# bats test_tags=hs_persist_state
+# bats test_tags=hs_persist_state_as_code
 @test "overwriting a local already set in cleanup should fail with explicit message" {
   # shellcheck disable=SC2016
   run -1 bash --noprofile -lc '
-  init(){ local foo=secret; hs_persist_state foo; };
+  init(){ local foo=secret; hs_persist_state_as_code foo; };
   cleanup(){ local foo=already; eval "$1"; }; 
   state=$(init); 
   cleanup "$state"'
   [[ "$output" == *"local foo already defined; refusing to overwrite"* ]]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state does not include variables that were not set in init" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code does not include variables that were not set in init" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo=one; hs_persist_state foo bar; };
+  init(){ local foo=one; hs_persist_state_as_code foo bar; };
   cleanup(){ local foo bar; eval "$1"; printf "%s:%s" "$foo" "${bar:-}"; };  
   state=$(init); 
   cleanup "$state"'
   [ "$output" = "one:" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state ignores unknown variable names" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code ignores unknown variable names" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
-  init(){ hs_persist_state not_a_var; };
+  init(){ hs_persist_state_as_code not_a_var; };
   state=$(init);
   printf "%s" "$state"
   '
@@ -197,11 +197,11 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$stderr" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state ignores function names" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code ignores function names" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
-  init(){ my_func(){ echo "nope"; }; hs_persist_state my_func; };
+  init(){ my_func(){ echo "nope"; }; hs_persist_state_as_code my_func; };
   state=$(init);
   printf "%s" "$state"
   '
@@ -209,11 +209,11 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$stderr" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state only captures the first element of an indexed array" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code only captures the first element of an indexed array" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local -a items=(one two); hs_persist_state items; };
+  init(){ local -a items=(one two); hs_persist_state_as_code items; };
   cleanup(){ local -a items; eval "$1"; printf "%s:%s" "${items[0]-}" "${items[1]-}"; };
   state=$(init);
   cleanup "$state"
@@ -221,11 +221,11 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ "$output" = "one:" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state ignores associative arrays" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code ignores associative arrays" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
-  init(){ local -A amap=([key]=value); hs_persist_state amap; };
+  init(){ local -A amap=([key]=value); hs_persist_state_as_code amap; };
   state=$(init);
   printf "%s" "$state"
   '
@@ -233,11 +233,11 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$stderr" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state treats namerefs as scalar values" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code treats namerefs as scalar values" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local target=secret; local -n ref=target; hs_persist_state ref; };
+  init(){ local target=secret; local -n ref=target; hs_persist_state_as_code ref; };
   cleanup(){ local target=""; local -n ref=target; eval "$1"; printf "%s:%s" "$target" "$ref"; };
   state=$(init);
   cleanup "$state"
@@ -245,40 +245,40 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ "$output" = "secret:secret" ]
 }
 
-# bats test_tags=hs_persist_state
+# bats test_tags=hs_persist_state_as_code
 @test "restore empty value" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo=""; hs_persist_state foo; };
+  init(){ local foo=""; hs_persist_state_as_code foo; };
   cleanup(){ local foo; eval "$1"; printf "%s" "$foo"; };  
   state=$(init); 
   cleanup "$state"'
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
+# bats test_tags=hs_persist_state_as_code
 @test "overwrite empty local variable with persisted value" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo=secret; hs_persist_state foo; }; 
+  init(){ local foo=secret; hs_persist_state_as_code foo; }; 
   cleanup(){ local foo=""; eval "$1"; printf "%s" "$foo"; hs_cleanup_output; }; 
   state=$(init); 
   cleanup "$state"'
   [ "$output" = "secret" ]
 }
 
-# bats test_tags=hs_persist_state
+# bats test_tags=hs_persist_state_as_code
 @test "preserve special characters in persisted values" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo='\''a b "c" $d'\''; hs_persist_state foo; }; 
+  init(){ local foo='\''a b "c" $d'\''; hs_persist_state_as_code foo; }; 
   cleanup(){ local foo; eval "$1"; printf "%s" "$foo"; hs_cleanup_output; }; 
   state=$(init); 
   cleanup "$state"'
   [ "$output" = "a b \"c\" \$d" ]
 }
 
-# bats test_tags=hs_setup_output_to_stdout, hs_persist_state
+# bats test_tags=hs_setup_output_to_stdout, hs_persist_state_as_code
 @test "hs_setup_output_to_stdout keeps logs separate from persisted state [no-setup]" {
   # hs_echo logs to stdout, captured by bats, even though it is explicitly captured by $state.
   # shellcheck disable=SC2016
@@ -287,7 +287,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     init() {
       local foo="secret"
       hs_echo "LOG foo is $foo"
-      hs_persist_state foo
+      hs_persist_state_as_code foo
     }
     state=$(init)
     printf "%s\n" "$state" >&2  # send persisted state to stderr
@@ -313,13 +313,13 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [[ "$output" =~ ^[0-9]+$ ]]
 } 
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state with -s appends to existing state" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code with -s appends to existing state" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
     init() {
       local bar=two
-      hs_persist_state -s "$1" bar
+      hs_persist_state_as_code -s "$1" bar
     }
     cleanup(){ 
       local foo bar 
@@ -334,13 +334,13 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$stderr" ]
 } 
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state with -s fails on variable name collision" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code with -s fails on variable name collision" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_VAR_NAME_COLLISION" --separate-stderr bash --noprofile -lc '
     init() {
       local foo=two
-      hs_persist_state -s "$1" foo  # Fails: foo already in state
+      hs_persist_state_as_code -s "$1" foo  # Fails: foo already in state
     }
     state1=$(make_state foo one)
     init "$state1" >/dev/null  # Invalid output must be ignored
@@ -350,23 +350,23 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state with -S detects an invalid variable name" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code with -S detects an invalid variable name" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -xlc '
-    hs_persist_state -S "1invalid-var-name"
+    hs_persist_state_as_code -S "1invalid-var-name"
   '
   [[ "$stderr" == *"invalid variable name '1invalid-var-name' for -S option"* ]]
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state,focus
-@test "hs_persist_state fails on reserved variable name __var_name" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code fails on reserved variable name __var_name" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_RESERVED_VAR_NAME" --separate-stderr bash --noprofile -xlc '
     init() {
       local __var_name=bad
-      hs_persist_state __var_name
+      hs_persist_state_as_code __var_name
     }
     init
   '
@@ -374,13 +374,13 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state fails on reserved variable name __existing_state" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code fails on reserved variable name __existing_state" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_RESERVED_VAR_NAME" --separate-stderr bash --noprofile -lc '
     init() {
       local __existing_state=bad
-      hs_persist_state __existing_state
+      hs_persist_state_as_code __existing_state
     }
     init
   '
@@ -388,13 +388,13 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state fails on reserved variable name __output_state_var" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code fails on reserved variable name __output_state_var" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_RESERVED_VAR_NAME" --separate-stderr bash --noprofile -lc '
     init() {
       local __output_state_var=bad
-      hs_persist_state __output_state_var
+      hs_persist_state_as_code __output_state_var
     }
     init
   '
@@ -402,13 +402,13 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state fails on reserved variable name __output" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code fails on reserved variable name __output" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_RESERVED_VAR_NAME" --separate-stderr bash --noprofile -lc '
     init() {
       local __output=bad
-      hs_persist_state __output
+      hs_persist_state_as_code __output
     }
     init
   '
@@ -416,13 +416,13 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state with -S var_name assigns to variable" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code with -S var_name assigns to variable" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     init() {
       local bar=two
-      hs_persist_state -S state bar
+      hs_persist_state_as_code -S state bar
     }
     cleanup(){ 
       local bar 
@@ -435,14 +435,14 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ "$output" = "two" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state detects corrupt state: infinite loop" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code detects corrupt state: infinite loop" {
   # The infinite loop is simulated by a 3 seconds sleep.
   # shellcheck disable=SC2016
   run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
     init() {
       local foo=two
-      hs_persist_state -s "$(corrupt_state slow)" foo
+      hs_persist_state_as_code -s "$(corrupt_state slow)" foo
     }
     init
   '
@@ -450,13 +450,13 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state detects corrupt state: error on eval" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code detects corrupt state: error on eval" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
     init() {
       local foo=two
-      hs_persist_state -s "$(corrupt_state error)" foo
+      hs_persist_state_as_code -s "$(corrupt_state error)" foo
     }
     init
   '
@@ -464,13 +464,13 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state detects corrupt state var: error on eval" {
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code detects corrupt state var: error on eval" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
     init() {
       local foo=two
-      hs_persist_state "$@" foo
+      hs_persist_state_as_code "$@" foo
     }
     state_var="$(corrupt_state error)"
     init -S state_var
@@ -479,15 +479,15 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state
-@test "hs_persist_state -s works when called via bats run on a shell function" {
-  # Regression test for issue #59: hs_persist_state used $0 to re-invoke the
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code -s works when called via bats run on a shell function" {
+  # Regression test for issue #59: hs_persist_state_as_code used $0 to re-invoke the
   # shell for collision checking, but $0 is the Bats runner (not bash) when a
   # function is invoked via 'bats run'.  The fix uses ${BASH:-bash} instead.
   # Also verifies that the collision-check subshell does not leak 'a' globally.
   state_accumulates() {
     local incoming_state="local a=kept"
-    hs_persist_state -s "$incoming_state" b >/dev/null
+    hs_persist_state_as_code -s "$incoming_state" b >/dev/null
   }
   run -0 --separate-stderr state_accumulates
   [ -z "$stderr" ]
@@ -503,7 +503,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     hs_cleanup_output
     init() {
       local foo=one bar=two baz=three
-      hs_persist_state foo bar baz
+      hs_persist_state_as_code foo bar baz
     }
     cleanup() {
       local foo="" bar="" baz=""
@@ -526,7 +526,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     hs_cleanup_output
     init() {
       local foo=one bar=two
-      hs_persist_state -S state foo bar
+      hs_persist_state_as_code -S state foo bar
     }
     cleanup() {
       local foo="" bar=""
@@ -562,7 +562,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     hs_cleanup_output
     init() {
       local foo=one
-      hs_persist_state foo
+      hs_persist_state_as_code foo
     }
     state=$(init)
     hs_destroy_state -s "$state" missing >/dev/null

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -15,7 +15,7 @@ setup_file() {
   # shellcheck source=config/handle_state.sh
   # shellcheck disable=SC1091
   source "$LIB"
-  export -f _hs_is_valid_variable_name \
+  export -f _hs_is_valid_variable_name _hs_is_array \
             _hs_resolve_state_inputs _hs_extract_persisted_state_var_names \
             hs_persist_state_as_code hs_destroy_state hs_read_persisted_state
   export HS_ERR_RESERVED_VAR_NAME HS_ERR_VAR_NAME_COLLISION HS_ERR_VAR_NAME_NOT_IN_STATE
@@ -57,6 +57,236 @@ corrupt_state() {
   esac
 }
 export -f make_state corrupt_state # makes it available in bash --noprofile -lc calls
+
+# bats test_tags=hs_is_array
+@test "_hs_is_array matches indexed and associative array attributes" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a indexed=(one two)
+      local -A assoc=([key]=value)
+      _hs_is_array indexed &&
+      _hs_is_array -A assoc &&
+      ! _hs_is_array assoc &&
+      ! _hs_is_array -A indexed
+    }
+    f
+  '
+  [ -z "$output" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_is_array
+@test "_hs_is_array recognizes declared but uninitialized arrays" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a indexed
+      local -A assoc
+      _hs_is_array indexed &&
+      _hs_is_array -A assoc &&
+      ! _hs_is_array -A indexed &&
+      ! _hs_is_array assoc
+    }
+    f
+  '
+  [ -z "$output" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_is_array
+@test "_hs_is_array rejects integers and strings" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -i number=42
+      local text="hello"
+      ! _hs_is_array number &&
+      ! _hs_is_array -A number &&
+      ! _hs_is_array text &&
+      ! _hs_is_array -A text
+    }
+    f
+  '
+  [ -z "$output" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_is_array
+@test "_hs_is_array works through namerefs for array targets" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a indexed=(one two)
+      local -A assoc=([key]=value)
+      local -n indexed_ref=indexed
+      local -n assoc_ref=assoc
+      _hs_is_array indexed_ref &&
+      _hs_is_array -A assoc_ref &&
+      ! _hs_is_array assoc_ref &&
+      ! _hs_is_array -A indexed_ref
+    }
+    f
+  '
+  [ -z "$output" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_is_array
+@test "_hs_is_array rejects scalar namerefs" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local text="hello"
+      local -i number=42
+      local -n text_ref=text
+      local -n number_ref=number
+      ! _hs_is_array text_ref &&
+      ! _hs_is_array -A text_ref &&
+      ! _hs_is_array number_ref &&
+      ! _hs_is_array -A number_ref
+    }
+    f
+  '
+  [ -z "$output" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs parses known options and preserves remaining arguments" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=([old]=x)
+      _hs_resolve_state_inputs my_helper remaining_args qS: processed_args bad -q -S state -- foo bar
+      printf "%s|%s|%s" "${processed_args[state]}" "${processed_args[quiet]}" "${remaining_args[*]}"
+    }
+    f
+  '
+  [ "$output" = "state|true|bad" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs extracts trailing variable names into processed vars" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args qS: processed_args bad -q -S state -- foo bar
+      printf "%s|%s|%s|%s" "${processed_args[state]}" "${processed_args[quiet]}" "${remaining_args[*]}" "${processed_args[vars]}"
+    }
+    f
+  '
+  [ "$output" = "state|true|bad|bar foo " ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs rejects a missing -S option" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_STATE_VAR_UNINITIALIZED" --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args qS: processed_args -q foo
+    }
+    f
+  '
+  [[ "$stderr" == *"missing required -S <statevar> option"* ]]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs rejects an invalid -S variable name" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args qS: processed_args -S 1invalid foo
+    }
+    f
+  '
+  [[ "$stderr" == *"invalid variable name '1invalid'"* ]]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs rejects -S without a parameter" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_MISSING_ARGUMENT" --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args qS: processed_args bad -S
+    }
+    f
+  '
+  [[ "$stderr" == *"missing required parameter to option -S"* ]]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs preserves an unknown short option without parameter" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args S: processed_args -a -S state foo
+      printf "%s|%s|%s" "${processed_args[state]}" "${remaining_args[*]}" "${processed_args[vars]}"
+    }
+    f
+  '
+  [ "$output" = "state|-a|foo " ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs preserves an unknown short option and its parameter" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args S: processed_args -b toto -S state foo
+      printf "%s|%s|%s" "${processed_args[state]}" "${remaining_args[*]}" "${processed_args[vars]}"
+    }
+    f
+  '
+  [ "$output" = "state|-b|toto foo " ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs extracts vars after unknown forwarded options" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args S: processed_args -b toto -S state foo bar
+      printf "%s|%s|%s" "${processed_args[state]}" "${remaining_args[*]}" "${processed_args[vars]}"
+    }
+    f
+  '
+  [ "$output" = "state|-b|toto foo bar " ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs rejects invalid bare words left outside the vars list" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args S: processed_args -S state 1invalid foo
+    }
+    f
+  '
+  [[ "$stderr" == *"invalid variable name '1invalid'"* ]]
+}
 
 # bats test_tags=hs_persist_state_as_code
 @test "eval without local should succeed and leave globals unchanged" {
@@ -195,6 +425,25 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
       local state_var="$1"
       local foo="" bar=""
       hs_read_persisted_state -q -S "$state_var" foo bar
+      printf "%s:%s" "$foo" "${bar:-}"
+    }
+    state=""
+    init state
+    cleanup state
+  '
+  [ "$output" = "secret:" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state accepts -q after -S state" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }
+    cleanup(){
+      local state_var="$1"
+      local foo="" bar=""
+      hs_read_persisted_state -S "$state_var" -q foo bar
       printf "%s:%s" "$foo" "${bar:-}"
     }
     state=""
@@ -367,7 +616,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -xlc '
     hs_persist_state_as_code -S "1invalid-var-name"
   '
-  [[ "$stderr" == *"invalid variable name '1invalid-var-name' for -S option"* ]]
+  [[ "$stderr" == *"invalid variable name '1invalid-var-name'"* ]]
   [ -z "$output" ]
 }
 
@@ -519,7 +768,6 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_destroy_state with -S rewrites the named variable in place" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
-    source "$LIB" 2>/dev/null
     init() {
       local foo=one bar=two
       hs_persist_state_as_code -S "$1" foo bar
@@ -542,7 +790,6 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_destroy_state requires -S" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_STATE_VAR_UNINITIALIZED" --separate-stderr bash --noprofile -lc '
-    source "$LIB" 2>/dev/null
     hs_destroy_state foo bar >/dev/null
   '
   [[ "$stderr" == *"missing required -S <statevar> option"* ]]
@@ -553,7 +800,6 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_destroy_state rejects invalid destroy variable names" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
-    source "$LIB" 2>/dev/null
     state="if local -p foo >/dev/null 2>&1; then
   foo=one
 fi"
@@ -567,7 +813,6 @@ fi"
 @test "hs_destroy_state ignores forwarded args before final --" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
-    source "$LIB" 2>/dev/null
     init() {
       local foo=one bar=two
       hs_persist_state_as_code -S "$1" foo bar
@@ -590,7 +835,6 @@ fi"
 @test "hs_destroy_state fails when asked to remove a variable not present in the state" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_VAR_NAME_NOT_IN_STATE" --separate-stderr bash --noprofile -lc '
-    source "$LIB" 2>/dev/null
     init() {
       local foo=one
       hs_persist_state_as_code -S "$1" foo
@@ -607,7 +851,6 @@ fi"
 @test "hs_destroy_state detects corrupt prior state" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
-    source "$LIB" 2>/dev/null
     local state
     state="$(corrupt_state error)"
     hs_destroy_state -S state foo >/dev/null

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -591,8 +591,8 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ "$output" = "one:" ]
 }
 
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code ignores unknown variable names" {
+# bats test_tags=hs_persist_state_as_code,known_issue
+@test "known issue nr.1: hs_persist_state_as_code silently ignores unknown variable names" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
   state="";
@@ -604,8 +604,8 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$stderr" ]
 }
 
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code ignores function names" {
+# bats test_tags=hs_persist_state_as_code,known_issue
+@test "known issue nr.2: hs_persist_state_as_code silently ignores function names" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
   state="";
@@ -617,8 +617,8 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$stderr" ]
 }
 
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code only captures the first element of an indexed array" {
+# bats test_tags=hs_persist_state_as_code,known_issue
+@test "known issue nr.3: hs_persist_state_as_code only captures the first element of an indexed array" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
   init(){ local -a items=(one two); hs_persist_state_as_code -S "$1" items; };
@@ -630,8 +630,8 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ "$output" = "one:" ]
 }
 
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code ignores associative arrays" {
+# bats test_tags=hs_persist_state_as_code,known_issue
+@test "known issue nr.4: hs_persist_state_as_code silently ignores associative arrays" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
   state="";
@@ -643,8 +643,8 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$stderr" ]
 }
 
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code treats namerefs as scalar values" {
+# bats test_tags=hs_persist_state_as_code,known_issue
+@test "known issue nr.5: hs_persist_state_as_code persists namerefs as scalar values" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
   init(){ local target=secret; local -n ref=target; hs_persist_state_as_code -S "$1" ref; };

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -17,8 +17,8 @@ setup_file() {
   source "$LIB"  # run hs_setup_output_to_stdout
   hs_cleanup_output  # ensure clean state at start
   export -f hs_setup_output_to_stdout hs_cleanup_output hs_get_pid_of_subshell\
-            hs_persist_state hs_read_persisted_state hs_echo
-  export HS_ERR_RESERVED_VAR_NAME HS_ERR_VAR_NAME_COLLISION 
+            _hs_resolve_state_inputs hs_persist_state hs_destroy_state hs_read_persisted_state hs_echo
+  export HS_ERR_RESERVED_VAR_NAME HS_ERR_VAR_NAME_COLLISION HS_ERR_VAR_NAME_NOT_IN_STATE
   export HS_ERR_MULTIPLE_STATE_INPUTS HS_ERR_CORRUPT_STATE HS_ERR_INVALID_VAR_NAME
   # Accelerate test failure
   export BATS_TEST_TIMEOUT=2
@@ -156,7 +156,7 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc ' 
   init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state foo bar baz; }; 
-  cleanup(){ local foo bar baz; eval "$(hs_read_persisted_state "$1")"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
+  cleanup(){ local state="$1"; local foo bar baz; eval "$(hs_read_persisted_state state)"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
   set -x
   state=$(init) 
   cleanup "$state"'
@@ -493,4 +493,92 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$stderr" ]
   # a must not have leaked into the current scope from the collision-check subshell
   [ -z "${a+set}" ]
+}
+
+# bats test_tags=hs_destroy_state
+@test "hs_destroy_state with -s removes the listed variables and prints the rebuilt state" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    source "$LIB" 2>/dev/null
+    hs_cleanup_output
+    init() {
+      local foo=one bar=two baz=three
+      hs_persist_state foo bar baz
+    }
+    cleanup() {
+      local foo="" bar="" baz=""
+      eval "$1"
+      printf "%s:%s:%s" "${foo:-}" "${bar:-}" "${baz:-}"
+    }
+    state=$(init)
+    stripped=$(hs_destroy_state -s "$state" foo baz)
+    cleanup "$stripped"
+  '
+  [[ "$output" == *":two:"* ]]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_destroy_state
+@test "hs_destroy_state with -S rewrites the named variable in place" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    source "$LIB" 2>/dev/null
+    hs_cleanup_output
+    init() {
+      local foo=one bar=two
+      hs_persist_state -S state foo bar
+    }
+    cleanup() {
+      local foo="" bar=""
+      eval "$state"
+      printf "%s:%s" "${foo:-}" "${bar:-}"
+    }
+    init
+    hs_destroy_state -S state foo
+    cleanup
+  '
+  [[ "$output" == *":two"* ]]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_destroy_state
+@test "hs_destroy_state rejects invalid destroy variable names" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
+    source "$LIB" 2>/dev/null
+    hs_cleanup_output
+    state=$(make_state foo one)
+    hs_destroy_state -s "$state" "1invalid-var-name" >/dev/null
+  '
+  [[ "$stderr" == *"invalid variable name '1invalid-var-name'"* ]]
+  [ -z "$output" ]
+}
+
+# bats test_tags=hs_destroy_state
+@test "hs_destroy_state fails when asked to remove a variable not present in the state" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_VAR_NAME_NOT_IN_STATE" --separate-stderr bash --noprofile -lc '
+    source "$LIB" 2>/dev/null
+    hs_cleanup_output
+    init() {
+      local foo=one
+      hs_persist_state foo
+    }
+    state=$(init)
+    hs_destroy_state -s "$state" missing >/dev/null
+  '
+  [[ "$stderr" == *"variable 'missing' is not defined in the state"* ]]
+  [ -z "$output" ]
+}
+
+# bats test_tags=hs_destroy_state
+@test "hs_destroy_state detects corrupt prior state" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
+    source "$LIB" 2>/dev/null
+    hs_cleanup_output
+    hs_destroy_state -s "$(corrupt_state error)" foo >/dev/null
+  '
+  [[ "$stderr" == *"prior state is corrupted"* ]]
+  [ -z "$output" ]
 }

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -17,9 +17,12 @@ setup_file() {
   source "$LIB"  # run hs_setup_output_to_stdout
   hs_cleanup_output  # ensure clean state at start
   export -f hs_setup_output_to_stdout hs_cleanup_output hs_get_pid_of_subshell\
-            _hs_resolve_state_inputs hs_persist_state_as_code hs_destroy_state hs_read_persisted_state hs_echo
+            _hs_is_valid_variable_name \
+            _hs_resolve_state_inputs _hs_extract_persisted_state_var_names \
+            hs_persist_state_as_code hs_destroy_state hs_read_persisted_state hs_echo
   export HS_ERR_RESERVED_VAR_NAME HS_ERR_VAR_NAME_COLLISION HS_ERR_VAR_NAME_NOT_IN_STATE
-  export HS_ERR_MULTIPLE_STATE_INPUTS HS_ERR_CORRUPT_STATE HS_ERR_INVALID_VAR_NAME
+  export HS_ERR_MULTIPLE_STATE_INPUTS HS_ERR_CORRUPT_STATE HS_ERR_INVALID_VAR_NAME \
+         HS_ERR_STATE_VAR_UNINITIALIZED HS_ERR_MISSING_ARGUMENT
   # Accelerate test failure
   export BATS_TEST_TIMEOUT=30
 }
@@ -122,8 +125,9 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "eval without local should succeed and leave globals unchanged" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init() { local bar=v2; local baz=new; hs_persist_state_as_code bar baz; }; 
-  state=$(init); 
+  init() { local bar=v2; local baz=new; hs_persist_state_as_code -S "$1" bar baz; }; 
+  state="";
+  init state;
   baz=old; 
   eval "$state"; 
   printf "%s:%s" "$bar" "$baz";'
@@ -132,8 +136,9 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   # ensure globals were not created or overwritten
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local bar=v2; local baz=new; hs_persist_state_as_code bar baz; }; 
-  state=$(init); 
+  init(){ local bar=v2; local baz=new; hs_persist_state_as_code -S "$1" bar baz; };
+  state="";
+  init state;
   baz=old; 
   eval "$state" 2>/dev/null || true; 
   [ -z "${bar+set}" ] && [ "${baz}" = "old" ]'
@@ -143,10 +148,11 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "cleanup declares local and eval restores values onto new locals" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state_as_code foo bar baz; };
-  cleanup(){ local foo bar baz; eval "$1"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
-  state=$(init); 
-  cleanup "$state";
+  init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state_as_code -S "$1" foo bar baz; };
+  cleanup(){ local -n state_ref="$1"; local foo bar baz; eval "$state_ref"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
+  state="";
+  init state;
+  cleanup state;
   '
   [ "$output" = "secret:v2:new" ]
 }
@@ -155,21 +161,152 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "eval the output of (hs_read_persisted_state ...) in caller scope restores values" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc ' 
-  init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state_as_code foo bar baz; }; 
+  init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state_as_code -S "$1" foo bar baz; }; 
   cleanup(){ local state="$1"; local foo bar baz; eval "$(hs_read_persisted_state state)"; printf "%s:%s:%s" "$foo" "$bar" "$baz"; }; 
   set -x
-  state=$(init) 
+  state="";
+  init state
   cleanup "$state"'
   [ "$output" = "secret:v2:new" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state accepts explicit -S state" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }
+    state=""
+    init state
+    printf "%s" "$(hs_read_persisted_state -S state)"
+  '
+  [[ "$output" == *'hs_read_persisted_state -S state'* ]]
+  [[ "$output" == *'if local -p foo >/dev/null 2>&1'* ]]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state restores only requested variables" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init(){ local foo=secret; local bar=v2; local baz=new; hs_persist_state_as_code -S "$1" foo bar baz; }
+    cleanup(){
+      local state_var="$1"
+      local foo="" bar="" baz=""
+      hs_read_persisted_state "$state_var" foo baz
+      printf "%s:%s:%s" "$foo" "${bar:-}" "$baz"
+    }
+    state=""
+    init state
+    cleanup state
+  '
+  [ "$output" = "secret::new" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state only auto-restores locals in the immediate caller scope" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }
+    outer(){
+      local foo=""
+      inner_auto
+      printf "%s:" "$foo"
+      foo=""
+      inner_explicit
+      printf "%s" "$foo"
+    }
+    inner_auto(){
+      eval "$(hs_read_persisted_state state)"
+    }
+    inner_explicit(){
+      hs_read_persisted_state state foo
+    }
+    state=""
+    init state
+    outer
+  '
+  [ "$output" = ":secret" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state warns when a requested variable is not in state" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }
+    cleanup(){
+      local state_var="$1"
+      local foo="" bar=""
+      hs_read_persisted_state "$state_var" foo bar
+      printf "%s:%s" "$foo" "${bar:-}"
+    }
+    state=""
+    init state
+    cleanup state
+  '
+  [[ "$stderr" == *"[WARNING] hs_read_persisted_state: variable 'bar' is not defined in the state."* ]]
+  [ "$output" = "secret:" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state -q silences warnings for variables not in state" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }
+    cleanup(){
+      local state_var="$1"
+      local foo="" bar=""
+      hs_read_persisted_state -q "$state_var" foo bar
+      printf "%s:%s" "$foo" "${bar:-}"
+    }
+    state=""
+    init state
+    cleanup state
+  '
+  [ "$output" = "secret:" ]
+  [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state rejects a missing state variable name" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_MISSING_ARGUMENT" --separate-stderr bash --noprofile -lc '
+    hs_read_persisted_state >/dev/null
+  '
+  [[ "$stderr" == *"missing required state variable name"* ]]
+  [ -z "$output" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state rejects an invalid state variable name" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
+    hs_read_persisted_state "1invalid-var-name" >/dev/null
+  '
+  [[ "$stderr" == *"invalid variable name '1invalid-var-name'"* ]]
+  [ -z "$output" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state rejects an unset or empty state variable" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_STATE_VAR_UNINITIALIZED" --separate-stderr bash --noprofile -lc '
+    state=""
+    hs_read_persisted_state state >/dev/null
+  '
+  [[ "$stderr" == *"state variable 'state' is not set or is empty"* ]]
+  [ -z "$output" ]
 }
 
 # bats test_tags=hs_persist_state_as_code
 @test "overwriting a local already set in cleanup should fail with explicit message" {
   # shellcheck disable=SC2016
   run -1 bash --noprofile -lc '
-  init(){ local foo=secret; hs_persist_state_as_code foo; };
+  init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; };
   cleanup(){ local foo=already; eval "$1"; }; 
-  state=$(init); 
+  state="";
+  init state;
   cleanup "$state"'
   [[ "$output" == *"local foo already defined; refusing to overwrite"* ]]
 }
@@ -178,9 +315,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_persist_state_as_code does not include variables that were not set in init" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo=one; hs_persist_state_as_code foo bar; };
+  init(){ local foo=one; hs_persist_state_as_code -S "$1" foo bar; };
   cleanup(){ local foo bar; eval "$1"; printf "%s:%s" "$foo" "${bar:-}"; };  
-  state=$(init); 
+  state="";
+  init state;
   cleanup "$state"'
   [ "$output" = "one:" ]
 }
@@ -189,8 +327,9 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_persist_state_as_code ignores unknown variable names" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
-  init(){ hs_persist_state_as_code not_a_var; };
-  state=$(init);
+  state="";
+  init(){ hs_persist_state_as_code -S "$1" not_a_var; };
+  init state;
   printf "%s" "$state"
   '
   [ -z "$output" ]
@@ -201,8 +340,9 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_persist_state_as_code ignores function names" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
-  init(){ my_func(){ echo "nope"; }; hs_persist_state_as_code my_func; };
-  state=$(init);
+  state="";
+  init(){ my_func(){ echo "nope"; }; hs_persist_state_as_code -S "$1" my_func; };
+  init state;
   printf "%s" "$state"
   '
   [ -z "$output" ]
@@ -213,9 +353,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_persist_state_as_code only captures the first element of an indexed array" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local -a items=(one two); hs_persist_state_as_code items; };
+  init(){ local -a items=(one two); hs_persist_state_as_code -S "$1" items; };
   cleanup(){ local -a items; eval "$1"; printf "%s:%s" "${items[0]-}" "${items[1]-}"; };
-  state=$(init);
+  state="";
+  init state;
   cleanup "$state"
   '
   [ "$output" = "one:" ]
@@ -225,8 +366,9 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_persist_state_as_code ignores associative arrays" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
-  init(){ local -A amap=([key]=value); hs_persist_state_as_code amap; };
-  state=$(init);
+  state="";
+  init(){ local -A amap=([key]=value); hs_persist_state_as_code -S "$1" amap; };
+  init state;
   printf "%s" "$state"
   '
   [ -z "$output" ]
@@ -237,9 +379,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "hs_persist_state_as_code treats namerefs as scalar values" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local target=secret; local -n ref=target; hs_persist_state_as_code ref; };
+  init(){ local target=secret; local -n ref=target; hs_persist_state_as_code -S "$1" ref; };
   cleanup(){ local target=""; local -n ref=target; eval "$1"; printf "%s:%s" "$target" "$ref"; };
-  state=$(init);
+  state="";
+  init state;
   cleanup "$state"
   '
   [ "$output" = "secret:secret" ]
@@ -249,9 +392,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "restore empty value" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo=""; hs_persist_state_as_code foo; };
+  init(){ local foo=""; hs_persist_state_as_code -S "$1" foo; };
   cleanup(){ local foo; eval "$1"; printf "%s" "$foo"; };  
-  state=$(init); 
+  state="";
+  init state;
   cleanup "$state"'
   [ -z "$output" ]
 }
@@ -260,9 +404,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "overwrite empty local variable with persisted value" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo=secret; hs_persist_state_as_code foo; }; 
+  init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }; 
   cleanup(){ local foo=""; eval "$1"; printf "%s" "$foo"; hs_cleanup_output; }; 
-  state=$(init); 
+  state="";
+  init state;
   cleanup "$state"'
   [ "$output" = "secret" ]
 }
@@ -271,30 +416,12 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 @test "preserve special characters in persisted values" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-  init(){ local foo='\''a b "c" $d'\''; hs_persist_state_as_code foo; }; 
+  init(){ local foo='\''a b "c" $d'\''; hs_persist_state_as_code -S "$1" foo; }; 
   cleanup(){ local foo; eval "$1"; printf "%s" "$foo"; hs_cleanup_output; }; 
-  state=$(init); 
+  state="";
+  init state;
   cleanup "$state"'
   [ "$output" = "a b \"c\" \$d" ]
-}
-
-# bats test_tags=hs_setup_output_to_stdout, hs_persist_state_as_code
-@test "hs_setup_output_to_stdout keeps logs separate from persisted state [no-setup]" {
-  # hs_echo logs to stdout, captured by bats, even though it is explicitly captured by $state.
-  # shellcheck disable=SC2016
-  run -0 --separate-stderr bash --noprofile -lc '
-    hs_setup_output_to_stdout
-    init() {
-      local foo="secret"
-      hs_echo "LOG foo is $foo"
-      hs_persist_state_as_code foo
-    }
-    state=$(init)
-    printf "%s\n" "$state" >&2  # send persisted state to stderr
-    hs_cleanup_output
-  '
-  [ "$output" = "LOG foo is secret" ]
-  [[ "$stderr" == *'foo=secret'* ]]
 }
 
 # This test uses kill -0 to check if a PID exists
@@ -314,43 +441,6 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 } 
 
 # bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code with -s appends to existing state" {
-  # shellcheck disable=SC2016
-  run -0 --separate-stderr bash --noprofile -lc '
-    init() {
-      local bar=two
-      hs_persist_state_as_code -s "$1" bar
-    }
-    cleanup(){ 
-      local foo bar 
-      eval "$1"
-      printf "%s:%s" "$foo" "$bar" 
-    }
-    state1=$(make_state foo one)
-    state2=$(init "$state1")
-    cleanup "$state2"
-  '
-  [ "$output" = "one:two" ]
-  [ -z "$stderr" ]
-} 
-
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code with -s fails on variable name collision" {
-  # shellcheck disable=SC2016
-  run -"$HS_ERR_VAR_NAME_COLLISION" --separate-stderr bash --noprofile -lc '
-    init() {
-      local foo=two
-      hs_persist_state_as_code -s "$1" foo  # Fails: foo already in state
-    }
-    state1=$(make_state foo one)
-    init "$state1" >/dev/null  # Invalid output must be ignored
-  '
-  # echo "stderr=$stderr" >&3
-  [[ "$stderr" == *"variable 'foo' is already defined in the state, with value 'one'"* ]]
-  [ -z "$output" ]
-}
-
-# bats test_tags=hs_persist_state_as_code
 @test "hs_persist_state_as_code with -S detects an invalid variable name" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -xlc '
@@ -361,14 +451,44 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 }
 
 # bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code rejects an invalid persisted variable name" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
+    state=""
+    init() {
+      local foo=two
+      hs_persist_state_as_code -S "$1" "1invalid-var-name" foo
+    }
+    init state
+  '
+  [[ "$stderr" == *"invalid variable name '1invalid-var-name'"* ]]
+  [ -z "$output" ]
+}
+
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code requires -S" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_STATE_VAR_UNINITIALIZED" --separate-stderr bash --noprofile -lc '
+    init() {
+      local foo=two bar=three
+      hs_persist_state_as_code foo bar
+    }
+    init
+  '
+  [[ "$stderr" == *"missing required -S <statevar> option"* ]]
+  [ -z "$output" ]
+}
+
+# bats test_tags=hs_persist_state_as_code
 @test "hs_persist_state_as_code fails on reserved variable name __var_name" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_RESERVED_VAR_NAME" --separate-stderr bash --noprofile -xlc '
     init() {
       local __var_name=bad
-      hs_persist_state_as_code __var_name
+      hs_persist_state_as_code -S "$1" __var_name
     }
-    init
+    state=""
+    init state
   '
   [[ "$stderr" == *"refusing to persist reserved variable name '__var_name'"* ]]
   [ -z "$output" ]
@@ -380,9 +500,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   run -"$HS_ERR_RESERVED_VAR_NAME" --separate-stderr bash --noprofile -lc '
     init() {
       local __existing_state=bad
-      hs_persist_state_as_code __existing_state
+      hs_persist_state_as_code -S "$1" __existing_state
     }
-    init
+    state=""
+    init state
   '
   [[ "$stderr" == *"refusing to persist reserved variable name '__existing_state'"* ]]
   [ -z "$output" ]
@@ -394,9 +515,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   run -"$HS_ERR_RESERVED_VAR_NAME" --separate-stderr bash --noprofile -lc '
     init() {
       local __output_state_var=bad
-      hs_persist_state_as_code __output_state_var
+      hs_persist_state_as_code -S "$1" __output_state_var
     }
-    init
+    state=""
+    init state
   '
   [[ "$stderr" == *"refusing to persist reserved variable name '__output_state_var'"* ]]
   [ -z "$output" ]
@@ -408,9 +530,10 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   run -"$HS_ERR_RESERVED_VAR_NAME" --separate-stderr bash --noprofile -lc '
     init() {
       local __output=bad
-      hs_persist_state_as_code __output
+      hs_persist_state_as_code -S "$1" __output
     }
-    init
+    state=""
+    init state
   '
   [[ "$stderr" == *"refusing to persist reserved variable name '__output'"* ]]
   [ -z "$output" ]
@@ -422,46 +545,17 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   run -0 bash --noprofile -lc '
     init() {
       local bar=two
-      hs_persist_state_as_code -S state bar
+      hs_persist_state_as_code -S "$1" bar
     }
     cleanup(){ 
       local bar 
       eval "$state"
       printf "%s" "$bar" 
     }
-    init
+    init state
     cleanup
   '
   [ "$output" = "two" ]
-}
-
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code detects corrupt state: infinite loop" {
-  # The infinite loop is simulated by a 3 seconds sleep.
-  # shellcheck disable=SC2016
-  run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
-    init() {
-      local foo=two
-      hs_persist_state_as_code -s "$(corrupt_state slow)" foo
-    }
-    init
-  '
-  [[ "$stderr" =~ "prior state is corrupted" ]]
-  [ -z "$output" ]
-}
-
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code detects corrupt state: error on eval" {
-  # shellcheck disable=SC2016
-  run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
-    init() {
-      local foo=two
-      hs_persist_state_as_code -s "$(corrupt_state error)" foo
-    }
-    init
-  '
-  [[ "$stderr" =~ "prior state is corrupted" ]]
-  [ -z "$output" ]
 }
 
 # bats test_tags=hs_persist_state_as_code
@@ -479,45 +573,6 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   [ -z "$output" ]
 }
 
-# bats test_tags=hs_persist_state_as_code
-@test "hs_persist_state_as_code -s works when called via bats run on a shell function" {
-  # Regression test for issue #59: hs_persist_state_as_code used $0 to re-invoke the
-  # shell for collision checking, but $0 is the Bats runner (not bash) when a
-  # function is invoked via 'bats run'.  The fix uses ${BASH:-bash} instead.
-  # Also verifies that the collision-check subshell does not leak 'a' globally.
-  state_accumulates() {
-    local incoming_state="local a=kept"
-    hs_persist_state_as_code -s "$incoming_state" b >/dev/null
-  }
-  run -0 --separate-stderr state_accumulates
-  [ -z "$stderr" ]
-  # a must not have leaked into the current scope from the collision-check subshell
-  [ -z "${a+set}" ]
-}
-
-# bats test_tags=hs_destroy_state
-@test "hs_destroy_state with -s removes the listed variables and prints the rebuilt state" {
-  # shellcheck disable=SC2016
-  run -0 --separate-stderr bash --noprofile -lc '
-    source "$LIB" 2>/dev/null
-    hs_cleanup_output
-    init() {
-      local foo=one bar=two baz=three
-      hs_persist_state_as_code foo bar baz
-    }
-    cleanup() {
-      local foo="" bar="" baz=""
-      eval "$1"
-      printf "%s:%s:%s" "${foo:-}" "${bar:-}" "${baz:-}"
-    }
-    state=$(init)
-    stripped=$(hs_destroy_state -s "$state" foo baz)
-    cleanup "$stripped"
-  '
-  [[ "$output" == *":two:"* ]]
-  [ -z "$stderr" ]
-}
-
 # bats test_tags=hs_destroy_state
 @test "hs_destroy_state with -S rewrites the named variable in place" {
   # shellcheck disable=SC2016
@@ -526,14 +581,15 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     hs_cleanup_output
     init() {
       local foo=one bar=two
-      hs_persist_state_as_code -S state foo bar
+      hs_persist_state_as_code -S "$1" foo bar
     }
     cleanup() {
       local foo="" bar=""
       eval "$state"
       printf "%s:%s" "${foo:-}" "${bar:-}"
     }
-    init
+    state=""
+    init state
     hs_destroy_state -S state foo
     cleanup
   '
@@ -542,13 +598,27 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
 }
 
 # bats test_tags=hs_destroy_state
+@test "hs_destroy_state requires -S" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_STATE_VAR_UNINITIALIZED" --separate-stderr bash --noprofile -lc '
+    source "$LIB" 2>/dev/null
+    hs_cleanup_output
+    hs_destroy_state foo bar >/dev/null
+  '
+  [[ "$stderr" == *"missing required -S <statevar> option"* ]]
+  [ -z "$output" ]
+}
+
+# bats test_tags=hs_destroy_state
 @test "hs_destroy_state rejects invalid destroy variable names" {
   # shellcheck disable=SC2016
   run -"$HS_ERR_INVALID_VAR_NAME" --separate-stderr bash --noprofile -lc '
     source "$LIB" 2>/dev/null
     hs_cleanup_output
-    state=$(make_state foo one)
-    hs_destroy_state -s "$state" "1invalid-var-name" >/dev/null
+    state="if local -p foo >/dev/null 2>&1; then
+  foo=one
+fi"
+    hs_destroy_state -S state "1invalid-var-name" >/dev/null
   '
   [[ "$stderr" == *"invalid variable name '1invalid-var-name'"* ]]
   [ -z "$output" ]
@@ -562,10 +632,11 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     hs_cleanup_output
     init() {
       local foo=one
-      hs_persist_state_as_code foo
+      hs_persist_state_as_code -S "$1" foo
     }
-    state=$(init)
-    hs_destroy_state -s "$state" missing >/dev/null
+    state=""
+    init state
+    hs_destroy_state -S state missing >/dev/null
   '
   [[ "$stderr" == *"variable 'missing' is not defined in the state"* ]]
   [ -z "$output" ]
@@ -577,7 +648,9 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   run -"$HS_ERR_CORRUPT_STATE" --separate-stderr bash --noprofile -lc '
     source "$LIB" 2>/dev/null
     hs_cleanup_output
-    hs_destroy_state -s "$(corrupt_state error)" foo >/dev/null
+    local state
+    state="$(corrupt_state error)"
+    hs_destroy_state -S state foo >/dev/null
   '
   [[ "$stderr" == *"prior state is corrupted"* ]]
   [ -z "$output" ]

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -20,7 +20,7 @@ setup_file() {
             hs_persist_state_as_code hs_destroy_state hs_read_persisted_state
   export HS_ERR_RESERVED_VAR_NAME HS_ERR_VAR_NAME_COLLISION HS_ERR_VAR_NAME_NOT_IN_STATE
   export HS_ERR_MULTIPLE_STATE_INPUTS HS_ERR_CORRUPT_STATE HS_ERR_INVALID_VAR_NAME \
-         HS_ERR_STATE_VAR_UNINITIALIZED HS_ERR_MISSING_ARGUMENT
+         HS_ERR_STATE_VAR_UNINITIALIZED HS_ERR_MISSING_ARGUMENT HS_ERR_INVALID_ARGUMENT_TYPE
   # Accelerate test failure
   export BATS_TEST_TIMEOUT=30
 }
@@ -150,6 +150,34 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   '
   [ -z "$output" ]
   [ -z "$stderr" ]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs rejects a non-array remaining_args container" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_INVALID_ARGUMENT_TYPE" --separate-stderr bash --noprofile -lc '
+    f() {
+      local remaining_args=""
+      local -A processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args qS: processed_args -S state foo
+    }
+    f
+  '
+  [[ "$stderr" == *"'remaining_args' must name an indexed array variable"* ]]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs rejects a non-associative processed_args container" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_INVALID_ARGUMENT_TYPE" --separate-stderr bash --noprofile -lc '
+    f() {
+      local -a remaining_args=()
+      local -a processed_args=()
+      _hs_resolve_state_inputs my_helper remaining_args qS: processed_args -S state foo
+    }
+    f
+  '
+  [[ "$stderr" == *"'processed_args' must name an associative array variable"* ]]
 }
 
 # bats test_tags=hs_resolve_state_inputs
@@ -346,8 +374,8 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
     init state
     printf "%s" "$(hs_read_persisted_state -S state)"
   '
-  [[ "$output" == *'hs_read_persisted_state -S state'* ]]
-  [[ "$output" == *'if local -p foo >/dev/null 2>&1'* ]]
+  [[ "$output" == *'hs_read_persisted_state -q -S state'* ]]
+  [[ "$output" == *'done < <(local -p)'* ]]
   [ -z "$stderr" ]
 }
 
@@ -414,6 +442,26 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   '
   [[ "$stderr" == *"[WARNING] hs_read_persisted_state: variable 'bar' is not defined in the state."* ]]
   [ "$output" = "secret:" ]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state warns for each missing requested variable" {
+  # shellcheck disable=SC2016
+  run -0 --separate-stderr bash --noprofile -lc '
+    init(){ local foo=secret; hs_persist_state_as_code -S "$1" foo; }
+    cleanup(){
+      local state_var="$1"
+      local foo="" bar="" baz=""
+      hs_read_persisted_state -S "$state_var" foo bar baz
+      printf "%s:%s:%s" "$foo" "${bar:-}" "${baz:-}"
+    }
+    state=""
+    init state
+    cleanup state
+  '
+  [[ "$stderr" == *"[WARNING] hs_read_persisted_state: variable 'bar' is not defined in the state."* ]]
+  [[ "$stderr" == *"[WARNING] hs_read_persisted_state: variable 'baz' is not defined in the state."* ]]
+  [ "$output" = "secret::" ]
 }
 
 # bats test_tags=hs_read_persisted_state
@@ -495,6 +543,26 @@ export -f make_state corrupt_state # makes it available in bash --noprofile -lc 
   init state;
   cleanup "$state"'
   [[ "$output" == *"local foo already defined; refusing to overwrite"* ]]
+}
+
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code reports all colliding variable names" {
+  # shellcheck disable=SC2016
+  run -"$HS_ERR_VAR_NAME_COLLISION" --separate-stderr bash --noprofile -lc '
+    init_existing() {
+      local foo=one bar=two
+      hs_persist_state_as_code -S "$1" foo bar
+    }
+    init_again() {
+      local foo=three bar=four baz=five
+      hs_persist_state_as_code -S "$1" foo bar baz
+    }
+    state=""
+    init_existing state
+    init_again state
+  '
+  [[ "$stderr" == *"variables already defined in the state: foo bar."* ]]
+  [ -z "$output" ]
 }
 
 # bats test_tags=hs_persist_state_as_code


### PR DESCRIPTION
Closes #62.

## Summary
- refactor `hs_read_persisted_state` to prefer explicit variable restoration and generate a safer probe snippet instead of returning raw persisted code by default
- factor shared persisted-state variable-name extraction into `_hs_extract_persisted_state_var_names`
- update tests and handle-state documentation for the safer restoration flow, warnings, and scope behavior

## Verification
- `bash -n config/handle_state.sh`
- `bats test/test-hs_persist_state.bats --filter 'hs_read_persisted_state|hs_persist_state_as_code|hs_destroy_state'`