### PR TITLE
docs(handle_state.rst): emphasize implicit restore snippet is safe locally generated code

### DIFF
--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -152,7 +152,7 @@ Implicit local restore
 ^^^^^^^^^^^^^^^^^^^^^^
 
 When no explicit variable names are supplied and no explicit ``--`` is present,
-``hs_read_persisted_state`` emits a small locally generated implicit restore snippet. The
+``hs_read_persisted_state`` emits a small safe, locally generated implicit restore snippet. The
 caller must ``eval`` the snippet using the forwarded-arguments form:
 
 .. code-block:: bash
@@ -172,8 +172,9 @@ The generated snippet:
 - reenters ``hs_read_persisted_state -q -S <statevar> -- ...``,
 - redirects that reentrant call's stdout to ``/dev/null``.
 
-This is safer than directly evaluating the opaque state object because the
-caller only evaluates the locally generated implicit restore code.
+The emitted snippet is safe: the only elements derived from the transmitted
+state are valid Bash identifiers that are tested for existence as local
+variables in the caller's scope.
 
 .. warning::
 


### PR DESCRIPTION
Closes #77

## Summary

- Adds "safe" to the description of the emitted snippet (line 155)
- Replaces the comparative "safer than" framing with a positive statement using the reviewer's exact wording: the only elements derived from the transmitted state are valid Bash identifiers tested for existence as local variables in the caller's scope

## Test plan

- [ ] Documentation-only change — no code behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)