### PR TITLE
docs(handle_state.rst): add -S calling context to Examples section

### DIFF
--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -273,6 +273,12 @@ Persisting and restoring a scalar:
        printf '%s\n' "$token"
    }
 
+.. code-block:: bash
+
+   local state_var=""
+   init_function -S state_var
+   cleanup_function -S state_var
+
 Representing an array manually through a scalar encoding:
 
 .. code-block:: bash
@@ -290,6 +296,12 @@ Representing an array manually through a scalar encoding:
        hs_read_persisted_state "$@" -- encoded
        mapfile -d '' -t items < <(printf '%s' "$encoded" | base64 -d)
    }
+
+.. code-block:: bash
+
+   local state_var=""
+   init_function -S state_var
+   cleanup_function -S state_var
 
 Caveats
 -------


### PR DESCRIPTION
Closes #80

## Summary

- Adds a calling-context code block after each example in the `Examples` section, showing `local state_var=""` / `init_function -S state_var` / `cleanup_function -S state_var`
- Makes the `-S` flag usage explicit and consistent with the Quick Start section

## Test plan

- [ ] Documentation-only change — no code behavior changes
- [ ] RST renders correctly with two separate code blocks per example (function bodies + calling context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)