### PR TITLE
docs(handle_state): replace non-standard hs_read_persisted_state usage example

### DIFF
--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -352,14 +352,10 @@ hs_destroy_state() {
 #     is supplied.
 # Usage examples:
 #   cleanup() {
-#       local state_var="$1"
 #       local temp_file resource_id
-#       hs_read_persisted_state -S "$state_var" -- temp_file resource_id
-#   }
-#   # Better: keeps -S convention for cleanup().
-#   cleanup() {
-#       local temp_file resource_id
-#       hs_read_persisted_state -q "$@" -- temp_file resource_id
+#       hs_read_persisted_state "$@" -- temp_file resource_id
+#       rm -f "$temp_file"
+#       printf 'Cleaned up resource: %s\n' "$resource_id"
 #   }
 hs_read_persisted_state() {
     # Step 1: normalize the convenience form `hs_read_persisted_state state`


### PR DESCRIPTION
## Summary

The `hs_read_persisted_state` usage block showed two examples — a non-standard one taking the state variable from `$1`, and a "Better" comparison using `"$@"`. The first example implied that passing state by positional argument is an acceptable pattern; it is not (the state variable name belongs to the caller and should be forwarded via `-S`).

Replaces both with a single clean example using the forwarded-args form, with the restored variables actually used so the example is self-contained.

Closes #75

## Test plan

- [x] `bats test/test-hs_persist_state.bats` — 70/70 pass (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)