### PR TITLE
docs(handle_state): rename probe-snippet to implicit local restore, prefer state_var in examples

### DIFF
--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -463,6 +463,9 @@ hs_read_persisted_state() {
     # inspects the current function's locals with `local -p`, selects unset
     # scalar locals, and reenters hs_read_persisted_state with -q so unrelated
     # locals stay quiet.
+    # The reentrant call below must forward all parameters decoded by
+    # _hs_resolve_state_inputs (state var, quiet flag, etc.). -q is added here
+    # automatically; -S carries the already-validated state variable name.
     IFS= read -r -d '' __probe_snippet <<EOF || true
 hs_read_persisted_state -q -S $(printf '%q' "$__output_state_var") -- \$(
   local -p | while IFS= read -r __hs_local_decl; do

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -79,13 +79,13 @@ readonly HS_ERR_INVALID_ARGUMENT_TYPE=9
 #   - `HS_ERR_CORRUPT_STATE` if the prior state object cannot be evaluated
 #     safely during collision checking.
 # Usage examples:
-#   local state
+#   local state_var
 #   init() {
 #       local var1 var2
 #       hs_persist_state_as_code "$@" -- var1 var2
 #   }
 #
-#   init -S state
+#   init -S state_var
 hs_persist_state_as_code() {
     local -a __remaining_args=()
     local -A __processed_args=()
@@ -321,10 +321,10 @@ hs_destroy_state() {
 #   With an explicit variable list: evaluates the state in an isolated
 #   subprocess, then writes each restored value back into the matching local
 #   in the caller's scope via nameref assignment.
-#   Without an explicit variable list (and no --): emits a probe snippet to
-#   stdout that the caller must eval; the snippet auto-discovers unset scalar
-#   locals in the immediate caller scope and reenters hs_read_persisted_state
-#   with those names explicitly.
+#   Without an explicit variable list (and no --): emits an implicit restore
+#   snippet to stdout that the caller must eval; the snippet auto-discovers
+#   unset scalar locals in the immediate caller scope and reenters
+#   hs_read_persisted_state with those names explicitly.
 #   With -- and no variable names: returns 0 without restoring anything,
 #   disabling the auto-probe path.
 # Options:
@@ -453,14 +453,14 @@ hs_read_persisted_state() {
     fi
 
     # Step 4: if the caller used an explicit `--` but provided no variable
-    # names after it, do not emit the auto-probe snippet. This lets callers
-    # disable the stdout/eval path intentionally.
+    # names after it, do not emit the implicit restore snippet. This lets
+    # callers disable the stdout/eval path intentionally.
     if [[ -n "$__has_separator" ]]; then
         return 0
     fi
 
-    # Step 5: otherwise, generate a generic local-scope probe snippet instead
-    # of returning the raw persisted code. The snippet inspects the current
+    # Step 5: otherwise, generate an implicit restore snippet instead of
+    # returning the raw persisted code. The snippet inspects the current
     # function's locals with `local -p`, selects unset scalar locals, and
     # reenters hs_read_persisted_state with -q so unrelated locals stay quiet.
     IFS= read -r -d '' __probe_snippet <<EOF || true

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -459,10 +459,10 @@ hs_read_persisted_state() {
         return 0
     fi
 
-    # Step 5: otherwise, generate an implicit restore snippet instead of
-    # returning the raw persisted code. The snippet inspects the current
-    # function's locals with `local -p`, selects unset scalar locals, and
-    # reenters hs_read_persisted_state with -q so unrelated locals stay quiet.
+    # Step 5: otherwise, generate an implicit restore snippet. The snippet
+    # inspects the current function's locals with `local -p`, selects unset
+    # scalar locals, and reenters hs_read_persisted_state with -q so unrelated
+    # locals stay quiet.
     IFS= read -r -d '' __probe_snippet <<EOF || true
 hs_read_persisted_state -q -S $(printf '%q' "$__output_state_var") -- \$(
   local -p | while IFS= read -r __hs_local_decl; do

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -43,9 +43,9 @@ Quick Start
        hs_destroy_state "$@" -- temp_file resource_id
    }
 
-   local state=""
-   init_function -S state
-   cleanup_function -S state
+   local state_var=""
+   init_function -S state_var
+   cleanup_function -S state_var
 
 Public API
 ----------
@@ -124,8 +124,8 @@ hs_read_persisted_state
 ``hs_read_persisted_state`` restores values from a named opaque state object.
 
 - Usage: ``hs_read_persisted_state [forwarded args] [-q] -S <statevar> [--] [var1 var2 ...]``
-- Convenience form: ``hs_read_persisted_state state ...`` is normalized to
-  ``-S state ...``. Not recommended in library code; prefer explicit ``-S``.
+- Convenience form: ``hs_read_persisted_state state_var ...`` is normalized to
+  ``-S state_var ...``. Not recommended in library code; prefer explicit ``-S``.
 - Preferred usage: ``hs_read_persisted_state "$@" -- var1 var2 ...``
 
 Explicit restore
@@ -148,11 +148,11 @@ Behavior:
 - ``-q`` suppresses those warnings.
 - The current implementation restores scalar string values only.
 
-Probe-snippet mode
-^^^^^^^^^^^^^^^^^^
+Implicit local restore
+^^^^^^^^^^^^^^^^^^^^^^
 
 When no explicit variable names are supplied and no explicit ``--`` is present,
-``hs_read_persisted_state`` emits a small locally generated probe snippet. The
+``hs_read_persisted_state`` emits a small locally generated implicit restore snippet. The
 caller must ``eval`` the snippet using the forwarded-arguments form:
 
 .. code-block:: bash
@@ -173,7 +173,7 @@ The generated snippet:
 - redirects that reentrant call's stdout to ``/dev/null``.
 
 This is safer than directly evaluating the opaque state object because the
-caller only evaluates the locally generated probe code.
+caller only evaluates the locally generated implicit restore code.
 
 .. warning::
 
@@ -181,7 +181,7 @@ caller only evaluates the locally generated probe code.
    caller scope may be considered for restoration. This can be the wrong
    behavior if the caller manages several unrelated state variables or reuses
    common local names. Prefer explicit variable lists in non-trivial cleanup
-   paths.
+   paths rather than relying on implicit local restore.
 
 .. warning::
 
@@ -190,7 +190,7 @@ caller only evaluates the locally generated probe code.
    if an intermediate function names them explicitly.
 
 If ``--`` is present and no variable names follow it, the function emits no
-probe snippet and returns success.
+implicit restore snippet and returns success.
 
 Errors:
 
@@ -292,7 +292,7 @@ Representing an array manually through a scalar encoding:
 Caveats
 -------
 
-- Prefer explicit restore lists over probe-snippet mode.
+- Prefer explicit restore lists over implicit local restore.
 - Do not rely on the opaque state format being executable code forever.
 - Early unit tests still use raw ``eval`` against the current code-based state
   representation, but library code should prefer ``hs_read_persisted_state``.


### PR DESCRIPTION
Closes #76

## Summary

- Renames the "Probe-snippet mode" section heading to "Implicit local restore" throughout `docs/libraries/handle_state.rst` and matching comments in `config/handle_state.sh`
- Replaces bare `state` variable name with `state_var` in all usage examples in both files

## Test plan

- [ ] No code behavior changes — documentation and comment edits only
- [ ] Verify RST renders correctly (section heading, prose, caveats)
- [ ] Verify `handle_state.sh` comments are consistent with RST

🤖 Generated with [Claude Code](https://claude.com/claude-code)