### PR TITLE
docs(handle_state.rst): remove caveat implying raw eval of state is valid

### DIFF
--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -308,8 +308,6 @@ Caveats
 
 - Prefer explicit restore lists over implicit local restore.
 - Do not rely on the opaque state format being executable code forever.
-- Early unit tests still use raw ``eval`` against the current code-based state
-  representation, but library code should prefer ``hs_read_persisted_state``.
 - The current implementation uses ``eval`` internally; state should therefore
   be treated as trusted input.
 


### PR DESCRIPTION
Closes #81

## Summary

- Removes the Caveats bullet: *"Early unit tests still use raw `eval` against the current code-based state representation, but library code should prefer `hs_read_persisted_state`."*
- This bullet was the only place in the docs that implied eval-ing the opaque state directly is a valid (if discouraged) pattern for any caller. Callers should never eval the raw state.
- The remaining caveats ("Do not rely on the opaque state format being executable code forever" and "The current implementation uses `eval` internally") cover the same concern without suggesting raw eval is acceptable.

## Test plan

- [ ] Documentation-only change — no code behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)