### PR TITLE
docs(handle_state.rst): remove internal-format mention, mark convenience form non-preferred

### DIFF
--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -11,10 +11,9 @@ Purpose
 
 ``handle_state.sh`` helps Bash libraries carry cleanup state by name.
 
-The current public API is built around a named state variable passed with
-``-S <statevar>``. The state value is opaque. The current implementation stores
-that value as guarded Bash code, but callers should not depend on that internal
-representation.
+The public API is built around a named state variable passed with
+``-S <statevar>``. The state value is an opaque internal token; callers should
+not inspect or modify its contents directly.
 
 Dependencies
 ------------
@@ -126,7 +125,7 @@ hs_read_persisted_state
 
 - Usage: ``hs_read_persisted_state [forwarded args] [-q] -S <statevar> [--] [var1 var2 ...]``
 - Convenience form: ``hs_read_persisted_state state ...`` is normalized to
-  ``-S state ...``.
+  ``-S state ...``. Not recommended in library code; prefer explicit ``-S``.
 - Preferred usage: ``hs_read_persisted_state "$@" -- var1 var2 ...``
 
 Explicit restore


### PR DESCRIPTION
## Summary

- **Purpose section**: removes "The current implementation stores that value as guarded Bash code" — the same implementation-leaking language that issue #65 removed from `config/handle_state.sh`, but which remained in the RST. Replaced with "opaque internal token; callers should not inspect or modify its contents directly."
- **hs_read_persisted_state convenience form**: adds "Not recommended in library code; prefer explicit ``-S``." so the positional form is clearly de-emphasised relative to `-S`.

No code change. All RST examples already used `-S` and `"$@" --` consistently.

Closes #73

## Test plan

- [x] `bats test/test-hs_persist_state.bats` — 70/70 pass (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)