### PR TITLE
feat(command_guard): implement name=path syntax in guard (issue #111)

### DIFF
--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -89,12 +89,32 @@ guard() {
         return 0
     fi
 
-    # First pass: validate all commands
-    local cmd full_path
+    # First pass: validate all tokens (plain names and name=path pairs)
+    local cmd full_path name fixed_path
     local -a valid_commands=()
     local -a full_paths=()
 
     for cmd in "${commands[@]}"; do
+        if [[ "$cmd" == *=* ]]; then
+            name="${cmd%%=*}"
+            fixed_path="${cmd#*=}"
+            if ! [[ "$name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+                echo "[ERROR] guard: invalid command identifier '$name'." >&2
+                return "$CG_ERR_INVALID_NAME"
+            fi
+            if [[ "${fixed_path:0:1}" != "/" ]]; then
+                echo "[ERROR] guard: '$name': path must be an absolute path." >&2
+                [[ "$BASHPID" != "$$" ]] && exit "$CG_ERR_NOT_FOUND" || return "$CG_ERR_NOT_FOUND"
+            fi
+            if [[ ! -x "$fixed_path" ]]; then
+                echo "[ERROR] guard: unable to resolve full path for '$name'. Use the full path." >&2
+                [[ "$BASHPID" != "$$" ]] && exit "$CG_ERR_NOT_FOUND" || return "$CG_ERR_NOT_FOUND"
+            fi
+            valid_commands+=("$name")
+            full_paths+=("$fixed_path")
+            continue
+        fi
+
         if ! [[ "$cmd" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
             echo "[ERROR] guard: invalid command identifier '$cmd'." >&2
             return "$CG_ERR_INVALID_NAME"

--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -41,23 +41,29 @@ _cg_resolve_command_path() {
 #   Defines a function named <command> that shadows the external command and
 #   dispatches to it by full path with all arguments forwarded.
 # Usage:
-#   guard [-q] [--] [command ...]
+#   guard [-q] [--] [token ...]
 # Options:
 #   -q  Quiet mode: suppress warnings when guard is called without any commands
-#   --  End of options, start of command list
-# Examples:
-#   guard uname
-#   guard uname date hostname
-#   guard -q  # no warning
-#   guard -- uname -login  # Treats "-login" as a command name
+#   --  End of options, start of token list
+# Tokens:
+#   Each token is either a plain command name or a name=path pair.
+#   Plain name:  guard uname             — resolved via restricted PATH (command -pv)
+#   name=path:   guard uname=/usr/bin/uname — pinned to the given absolute path,
+#                bypassing PATH resolution. name must be a valid Bash identifier;
+#                path must be absolute and point to an existing executable file.
+#   Both forms may be mixed: guard "uname=/usr/bin/uname" date hostname
 # Errors:
-#   CG_ERR_INVALID_NAME, CG_ERR_NOT_FOUND
+#   - CG_ERR_INVALID_NAME if a name is not a valid Bash identifier, or an unknown
+#     option is passed.
+#   - CG_ERR_NOT_FOUND if a plain command cannot be resolved, or a name=path token
+#     has a non-absolute, non-existent, or non-executable path.
 # Notes:
-#   Uses a restricted PATH ("/usr/bin:/bin") in a subshell to resolve the command.
-#   This avoids resolving through user-controlled PATH entries.
-#
-#   This function uses eval to define the shadowing function; input is validated
-#   to be a legal Bash identifier before eval is invoked.
+#   Validation is all-or-nothing: no wrapper functions are created unless every
+#   token is valid.
+#   Uses a restricted PATH in a subshell to resolve plain names, avoiding
+#   user-controlled PATH entries.
+#   Uses eval to define the shadowing function; input is validated to be a legal
+#   Bash identifier before eval is invoked.
 guard() {
     local quiet=false
     local -a commands=()

--- a/docs/libraries/command_guard.rst
+++ b/docs/libraries/command_guard.rst
@@ -34,20 +34,34 @@ guard
 Defines a function named `<command>` that forwards to the external command by
 full path.
 
-- Usage: `guard [-q] [--] [command ...]`
+- Usage: `guard [-q] [--] [token ...]`
 - Options:
   - `-q`: Quiet mode, suppresses warnings for zero commands.
-  - `--`: End of options, start of command list.
+  - `--`: End of options, start of token list.
+- Tokens: each token is either a plain command name or a ``name=path`` pair:
+  - **Plain name** (e.g. ``uname``): the command is resolved via the builtin
+    restricted PATH using ``command -pv``.
+  - **name=path** (e.g. ``uname=/usr/bin/uname``): the command function is
+    pinned to the specified absolute path, bypassing PATH resolution entirely.
+    The ``name`` must be a valid Bash identifier. The ``path`` must be absolute
+    (start with ``/``) and point to an existing, executable file.
+  - Both forms may be mixed freely in a single ``guard`` call.
+  - Validation is all-or-nothing: no wrapper functions are created unless
+    every token passes validation.
 - Returns:
-  - `0` on success, including when zero commands are provided (with optional warning).
-  - `CG_ERR_INVALID_NAME` when an option is invalid or a command name is not a valid Bash identifier.
-  - `CG_ERR_NOT_FOUND` when a command cannot be resolved to an executable path.
+  - ``0`` on success, including when zero tokens are provided (with optional warning).
+  - ``CG_ERR_INVALID_NAME`` when an option is invalid, a command name is not a
+    valid Bash identifier, or the ``name`` part of a ``name=path`` token is not
+    a valid Bash identifier.
+  - ``CG_ERR_NOT_FOUND`` when a plain command cannot be resolved, or the ``path``
+    part of a ``name=path`` token does not exist, is not executable, or is not
+    an absolute path.
 
 Error Codes
 -----------
 
-- `CG_ERR_INVALID_NAME=2`: invalid command name or option.
-- `CG_ERR_NOT_FOUND=3`: command not found in the restricted PATH.
+- ``CG_ERR_INVALID_NAME=2``: invalid command identifier or option.
+- ``CG_ERR_NOT_FOUND=3``: command not found or path invalid/non-executable.
 
 Behavior Details
 ----------------

--- a/test/test-command_guard.bats
+++ b/test/test-command_guard.bats
@@ -165,18 +165,16 @@ setup_file() {
 
 # --- PR#2: Custom path syntax (should fail initially) ---
 
-# bats test_tags=guard,pr2
+# bats test_tags=guard,pr2,xfail
 @test "PR#2: guard accepts cmd=path syntax" {
-  skip "Feature not yet implemented - PR#2"
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard "uname=/usr/bin/uname"
   '
 }
 
-# bats test_tags=guard,pr2
+# bats test_tags=guard,pr2,xfail
 @test "PR#2: custom path command creates wrapper function" {
-  skip "Feature not yet implemented - PR#2"
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard "uname=/usr/bin/uname"
@@ -184,9 +182,8 @@ setup_file() {
   '
 }
 
-# bats test_tags=guard,pr2
+# bats test_tags=guard,pr2,xfail
 @test "PR#2: custom path command executes with specified path" {
-  skip "Feature not yet implemented - PR#2"
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard "uname=/usr/bin/uname"
@@ -195,9 +192,8 @@ setup_file() {
   '
 }
 
-# bats test_tags=guard,pr2
+# bats test_tags=guard,pr2,xfail
 @test "PR#2: mix of custom path and regular commands" {
-  skip "Feature not yet implemented - PR#2"
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard "uname=/usr/bin/uname" date hostname
@@ -207,9 +203,8 @@ setup_file() {
   '
 }
 
-# bats test_tags=guard,pr2
+# bats test_tags=guard,pr2,xfail
 @test "PR#2: custom path with nonexistent file fails" {
-  skip "Feature not yet implemented - PR#2"
   # shellcheck disable=SC2016
   run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
     guard "badcmd=/nonexistent/path/badcmd"
@@ -217,9 +212,8 @@ setup_file() {
   [[ "$output" == *"unable to resolve"* ]]
 }
 
-# bats test_tags=guard,pr2
+# bats test_tags=guard,pr2,xfail
 @test "PR#2: custom path with non-executable fails" {
-  skip "Feature not yet implemented - PR#2"
   # shellcheck disable=SC2016
   run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
     tmpfile=$(mktemp)
@@ -228,9 +222,8 @@ setup_file() {
   '
 }
 
-# bats test_tags=guard,pr2
+# bats test_tags=guard,pr2,xfail
 @test "PR#2: custom path with relative path fails" {
-  skip "Feature not yet implemented - PR#2"
   # shellcheck disable=SC2016
   run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
     guard "cmd=../bin/cmd"
@@ -238,9 +231,8 @@ setup_file() {
   [[ "$output" == *"absolute path"* ]]
 }
 
-# bats test_tags=guard,pr2
+# bats test_tags=guard,pr2,xfail
 @test "PR#2: invalid syntax in cmd=path fails gracefully" {
-  skip "Feature not yet implemented - PR#2"
   # shellcheck disable=SC2016
   run -"$CG_ERR_INVALID_NAME" bash --noprofile -lc '
     guard "bad-name=/usr/bin/test"

--- a/test/test-command_guard.bats
+++ b/test/test-command_guard.bats
@@ -165,7 +165,7 @@ setup_file() {
 
 # --- PR#2: Custom path syntax (should fail initially) ---
 
-# bats test_tags=guard,pr2,xfail
+# bats test_tags=guard,pr2
 @test "PR#2: guard accepts cmd=path syntax" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
@@ -173,7 +173,7 @@ setup_file() {
   '
 }
 
-# bats test_tags=guard,pr2,xfail
+# bats test_tags=guard,pr2
 @test "PR#2: custom path command creates wrapper function" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
@@ -182,17 +182,17 @@ setup_file() {
   '
 }
 
-# bats test_tags=guard,pr2,xfail
+# bats test_tags=guard,pr2
 @test "PR#2: custom path command executes with specified path" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
-    guard "uname=/usr/bin/uname"
-    out="$(uname)"
+    guard "kernel=/usr/bin/uname"
+    out="$(kernel -s)"
     [ -n "$out" ]
   '
 }
 
-# bats test_tags=guard,pr2,xfail
+# bats test_tags=guard,pr2
 @test "PR#2: mix of custom path and regular commands" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
@@ -203,7 +203,7 @@ setup_file() {
   '
 }
 
-# bats test_tags=guard,pr2,xfail
+# bats test_tags=guard,pr2
 @test "PR#2: custom path with nonexistent file fails" {
   # shellcheck disable=SC2016
   run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
@@ -212,17 +212,15 @@ setup_file() {
   [[ "$output" == *"unable to resolve"* ]]
 }
 
-# bats test_tags=guard,pr2,xfail
+# bats test_tags=guard,pr2
 @test "PR#2: custom path with non-executable fails" {
-  # shellcheck disable=SC2016
-  run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
-    tmpfile=$(mktemp)
-    guard "notexec=$tmpfile"
-    rm -f "$tmpfile"
-  '
+  local tmpfile
+  tmpfile=$(mktemp)
+  run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc "guard 'notexec=${tmpfile}'"
+  rm -f "$tmpfile"
 }
 
-# bats test_tags=guard,pr2,xfail
+# bats test_tags=guard,pr2
 @test "PR#2: custom path with relative path fails" {
   # shellcheck disable=SC2016
   run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
@@ -231,7 +229,7 @@ setup_file() {
   [[ "$output" == *"absolute path"* ]]
 }
 
-# bats test_tags=guard,pr2,xfail
+# bats test_tags=guard,pr2
 @test "PR#2: invalid syntax in cmd=path fails gracefully" {
   # shellcheck disable=SC2016
   run -"$CG_ERR_INVALID_NAME" bash --noprofile -lc '

--- a/test/test-command_guard.bats
+++ b/test/test-command_guard.bats
@@ -106,10 +106,10 @@ setup_file() {
   [[ "$output" != *"inside"* ]]
   [[ "$stderr" == "[BUG] guard: 'myalias' is an alias"* ]]
 }
-# --- PR#1: Multiple commands support (should fail initially) ---
+# --- Multiple commands support ---
 
 # bats test_tags=guard,pr1
-@test "PR#1: guard accepts multiple commands" {
+@test "guard accepts multiple commands" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard uname date hostname
@@ -117,7 +117,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr1
-@test "PR#1: multiple commands all create wrapper functions" {
+@test "multiple commands all create wrapper functions" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard uname date hostname
@@ -128,7 +128,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr1
-@test "PR#1: multiple guarded commands execute correctly" {
+@test "multiple guarded commands execute correctly" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard uname echo
@@ -140,7 +140,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr1
-@test "PR#1: failure in one command stops processing, acts as no-op" {
+@test "failure in one command stops processing, acts as no-op" {
   # shellcheck disable=SC2016
   run bash --noprofile -lc '
     guard uname nonexistent_xyz date
@@ -153,7 +153,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr1
-@test "PR#1: backward compatible with single command" {
+@test "backward compatible with single command" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard uname
@@ -163,10 +163,10 @@ setup_file() {
   '
 }
 
-# --- PR#2: Custom path syntax (should fail initially) ---
+# --- name=path token syntax ---
 
 # bats test_tags=guard,pr2
-@test "PR#2: guard accepts cmd=path syntax" {
+@test "guard accepts cmd=path syntax" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard "uname=/usr/bin/uname"
@@ -174,7 +174,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr2
-@test "PR#2: custom path command creates wrapper function" {
+@test "custom path command creates wrapper function" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard "uname=/usr/bin/uname"
@@ -183,7 +183,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr2
-@test "PR#2: custom path command executes with specified path" {
+@test "custom path command executes with specified path" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard "kernel=/usr/bin/uname"
@@ -193,7 +193,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr2
-@test "PR#2: mix of custom path and regular commands" {
+@test "mix of custom path and regular commands" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard "uname=/usr/bin/uname" date hostname
@@ -204,7 +204,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr2
-@test "PR#2: custom path with nonexistent file fails" {
+@test "custom path with nonexistent file fails" {
   # shellcheck disable=SC2016
   run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
     guard "badcmd=/nonexistent/path/badcmd"
@@ -213,7 +213,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr2
-@test "PR#2: custom path with non-executable fails" {
+@test "custom path with non-executable fails" {
   local tmpfile
   tmpfile=$(mktemp)
   run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc "guard 'notexec=${tmpfile}'"
@@ -221,7 +221,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr2
-@test "PR#2: custom path with relative path fails" {
+@test "custom path with relative path fails" {
   # shellcheck disable=SC2016
   run -"$CG_ERR_NOT_FOUND" bash --noprofile -lc '
     guard "cmd=../bin/cmd"
@@ -230,7 +230,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr2
-@test "PR#2: invalid syntax in cmd=path fails gracefully" {
+@test "invalid syntax in cmd=path fails gracefully" {
   # shellcheck disable=SC2016
   run -"$CG_ERR_INVALID_NAME" bash --noprofile -lc '
     guard "bad-name=/usr/bin/test"
@@ -238,11 +238,11 @@ setup_file() {
   [[ "$output" == *"invalid command identifier"* ]]
 }
 
-# --- PR#3: PATH enforcement and debug trap (should fail initially) ---
+# --- PATH enforcement and debug trap ---
 
 # bats test_tags=guard,pr3
-@test "PR#3: original PATH is saved on source" {
-  skip "Feature not yet implemented - PR#3"
+@test "original PATH is saved on source" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     original="$PATH"
@@ -253,8 +253,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: PATH is unset after sourcing" {
-  skip "Feature not yet implemented - PR#3"
+@test "PATH is unset after sourcing" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     source "$LIB"
@@ -264,8 +264,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: non-guarded command fails when PATH unset" {
-  skip "Feature not yet implemented - PR#3"
+@test "non-guarded command fails when PATH unset" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run -127 bash --noprofile -lc '
     source "$LIB"
@@ -274,8 +274,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: guarded command works despite unset PATH" {
-  skip "Feature not yet implemented - PR#3"
+@test "guarded command works despite unset PATH" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     source "$LIB"
@@ -286,8 +286,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: debug trap catches non-guarded command in debug mode" {
-  skip "Feature not yet implemented - PR#3"
+@test "debug trap catches non-guarded command in debug mode" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run -127 --separate-stderr bash --noprofile -lc '
     set -x
@@ -298,8 +298,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: debug trap suggests guard command with path" {
-  skip "Feature not yet implemented - PR#3"
+@test "debug trap suggests guard command with path" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run --separate-stderr bash --noprofile -lc '
     set -x
@@ -310,8 +310,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: debug trap uses default PATH for suggestions" {
-  skip "Feature not yet implemented - PR#3"
+@test "debug trap uses default PATH for suggestions" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run --separate-stderr bash --noprofile -lc '
     set -x
@@ -323,8 +323,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: debug trap falls back to original PATH" {
-  skip "Feature not yet implemented - PR#3"
+@test "debug trap falls back to original PATH" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run --separate-stderr bash --noprofile -lc '
     export PATH="/custom/bin:$PATH"
@@ -337,8 +337,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: debug trap does not trigger for guarded commands" {
-  skip "Feature not yet implemented - PR#3"
+@test "debug trap does not trigger for guarded commands" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
     set -x
@@ -350,8 +350,8 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr3
-@test "PR#3: debug trap does not trigger for builtins" {
-  skip "Feature not yet implemented - PR#3"
+@test "debug trap does not trigger for builtins" {
+  skip "Feature not yet implemented"
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
     set -x
@@ -361,10 +361,10 @@ setup_file() {
   [[ "$stderr" != *"WARNING: Non-guarded command"* ]]
 }
 
-# --- PR#4: Zero commands and options support (should fail initially) ---
+# --- Zero commands and options support ---
 
 # bats test_tags=guard,pr4
-@test "PR#4: guard with zero commands emits warning and returns 0" {
+@test "guard with zero commands emits warning and returns 0" {
 
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
@@ -374,7 +374,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr4
-@test "PR#4: guard with -q suppresses warnings for zero commands" {
+@test "guard with -q suppresses warnings for zero commands" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
     guard -q
@@ -383,7 +383,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr4
-@test "PR#4: guard with -- separates options from commands" {
+@test "guard with -- separates options from commands" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard -- uname
@@ -392,7 +392,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr4
-@test "PR#4: guard with -q -- suppresses warnings and separates options" {
+@test "guard with -q -- suppresses warnings and separates options" {
   # shellcheck disable=SC2016
   run -0 --separate-stderr bash --noprofile -lc '
     guard -q --
@@ -402,7 +402,7 @@ setup_file() {
 }
 
 # bats test_tags=guard,pr4
-@test "PR#4: guard backward compatible with single command after options" {
+@test "guard backward compatible with single command after options" {
   # shellcheck disable=SC2016
   run -0 bash --noprofile -lc '
     guard -q -- uname


### PR DESCRIPTION
## Summary

- Adds the `name=path` token form to `guard()`: `guard "uname=/usr/bin/uname"` pins the wrapper to a specified absolute path, bypassing PATH resolution entirely.
- Validation is all-or-nothing (consistent with existing behavior): no wrapper functions are created unless every token passes validation.
- `name` must be a valid Bash identifier; `path` must be absolute and point to an existing executable file.
- Plain name and `name=path` tokens may be freely mixed in a single `guard` call.
- All 8 PR#2 xfail tests are now active and passing; non-executable test restructured to avoid exit-code reset.

## Test plan

- [x] `bats --filter-tags '!xfail' test/test-command_guard.bats` — 36 tests, all pass
- [x] PR#2 tests: `guard` accepts `cmd=path` syntax, creates wrapper, executes with specified path, mixes forms, rejects nonexistent/non-executable/relative paths, rejects invalid name in `name=path`
- [x] No regression in existing guard, PR#1, or PR#4 tests

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)