### PR TITLE
fix(hs_persist_state_as_code): reject function names with HS_ERR_UNKNOWN_VAR_NAME

### DIFF
--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -154,12 +154,12 @@ hs_persist_state_as_code() {
             echo "[ERROR] hs_persist_state_as_code: refusing to persist reserved variable name '$__var_name'." >&2  
             return "$HS_ERR_RESERVED_VAR_NAME"
         fi
-        # Fail fast if the name is not declared anywhere in the dynamic scope
-        # (catches typos). Function names are silently skipped — persisting
-        # functions is tracked separately as a known limitation.
+        # Fail fast if the name is not declared as a variable in the dynamic scope
+        # (catches typos and misuse of function names).
         if ! declare -p "$__var_name" >/dev/null 2>&1; then
             if declare -f "$__var_name" >/dev/null 2>&1; then
-                continue
+                echo "[ERROR] hs_persist_state_as_code: '$__var_name' is a function, not a variable." >&2
+                return "$HS_ERR_UNKNOWN_VAR_NAME"
             fi
             echo "[ERROR] hs_persist_state_as_code: '$__var_name' is not declared in scope." >&2
             return "$HS_ERR_UNKNOWN_VAR_NAME"

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -287,7 +287,6 @@ Known Limitations
 
 The tests currently demonstrate these limitations:
 
-- function names passed to ``hs_persist_state_as_code`` are ignored
 - indexed arrays preserve only their first element
 - associative arrays are ignored
 - namerefs are restored as scalar values

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -802,18 +802,18 @@ fi'
   [[ "$stderr" == *"'not_a_var' is not declared in scope"* ]]
 }
 
-# bats test_tags=hs_persist_state_as_code,known_issue
-@test "known issue nr.2: hs_persist_state_as_code silently ignores function names" {
+# bats test_tags=hs_persist_state_as_code,xfail
+@test "hs_persist_state_as_code rejects a function name with HS_ERR_UNKNOWN_VAR_NAME" {
   # shellcheck disable=SC2329
   f() {
     my_func(){ echo "nope"; }
     local state_var=""
-    hs_persist_state_as_code -S state_var my_func
+    hs_persist_state_as_code -S state_var my_func || return $?
     printf "%s" "$state_var"
   }
-  run -0 --separate-stderr f
+  run -"$HS_ERR_UNKNOWN_VAR_NAME" --separate-stderr f
   [ -z "$output" ]
-  [ -z "$stderr" ]
+  [[ "$stderr" == *"is a function, not a variable"* ]]
 }
 
 # bats test_tags=hs_persist_state_as_code,known_issue

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -802,13 +802,28 @@ fi'
   [[ "$stderr" == *"'not_a_var' is not declared in scope"* ]]
 }
 
-# bats test_tags=hs_persist_state_as_code,xfail
+# bats test_tags=hs_persist_state_as_code
 @test "hs_persist_state_as_code rejects a function name with HS_ERR_UNKNOWN_VAR_NAME" {
   # shellcheck disable=SC2329
   f() {
     my_func(){ echo "nope"; }
     local state_var=""
     hs_persist_state_as_code -S state_var my_func || return $?
+    printf "%s" "$state_var"
+  }
+  run -"$HS_ERR_UNKNOWN_VAR_NAME" --separate-stderr f
+  [ -z "$output" ]
+  [[ "$stderr" == *"is a function, not a variable"* ]]
+}
+
+# bats test_tags=hs_persist_state_as_code
+@test "hs_persist_state_as_code rejects a function name even when mixed with valid variables" {
+  # shellcheck disable=SC2329
+  f() {
+    my_func(){ echo "nope"; }
+    local good_var="kept"
+    local state_var=""
+    hs_persist_state_as_code -S state_var good_var my_func || return $?
     printf "%s" "$state_var"
   }
   run -"$HS_ERR_UNKNOWN_VAR_NAME" --separate-stderr f


### PR DESCRIPTION
## Summary

- `hs_persist_state_as_code` silently ignored function names, producing an empty state with no diagnostic (issue #2).
- Now detects function names via `declare -f`, emits `[ERROR] … is a function, not a variable.` on stderr, and returns `HS_ERR_UNKNOWN_VAR_NAME`.

## Changes

- **`config/handle_state.sh`**: replaced the silent `continue` branch with an error + early return; updated the comment.
- **`test/test-hs_persist_state.bats`**: repurposed the `known_issue` test as a regression test; added an edge-case test (function name mixed with a valid variable).
- **`docs/libraries/handle_state.rst`**: removed the function-name entry from Known Limitations.

## Test plan

- [ ] `bats --filter-tags '!known_issue' test/test-hs_persist_state.bats` → 71/71 pass
- [ ] New regression test `hs_persist_state_as_code rejects a function name with HS_ERR_UNKNOWN_VAR_NAME` passes
- [ ] New edge-case test `hs_persist_state_as_code rejects a function name even when mixed with valid variables` passes
- [ ] Documentation builds without new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)