### PR TITLE
fix(shellcheck): quote exit/return args, fix source annotations, add .shellcheckrc

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -104,7 +104,7 @@ guard() {
             else
                 echo "[ERROR] guard: unable to resolve full path for '$cmd'. Use the full path." >&2
             fi
-            [[ "$BASHPID" != "$$" ]] && exit $CG_ERR_NOT_FOUND || return $CG_ERR_NOT_FOUND
+            [[ "$BASHPID" != "$$" ]] && exit "$CG_ERR_NOT_FOUND" || return "$CG_ERR_NOT_FOUND"
         }
         valid_commands+=("$cmd")
         full_paths+=("$full_path")

--- a/test/test-command_guard.bats
+++ b/test/test-command_guard.bats
@@ -10,7 +10,7 @@ setup_file() {
     echo "Missing library $LIB" >&2
     return 1
   fi
-  # shellcheck source=config/command_guard.sh
+  # shellcheck source=../config/command_guard.sh
   source "$LIB"
   export -f guard _cg_resolve_command_path
   export CG_ERR_INVALID_NAME CG_ERR_NOT_FOUND

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -12,8 +12,7 @@ setup_file() {
     return 1
   fi
   export BATS_TEST_TMPDIR
-  # shellcheck source=config/handle_state.sh
-  # shellcheck disable=SC1091
+  # shellcheck source=../config/handle_state.sh
   #source "$LIB"
   #export -f _hs_is_valid_variable_name \
   #          _hs_resolve_state_inputs _hs_extract_persisted_state_var_names \
@@ -25,8 +24,7 @@ setup_file() {
   export BATS_TEST_TIMEOUT=30
 }
 setup() {
-  # shellcheck source=config/handle_state.sh
-  # shellcheck disable=SC1091
+  # shellcheck source=../config/handle_state.sh
   source "$LIB"
 }
 # Define a helper to create a fake simplified persisted state


### PR DESCRIPTION
## Summary

- Quote `$CG_ERR_NOT_FOUND` in `exit`/`return` in `config/command_guard.sh` (SC2086)
- Fix `# shellcheck source=` annotation paths in both test files: paths are relative to the file being checked, so `config/` → `../config/`
- Remove now-redundant `# shellcheck disable=SC1091` lines from both test files
- Add `.shellcheckrc` with `external-sources=true` so shellcheck follows sourced files project-wide without per-file annotations

Closes #85

## Test plan

- [x] `bats test/test-command_guard.bats` — 36/36 pass
- [ ] Shellcheck clean on all modified files (verified via VSCode extension; CI will confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)