### PR TITLE
docs(handle_state.rst): clarify caller evaluates safe probe code, not transmitted state

### DIFF
--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -174,7 +174,8 @@ The generated snippet:
 
 The emitted snippet is safe: the only elements derived from the transmitted
 state are valid Bash identifiers that are tested for existence as local
-variables in the caller's scope.
+variables in the caller's scope. The caller evaluates safe probing code, not
+the persisted state transmitted by the caller directly.
 
 .. warning::
 


### PR DESCRIPTION
Closes #78

## Summary

- Appends one sentence to the safety paragraph in the "Implicit local restore" section: "The caller evaluates safe probing code, not the persisted state transmitted by the caller directly."

## Test plan

- [ ] Documentation-only change — no code behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)