### PR TITLE
refactor(command_guard): remove unused CG_ERR_MISSING_COMMAND constant

### DIFF
--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -52,7 +52,7 @@ _cg_resolve_command_path() {
 #   guard -q  # no warning
 #   guard -- uname -login  # Treats "-login" as a command name
 # Errors:
-#   CG_ERR_MISSING_COMMAND, CG_ERR_INVALID_NAME, CG_ERR_NOT_FOUND
+#   CG_ERR_INVALID_NAME, CG_ERR_NOT_FOUND
 # Notes:
 #   Uses a restricted PATH ("/usr/bin:/bin") in a subshell to resolve the command.
 #   This avoids resolving through user-controlled PATH entries.

--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -7,7 +7,6 @@
 [[ -z ${__COMMAND_GUARD_SH_INCLUDED:-} ]] && __COMMAND_GUARD_SH_INCLUDED=1 || return 0
 
 # --- Public error codes --------------------------------------------------------
-readonly CG_ERR_MISSING_COMMAND=1
 readonly CG_ERR_INVALID_NAME=2
 readonly CG_ERR_NOT_FOUND=3
 

--- a/test/test-command_guard.bats
+++ b/test/test-command_guard.bats
@@ -13,7 +13,7 @@ setup_file() {
   # shellcheck source=config/command_guard.sh
   source "$LIB"
   export -f guard _cg_resolve_command_path
-  export CG_ERR_MISSING_COMMAND CG_ERR_INVALID_NAME CG_ERR_NOT_FOUND
+  export CG_ERR_INVALID_NAME CG_ERR_NOT_FOUND
 }
 
 # bats test_tags=guard,issue-24

--- a/test/test-command_guard.bats
+++ b/test/test-command_guard.bats
@@ -16,6 +16,16 @@ setup_file() {
   export CG_ERR_MISSING_COMMAND CG_ERR_INVALID_NAME CG_ERR_NOT_FOUND
 }
 
+# bats test_tags=guard,issue-24
+# Expected to fail until CG_ERR_MISSING_COMMAND is removed from command_guard.sh
+@test "issue-24: CG_ERR_MISSING_COMMAND is not defined after sourcing" {
+  # shellcheck disable=SC2016
+  run -0 bash --noprofile --norc -c '
+    source "$LIB"
+    [[ -z "${CG_ERR_MISSING_COMMAND+x}" ]]
+  '
+}
+
 # bats test_tags=guard
 @test "guard defines a function that shadows the command" {
   # shellcheck disable=SC2016


### PR DESCRIPTION
## Summary

- Removes the unused `readonly CG_ERR_MISSING_COMMAND=1` constant from `config/command_guard.sh` — it was never returned by any code path
- Trims it from the `# Errors:` doc comment on the `guard` function
- Removes it from the `export` line in `test/test-command_guard.bats`
- Adds a regression test asserting the constant is absent after sourcing

No behavioral change. `docs/libraries/command_guard.rst` had no reference to this constant and required no update.

Closes #24

## Test plan

- [x] New test `issue-24: CG_ERR_MISSING_COMMAND is not defined after sourcing` passes
- [x] Full suite: 36/36 tests pass (`bats test/test-command_guard.bats`)
- [ ] `shellcheck config/command_guard.sh` — shellcheck not available locally; CI will verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)