### PR TITLE
doc(handle_state): document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points

### DIFF
--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -54,7 +54,8 @@ readonly HS_ERR_NAMEREF_TARGET_NOT_PERSISTED=12
 #        mistaken for a variable unless `--` is used.
 # Errors:
 #   - `HS_ERR_MISSING_ARGUMENT` if no state variable name is supplied at all.
-#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once.
+#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once, even with
+#     the same variable name.
 #   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
 #     persist variable name is not a valid Bash identifier.
 #   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing.
@@ -101,6 +102,7 @@ hs_persist_state() {
         # is absent from the output. Splitting declare+assign would cause
         # lp_snapshot to appear in its own snapshot; the combined form is
         # intentional here.
+        : "${list_reserved}"
         # shellcheck disable=SC2155
         local lp_snapshot="$(local -p)"
         _hs_print_reserved_names "$lp_snapshot" list_reserved
@@ -209,7 +211,8 @@ _hs_ps_body() {
 #        for a variable unless `--` is used.
 # Errors:
 #   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing.
-#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once.
+#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once, even with
+#     the same variable name.
 #   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
 #     destroy variable name is not a valid Bash identifier.
 #   - `HS_ERR_VAR_NAME_NOT_IN_STATE` if a requested destroy variable is not
@@ -243,6 +246,7 @@ hs_destroy_state() {
         # is absent from the output. Splitting declare+assign would cause
         # lp_snapshot to appear in its own snapshot; the combined form is
         # intentional here.
+        : "${list_reserved}"
         # shellcheck disable=SC2155
         local lp_snapshot="$(local -p)"
         _hs_print_reserved_names "$lp_snapshot" list_reserved
@@ -335,7 +339,8 @@ _hs_ds_body() {
 #        `--` is used.
 # Errors:
 #   - `HS_ERR_MISSING_ARGUMENT` if no state variable name is supplied at all.
-#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once.
+#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once, even with
+#     the same variable name.
 #   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
 #     restore variable name is not a valid Bash identifier.
 #   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing, or if
@@ -653,6 +658,10 @@ _hs_resolve_state_inputs() {
                           $'\n'"$__hs_ri_reserved_list"$'\n' == *$'\n'"$OPTARG"$'\n'* ]]; then
                         echo "[ERROR] ${__hs_ri_caller}: state variable name '$OPTARG' is reserved; choose a different variable name." >&2
                         return "$HS_ERR_RESERVED_VAR_NAME"
+                    fi
+                    if [[ -n "${__hs_processed[state]-}" ]]; then
+                        echo "[ERROR] ${__hs_ri_caller}: option -S may only be given once." >&2
+                        return "$HS_ERR_MULTIPLE_STATE_INPUTS"
                     fi
                     __hs_processed["state"]="$OPTARG"
                     __hs_ri_last_opt_sz=${#__hs_remaining[@]}

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -54,6 +54,7 @@ readonly HS_ERR_NAMEREF_TARGET_NOT_PERSISTED=12
 #        mistaken for a variable unless `--` is used.
 # Errors:
 #   - `HS_ERR_MISSING_ARGUMENT` if no state variable name is supplied at all.
+#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once.
 #   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
 #     persist variable name is not a valid Bash identifier.
 #   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing.
@@ -208,6 +209,7 @@ _hs_ps_body() {
 #        for a variable unless `--` is used.
 # Errors:
 #   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing.
+#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once.
 #   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
 #     destroy variable name is not a valid Bash identifier.
 #   - `HS_ERR_VAR_NAME_NOT_IN_STATE` if a requested destroy variable is not
@@ -333,6 +335,7 @@ _hs_ds_body() {
 #        `--` is used.
 # Errors:
 #   - `HS_ERR_MISSING_ARGUMENT` if no state variable name is supplied at all.
+#   - `HS_ERR_MULTIPLE_STATE_INPUTS` if `-S` is given more than once.
 #   - `HS_ERR_INVALID_VAR_NAME` if the state variable name or a requested
 #     restore variable name is not a valid Bash identifier.
 #   - `HS_ERR_STATE_VAR_UNINITIALIZED` if `-S <statevar>` is missing, or if
@@ -392,6 +395,7 @@ hs_read_persisted_state() {
         # is absent from the output. Splitting declare+assign would cause
         # lp_snapshot to appear in its own snapshot; the combined form is
         # intentional here.
+        : "${list_reserved}"
         # shellcheck disable=SC2155
         local lp_snapshot="$(local -p)"
         _hs_print_reserved_names "$lp_snapshot" list_reserved

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -85,7 +85,8 @@ Behavior:
 Errors:
 
 - ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``.
-- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once.
+- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once; repeating
+  the option is not allowed even when both occurrences name the same variable.
 - ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
   requested variable name.
 - ``HS_ERR_RESERVED_VAR_NAME=1``: requested name starts with the reserved
@@ -126,7 +127,8 @@ Behavior:
 Errors:
 
 - ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``.
-- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once.
+- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once; repeating
+  the option is not allowed even when both occurrences name the same variable.
 - ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
   requested destroy name.
 - ``HS_ERR_VAR_NAME_NOT_IN_STATE=6``: requested destroy name is not present in
@@ -248,7 +250,8 @@ implicit restore snippet and returns success.
 Errors:
 
 - ``HS_ERR_MISSING_ARGUMENT=8``: no state variable name was supplied at all.
-- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once.
+- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once; repeating
+  the option is not allowed even when both occurrences name the same variable.
 - ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
   requested restore name.
 - ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``, or the named

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -85,6 +85,7 @@ Behavior:
 Errors:
 
 - ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``.
+- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once.
 - ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
   requested variable name.
 - ``HS_ERR_RESERVED_VAR_NAME=1``: requested name starts with the reserved
@@ -125,6 +126,7 @@ Behavior:
 Errors:
 
 - ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``.
+- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once.
 - ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
   requested destroy name.
 - ``HS_ERR_VAR_NAME_NOT_IN_STATE=6``: requested destroy name is not present in
@@ -246,6 +248,7 @@ implicit restore snippet and returns success.
 Errors:
 
 - ``HS_ERR_MISSING_ARGUMENT=8``: no state variable name was supplied at all.
+- ``HS_ERR_MULTIPLE_STATE_INPUTS=3``: ``-S`` was given more than once.
 - ``HS_ERR_INVALID_VAR_NAME=5``: invalid state variable name or invalid
   requested restore name.
 - ``HS_ERR_STATE_VAR_UNINITIALIZED=7``: missing ``-S <statevar>``, or the named

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -27,6 +27,7 @@ hs2_corrupt_state() {
 @test "_hs_resolve_state_inputs rejects caller that declared __hs_remaining as a non-array" {
   # shellcheck disable=SC2329
   f() {
+    # shellcheck disable=SC2178
     local __hs_remaining=""
     local -A __hs_processed=()
     _hs_resolve_state_inputs my_helper qS: -S state foo
@@ -255,6 +256,7 @@ hs2_corrupt_state() {
 @test "hs_persist_state rejects variable names starting with the __hs_ reserved prefix" {
   # shellcheck disable=SC2329
   f() {
+    # shellcheck disable=SC2178
     local __hs_remaining="some_value"
     local state=""
     hs_persist_state -S state -- __hs_remaining
@@ -935,6 +937,66 @@ hs2_corrupt_state() {
   [[ "$stderr" == *"reserved"* ]]
 }
 
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs rejects a repeated -S option" {
+  # shellcheck disable=SC2329
+  f() {
+    local -a __hs_remaining=()
+    local -A __hs_processed=()
+    _hs_resolve_state_inputs my_helper qS: -S var1 -S var2
+  }
+  run -"$HS_ERR_MULTIPLE_STATE_INPUTS" --separate-stderr f
+  [[ "$stderr" == *"-S"* ]]
+}
+
+# bats test_tags=hs_resolve_state_inputs
+@test "_hs_resolve_state_inputs rejects an identically repeated -S option" {
+  # shellcheck disable=SC2329
+  f() {
+    local -a __hs_remaining=()
+    local -A __hs_processed=()
+    _hs_resolve_state_inputs my_helper qS: -S state -S state
+  }
+  run -"$HS_ERR_MULTIPLE_STATE_INPUTS" --separate-stderr f
+  [[ "$stderr" == *"-S"* ]]
+}
+
+# bats test_tags=hs_persist_state
+@test "hs_persist_state rejects adjacent repeated -S options" {
+  # shellcheck disable=SC2329
+  f() {
+    local state1="" state2=""
+    local myvar="hello"
+    : "$myvar"
+    hs_persist_state -S state1 -S state2 -- myvar
+  }
+  run -"$HS_ERR_MULTIPLE_STATE_INPUTS" --separate-stderr f
+  [[ "$stderr" == *"-S"* ]]
+}
+
+# bats test_tags=hs_destroy_state
+@test "hs_destroy_state rejects repeated -S options spaced by a non-option word" {
+  # shellcheck disable=SC2329
+  f() {
+    local state1="" state2=""
+    hs_destroy_state -S state1 extra_arg -S state2 -- myvar
+  }
+  run -"$HS_ERR_MULTIPLE_STATE_INPUTS" --separate-stderr f
+  [[ "$stderr" == *"-S"* ]]
+}
+
+# bats test_tags=hs_read_persisted_state
+@test "hs_read_persisted_state rejects repeated -S options spaced by -q" {
+  # shellcheck disable=SC2329
+  f() {
+    local state1="" state2=""
+    : "$state1" "$state2"
+    hs_read_persisted_state -S state1 -q -S state2
+  }
+  run -"$HS_ERR_MULTIPLE_STATE_INPUTS" --separate-stderr f
+  [[ "$stderr" == *"-S"* ]]
+}
+
 # ---------------------------------------------------------------------------
 # hs_persist_state
 
@@ -1412,6 +1474,7 @@ hs2_corrupt_state() {
     local temp=""
     init() { local foo=one bar=two; hs_persist_state -S "$1" -- foo bar || return $?; }
     init temp || return $?
+    # shellcheck disable=SC2178
     local __hs_processed="$temp"
     hs_destroy_state -S __hs_processed -- foo
   }


### PR DESCRIPTION
Add HS_ERR_MULTIPLE_STATE_INPUTS=3 to the Errors sections of hs_persist_state,
hs_destroy_state, and hs_read_persisted_state in both the source file headers
and docs/libraries/handle_state.rst. The error code was declared but never
referenced; issue #106 (Option A) wires it up by detecting a repeated -S.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>