### PR TITLE
doc/fix(handle_state): fix top-of-file usage example and IFS-safe trailing-vars join

### DIFF
--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -7,8 +7,7 @@
 [[ -z ${__HANDLE_STATE_SH_INCLUDED:-} ]] && __HANDLE_STATE_SH_INCLUDED=1 || return 0
 
 # Source command guard for secure external command usage
-# shellcheck source=config/command_guard.sh
-# shellcheck disable=SC1091
+# shellcheck source=command_guard.sh
 source "${BASH_SOURCE%/*}/command_guard.sh"
 
 # Library usage:
@@ -18,21 +17,21 @@ source "${BASH_SOURCE%/*}/command_guard.sh"
 #   init_function() {
 #       local temp_file="/tmp/some_temp_file"
 #       local resource_id="resource_123"
-#       hs_persist_state_as_code "$@" temp_file resource_id
-#       return 0
+#       hs_persist_state_as_code "$@" -- temp_file resource_id
 #   }
 #   cleanup() {
 #       local temp_file
 #       local resource_id
-#       hs_read_persisted_state "$@" temp_file resource_id  # Recreate local variables from the state string
-#       # Now temp_file and resource_id are available for cleanup operations
+#       hs_read_persisted_state "$@" -- temp_file resource_id
 #       rm -f "$temp_file"
-#       echo "Cleaned up resource: $resource_id"
-#       hs_destroy_state "$@" -- temp_file resource_id  # Ensure the state variable can be reused.
+#       printf 'Cleaned up resource: %s\n' "$resource_id"
+#       hs_destroy_state "$@" -- temp_file resource_id
 #   }
 #
-# Upper level usage: state=$(init_function)
-#                    cleanup "$state"
+# Upper level usage:
+#   local _state=""
+#   init_function -S _state
+#   cleanup -S _state
 
 guard timeout
 

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -659,7 +659,8 @@ _hs_resolve_state_inputs() {
             __trailing_vars=("${__remaining_args_ref[-1]}" "${__trailing_vars[@]}")
             unset "__remaining_args_ref[-1]"
         done
-        __processed_args_ref["vars"]="${__trailing_vars[@]}"
+        local IFS=' '
+        __processed_args_ref["vars"]="${__trailing_vars[*]}"
         if [[ "${__processed_args_ref[quiet]}" == false ]] && ((${#__remaining_args_ref[@]} > 0)); then
             echo "[WARNING] ${__caller_name}: forwarded arguments remain after implicit variable-list parsing; use -- before the variable names." >&2
         fi


### PR DESCRIPTION
## Summary

- Add missing `--` separator to `hs_persist_state_as_code` and `hs_read_persisted_state` calls in the top-of-file usage example
- Replace the old stdout API pattern (`state=$(init_function)` / `cleanup "$state"`) with the `-S` named-variable pattern
- Fix `shellcheck source=` path in the source directive (`config/command_guard.sh` → `command_guard.sh`, path is relative to the file's own directory)
- Remove now-redundant `# shellcheck disable=SC1091` (covered by project-level `.shellcheckrc`)
- Replace `"${__trailing_vars[@]}"` with `local IFS=' '; "${__trailing_vars[*]}"` in `_hs_resolve_state_inputs` — makes the space-join intent explicit and IFS-safe (SC2145)

Closes #64

## Test plan

- [x] `bats test/test-hs_persist_state.bats` — 70/70 pass
- [x] Existing test "preserves trailing variable order without explicit separator" (line 218) covers the `[*]` path with multiple vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)