### PR TITLE
docs(handle_state.rst): add forwarded-args eval example for probe-snippet mode

### DIFF
--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -153,7 +153,14 @@ Probe-snippet mode
 
 When no explicit variable names are supplied and no explicit ``--`` is present,
 ``hs_read_persisted_state`` emits a small locally generated probe snippet. The
-caller may ``eval`` that snippet.
+caller must ``eval`` the snippet using the forwarded-arguments form:
+
+.. code-block:: bash
+
+   cleanup_function() {
+       local temp_file resource_id
+       eval "$(hs_read_persisted_state "$@")"
+   }
 
 The generated snippet:
 

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -160,6 +160,8 @@ caller must ``eval`` the snippet using the forwarded-arguments form:
    cleanup_function() {
        local temp_file resource_id
        eval "$(hs_read_persisted_state "$@")"
+       rm -f "$temp_file"
+       printf 'Cleaned up resource: %s\n' "$resource_id"
    }
 
 The generated snippet:


### PR DESCRIPTION
## Summary

The probe-snippet mode section said "The caller may ``eval`` that snippet" with no code example. Adds an explicit code block showing the correct forwarded-arguments form:

```bash
eval "$(hs_read_persisted_state "$@")"
```

Also strengthens "may" to "must" since the snippet must be eval'd for restoration to take effect.

Closes #74

## Test plan

- [x] `bats test/test-hs_persist_state.bats` — 70/70 pass (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)