### PR TITLE
feat(scm): add PR change history sections to all tracked files (closes #43)

### DIFF
--- a/.github/skills/bash-library-template/history.md
+++ b/.github/skills/bash-library-template/history.md
@@ -1,0 +1,6 @@
+# Change History
+
+| PR  | Closes | Summary |
+|-----|--------|---------|
+| #22 | —      | initial creation |
+| #23 | —      | feature/skills update |

--- a/.github/skills/bash-path-prefix-scan/history.md
+++ b/.github/skills/bash-path-prefix-scan/history.md
@@ -1,0 +1,6 @@
+# Change History
+
+| PR  | Closes | Summary |
+|-----|--------|---------|
+| #22 | —      | initial creation |
+| #23 | —      | feature/skills update |

--- a/.github/skills/github-issues/history.md
+++ b/.github/skills/github-issues/history.md
@@ -1,0 +1,5 @@
+# Change History
+
+| PR  | Closes | Summary |
+|-----|--------|---------|
+| —   | —      | initial creation (pre-PR-workflow) |

--- a/.github/skills/handle-state/history.md
+++ b/.github/skills/handle-state/history.md
@@ -1,0 +1,7 @@
+# Change History
+
+| PR  | Closes | Summary |
+|-----|--------|---------|
+| #23 | —      | feature/skills update |
+| #38 | —      | do not return state via stdout |
+| #63 | #62    | refactor safer handle-state restoration flow |

--- a/.github/skills/skill-creator/history.md
+++ b/.github/skills/skill-creator/history.md
@@ -1,0 +1,6 @@
+# Change History
+
+| PR  | Closes | Summary |
+|-----|--------|---------|
+| #22 | —      | initial creation |
+| #23 | —      | feature/skills update |

--- a/.github/skills/software-configuration-management/history.md
+++ b/.github/skills/software-configuration-management/history.md
@@ -1,0 +1,17 @@
+# Change History
+
+This file tracks which product or process PRs drove changes to the
+software-configuration-management skill files. It is never referenced
+from skill content and is not loaded into Claude's context.
+
+| PR  | Closes | Skill files changed | Process change |
+|-----|--------|---------------------|----------------|
+| #22 | —      | ALL (initial creation) | initial SCM skill framework |
+| #23 | —      | ALL | feature/skills update |
+| #29 | #25    | SKILL.md | fix duplicated headers |
+| #31 | #30    | SKILL.md | remove manual merge instructions |
+| #37 | —      | SKILL.md, implementation-workflow.md, templates.md | document meta-task path |
+| #45 | —      | SKILL.md | prohibit direct commits to main |
+| #52 | #51    | ALL references | restructure task selection; add TDD, planning, integration phases |
+| #114 | #112  | references/pr-threads.sh | add pr-threads helper script (added during PATH enforcement PR) |
+| #43 | —      | templates.md, implementation.md, integration.md | introduce per-file change history sections |

--- a/.github/skills/software-configuration-management/references/implementation.md
+++ b/.github/skills/software-configuration-management/references/implementation.md
@@ -31,6 +31,7 @@ This task covers source code implementation, edge-cases tests expansion, testing
 ## Prepare for Review
 - **Objective**: Surface the work for maintainers' review.
 - **Activities**:
+  - Update the change history section of every file modified by this PR, following the templates in `templates.md`. For skill files, update the skill directory's `history.md` instead of the skill file itself. Use `gh api repos/{owner}/{repo}/pulls/{n}/files` to confirm the exact set of changed files — do not rely on `git log`.
   - Open a PR with a descriptive title and body referencing the issue.
   - Assign the **maintainers team** as reviewers (@CriticalOptimisation/maintainers).
   - Link the original issue and summarize the changes.

--- a/.github/skills/software-configuration-management/references/integration.md
+++ b/.github/skills/software-configuration-management/references/integration.md
@@ -19,6 +19,7 @@ This segment covers final integration and post-implementation validation.
 - **Objective**: Confirm the change stabilizes in the repository.
 - **Activities**:
   - Monitor for regressions or failures triggered by the merge.
+  - Confirm that change history entries are present and accurate in all files modified by the PR, and that `history.md` files are present in all skill directories touched by the PR.
   - Update release notes or communication channels if required.
   - Archive or delete the feature branch if the work is complete (GitHub may have already deleted it).
 - **Completion**: Issue is marked resolved and all follow-ups addressed.

--- a/.github/skills/software-configuration-management/references/templates.md
+++ b/.github/skills/software-configuration-management/references/templates.md
@@ -88,3 +88,56 @@ Related to #456
 - Common patterns
 - Troubleshooting
 - Best practices
+
+## Change History Section Templates
+
+Every file modified by a PR must carry a change history section. The format depends on the file type. Add one row per PR in ascending PR-number order. Use the GitHub API (`gh api repos/{owner}/{repo}/pulls/{n}/files`) to confirm which files a PR actually changed — do not rely on `git log`.
+
+### Shell and BATS files (`.sh`, `.bats`)
+
+Place after the last executable statement, before EOF. The `return 0` guards against accidental direct execution and marks the boundary between executable content and metadata.
+
+```bash
+return 0
+
+# --- Change History -------------------------------------------------------
+# | PR     | Summary                                                       |
+# |--------|---------------------------------------------------------------|
+# | #N     | one-line description                                          |
+```
+
+### RST documentation files (`.rst`)
+
+Place at the end of the file. The `..` RST comment directive causes Sphinx to discard the block entirely; it never surfaces in built HTML or PDF output.
+
+```rst
+..
+
+   Change History
+
+   | PR     | Summary                                                       |
+   |--------|---------------------------------------------------------------|
+   | #N     | one-line description                                          |
+```
+
+### Skills `history.md` (SCM skill — tracks product→process causality)
+
+A standalone file in the skill directory, **never referenced from skill content**. Records which product or process PRs drove each change to the skill files.
+
+```markdown
+# Change History
+
+| PR  | Closes | Skill files changed | Process change |
+|-----|--------|---------------------|----------------|
+| #N  | #M     | filename.md         | one-line description |
+```
+
+### Skills `history.md` (all other skills)
+
+```markdown
+# Change History
+
+| PR  | Closes | Summary |
+|-----|--------|---------|
+| #N  | #M     | one-line description |
+```

--- a/.github/skills/software-configuration-management/references/templates.md
+++ b/.github/skills/software-configuration-management/references/templates.md
@@ -115,10 +115,12 @@ Place at the end of the file. The `..` RST comment directive causes Sphinx to di
 
    Change History
 
-   | PR     | Summary                                                       |
-   |--------|---------------------------------------------------------------|
-   | #N     | one-line description                                          |
+   PR     Summary
+   -----  -----------------------------------------------------------------
+   #N     one-line description
 ```
+
+Note: pipe-table syntax (`| col |`) must not be used inside RST `..` comments — the RST parser expands `|...|` as substitution references even inside comment blocks. Use plain aligned text columns instead.
 
 ### Skills `history.md` (SCM skill — tracks product→process causality)
 

--- a/.github/skills/sphinx-docs/history.md
+++ b/.github/skills/sphinx-docs/history.md
@@ -1,0 +1,5 @@
+# Change History
+
+| PR  | Closes | Summary |
+|-----|--------|---------|
+| —   | —      | initial creation (pre-PR-workflow) |

--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -446,3 +446,17 @@ cg_guard() {
 if ! declare -f guard >/dev/null 2>&1; then
     guard() { cg_guard "$@"; }
 fi
+
+return 0
+
+# --- Change History -------------------------------------------------------
+# | PR    | Summary                                                        |
+# |-------|----------------------------------------------------------------|
+# | #8    | initial library                                                |
+# | #18   | multiple arguments support in guard function                   |
+# | #23   | feature/skills update                                          |
+# | #84   | remove unused CG_ERR_MISSING_COMMAND [closes #24]              |
+# | #86   | shellcheck: quote args, fix source annotations [closes #85]    |
+# | #113  | name=path guard token syntax [closes #111]                     |
+# | #114  | PATH enforcement API — cg_safe_run, cg_unsafe [closes #112]    |
+# | #118  | name filter and snap search API [closes #116, #117]            |

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -812,3 +812,25 @@ _hs_hs2_parse() {
     IFS=$'\001' read -ra __hs2p_out <<< "$__hs2p_payload"
     IFS="$__hs2p_old_ifs"
 }
+
+return 0
+
+# --- Change History -------------------------------------------------------
+# | PR    | Summary                                                        |
+# |-------|----------------------------------------------------------------|
+# | #32   | batch security fixes: guard commands [closes #7]               |
+# | #38   | do not return state via stdout                                 |
+# | #60   | use ${BASH:-bash} for collision-check subprocess [closes #59]  |
+# | #63   | refactor safer handle-state restoration flow [closes #62]      |
+# | #83   | fix hs_destroy_state rebuild subprocess helper [closes #82]    |
+# | #87   | fix top-of-file usage example, IFS-safe join [closes #64]      |
+# | #88   | clarify hs_persist_state_as_code as opaque token [closes #65]  |
+# | #89   | describe sandboxed eval and nameref restore [closes #68]       |
+# | #92   | replace non-standard hs_read_persisted_state example [cls #75] |
+# | #93   | rename probe-snippet to implicit local restore [closes #76]    |
+# | #99   | error on undeclared variable names [closes #1]                 |
+# | #102  | guard nameref restore against undeclared variables [cls #100]  |
+# | #103  | reject function names with HS_ERR_UNKNOWN_VAR_NAME             |
+# | #105  | fix hs_persist_state dropping indexed array elements [cls #3]  |
+# | #109  | reduce nameref collision surface [closes #104]                 |
+# | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |

--- a/docs/libraries/command_guard.rst
+++ b/docs/libraries/command_guard.rst
@@ -713,3 +713,15 @@ Source Listing
 .. literalinclude:: ../../config/command_guard.sh
    :language: bash
    :linenos:
+
+..
+
+   Change History
+
+   PR     Summary
+   -----  -----------------------------------------------------------------
+   #8     initial documentation
+   #23    feature/skills update
+   #113   name=path guard token syntax [closes #111]
+   #114   PATH enforcement API -- cg_safe_run, cg_unsafe [closes #112]
+   #118   name filter and snap search API [closes #116, #117]

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -414,3 +414,28 @@ Source Listing
 .. literalinclude:: ../../config/handle_state.sh
    :language: bash
    :linenos:
+
+..
+
+   Change History
+
+   PR     Summary
+   -----  -----------------------------------------------------------------
+   #23    feature/skills update
+   #32    batch security fixes [closes #7]
+   #38    do not return state via stdout
+   #63    refactor safer handle-state restoration flow [closes #62]
+   #83    fix hs_destroy_state rebuild subprocess helper [closes #82]
+   #90    remove internal-format mention, convenience form non-preferred
+   #91    add forwarded-args eval example for probe-snippet mode
+   #93    rename probe-snippet to implicit local restore [closes #76]
+   #94    emphasize implicit restore snippet is safe local code
+   #95    clarify caller evaluates probe code, not transmitted state
+   #96    add -S calling context to Examples section [closes #80]
+   #98    remove caveat implying raw eval of state is valid [closes #81]
+   #99    error on undeclared variable names [closes #1]
+   #102   guard nameref restore against undeclared variables [closes #100]
+   #103   reject function names with HS_ERR_UNKNOWN_VAR_NAME
+   #105   fix hs_persist_state dropping indexed array elements [closes #3]
+   #109   reduce nameref collision surface [closes #104]
+   #110   document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points

--- a/docs/libraries/index.rst
+++ b/docs/libraries/index.rst
@@ -9,3 +9,12 @@ pieces they ship.
 
    handle_state
    command_guard
+
+..
+
+   Change History
+
+   PR     Summary
+   -----  -----------------------------------------------------------------
+   #8     add command_guard to library index
+   #109   reduce nameref collision surface [closes #104]

--- a/test/test-command_guard.bats
+++ b/test/test-command_guard.bats
@@ -1011,3 +1011,17 @@ setup() {
   }
   run -0 f
 }
+
+return 0
+
+# --- Change History -------------------------------------------------------
+# | PR    | Summary                                                        |
+# |-------|----------------------------------------------------------------|
+# | #8    | initial library                                                |
+# | #18   | multiple arguments support in guard function                   |
+# | #23   | feature/skills update                                          |
+# | #84   | remove unused CG_ERR_MISSING_COMMAND [closes #24]              |
+# | #86   | shellcheck: quote args, fix source annotations [closes #85]    |
+# | #113  | name=path guard token syntax [closes #111]                     |
+# | #114  | PATH enforcement API — cg_safe_run, cg_unsafe [closes #112]    |
+# | #118  | name filter and snap search API [closes #116, #117]            |

--- a/test/test-file-structure.bats
+++ b/test/test-file-structure.bats
@@ -20,12 +20,6 @@ _last_code_line() {
 # Shell / BATS files — must end with "return 0" then a history block
 # ---------------------------------------------------------------------------
 
-SHELL_FILES=(
-  config/command_guard.sh
-  config/handle_state.sh
-  test/test-command_guard.bats
-  test/test-hs_persist_state.bats
-)
 
 # bats test_tags=structure,history,issue-43
 @test "config/command_guard.sh: last code line is return 0" {
@@ -90,15 +84,6 @@ SHELL_FILES=(
 # Skills directories — must each contain a history.md file
 # ---------------------------------------------------------------------------
 
-SKILL_DIRS=(
-  .github/skills/software-configuration-management
-  .github/skills/handle-state
-  .github/skills/bash-library-template
-  .github/skills/bash-path-prefix-scan
-  .github/skills/skill-creator
-  .github/skills/github-issues
-  .github/skills/sphinx-docs
-)
 
 # bats test_tags=structure,history,issue-43
 @test "software-configuration-management skill has history.md" {
@@ -134,3 +119,10 @@ SKILL_DIRS=(
 @test "sphinx-docs skill has history.md" {
   [[ -f "$ROOT/.github/skills/sphinx-docs/history.md" ]]
 }
+
+return 0
+
+# --- Change History -------------------------------------------------------
+# | PR    | Summary                                                        |
+# |-------|----------------------------------------------------------------|
+# | #43   | initial file — structural tests for PR change history sections |

--- a/test/test-file-structure.bats
+++ b/test/test-file-structure.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+
+# Structural tests: verify change history sections are present in all
+# files that require them (issue #43).
+# Run with: bats test/test-file-structure.bats
+
+setup_file() {
+  bats_require_minimum_version 1.5.0
+  export ROOT="$BATS_TEST_DIRNAME/.."
+}
+
+# ---------------------------------------------------------------------------
+# Helper: last non-comment, non-blank line of a shell file
+# ---------------------------------------------------------------------------
+_last_code_line() {
+  grep -v "^[[:space:]]*#" "$1" | grep -v "^[[:space:]]*$" | tail -1
+}
+
+# ---------------------------------------------------------------------------
+# Shell / BATS files — must end with "return 0" then a history block
+# ---------------------------------------------------------------------------
+
+SHELL_FILES=(
+  config/command_guard.sh
+  config/handle_state.sh
+  test/test-command_guard.bats
+  test/test-hs_persist_state.bats
+)
+
+# bats test_tags=structure,history,issue-43
+@test "config/command_guard.sh: last code line is return 0" {
+  [[ "$(_last_code_line "$ROOT/config/command_guard.sh")" == "return 0" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "config/command_guard.sh: change history block present" {
+  grep -q "^# --- Change History" "$ROOT/config/command_guard.sh"
+}
+
+# bats test_tags=structure,history,issue-43
+@test "config/handle_state.sh: last code line is return 0" {
+  [[ "$(_last_code_line "$ROOT/config/handle_state.sh")" == "return 0" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "config/handle_state.sh: change history block present" {
+  grep -q "^# --- Change History" "$ROOT/config/handle_state.sh"
+}
+
+# bats test_tags=structure,history,issue-43
+@test "test/test-command_guard.bats: last code line is return 0" {
+  [[ "$(_last_code_line "$ROOT/test/test-command_guard.bats")" == "return 0" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "test/test-command_guard.bats: change history block present" {
+  grep -q "^# --- Change History" "$ROOT/test/test-command_guard.bats"
+}
+
+# bats test_tags=structure,history,issue-43
+@test "test/test-hs_persist_state.bats: last code line is return 0" {
+  [[ "$(_last_code_line "$ROOT/test/test-hs_persist_state.bats")" == "return 0" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "test/test-hs_persist_state.bats: change history block present" {
+  grep -q "^# --- Change History" "$ROOT/test/test-hs_persist_state.bats"
+}
+
+# ---------------------------------------------------------------------------
+# RST files — must contain an RST comment block with "Change History"
+# ---------------------------------------------------------------------------
+
+# bats test_tags=structure,history,issue-43
+@test "docs/libraries/command_guard.rst: change history RST comment present" {
+  grep -q "Change History" "$ROOT/docs/libraries/command_guard.rst"
+}
+
+# bats test_tags=structure,history,issue-43
+@test "docs/libraries/handle_state.rst: change history RST comment present" {
+  grep -q "Change History" "$ROOT/docs/libraries/handle_state.rst"
+}
+
+# bats test_tags=structure,history,issue-43
+@test "docs/libraries/index.rst: change history RST comment present" {
+  grep -q "Change History" "$ROOT/docs/libraries/index.rst"
+}
+
+# ---------------------------------------------------------------------------
+# Skills directories — must each contain a history.md file
+# ---------------------------------------------------------------------------
+
+SKILL_DIRS=(
+  .github/skills/software-configuration-management
+  .github/skills/handle-state
+  .github/skills/bash-library-template
+  .github/skills/bash-path-prefix-scan
+  .github/skills/skill-creator
+  .github/skills/github-issues
+  .github/skills/sphinx-docs
+)
+
+# bats test_tags=structure,history,issue-43
+@test "software-configuration-management skill has history.md" {
+  [[ -f "$ROOT/.github/skills/software-configuration-management/history.md" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "handle-state skill has history.md" {
+  [[ -f "$ROOT/.github/skills/handle-state/history.md" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "bash-library-template skill has history.md" {
+  [[ -f "$ROOT/.github/skills/bash-library-template/history.md" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "bash-path-prefix-scan skill has history.md" {
+  [[ -f "$ROOT/.github/skills/bash-path-prefix-scan/history.md" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "skill-creator skill has history.md" {
+  [[ -f "$ROOT/.github/skills/skill-creator/history.md" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "github-issues skill has history.md" {
+  [[ -f "$ROOT/.github/skills/github-issues/history.md" ]]
+}
+
+# bats test_tags=structure,history,issue-43
+@test "sphinx-docs skill has history.md" {
+  [[ -f "$ROOT/.github/skills/sphinx-docs/history.md" ]]
+}

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1530,3 +1530,21 @@ hs2_corrupt_state() {
   [[ "$count" -ge 1 ]]  # guards against vacuous pass when --list-reserved is broken
   [[ "$count" -le 2 ]]  # regression guard: target is exactly 2 (__hs_remaining, __hs_processed)
 }
+
+return 0
+
+# --- Change History -------------------------------------------------------
+# | PR    | Summary                                                        |
+# |-------|----------------------------------------------------------------|
+# | #38   | do not return state via stdout                                 |
+# | #60   | use ${BASH:-bash} for collision-check subprocess [closes #59]  |
+# | #63   | refactor safer handle-state restoration flow [closes #62]      |
+# | #83   | fix hs_destroy_state rebuild subprocess helper [closes #82]    |
+# | #86   | shellcheck fixes [closes #85]                                  |
+# | #99   | error on undeclared variable names [closes #1]                 |
+# | #102  | guard nameref restore against undeclared variables [cls #100]  |
+# | #103  | reject function names with HS_ERR_UNKNOWN_VAR_NAME             |
+# | #105  | fix hs_persist_state dropping indexed array elements [cls #3]  |
+# | #108  | fix shellcheck linter errors in bats file [closes #107]        |
+# | #109  | reduce nameref collision surface [closes #104]                 |
+# | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |


### PR DESCRIPTION
## Summary

- Add `return 0` + `# --- Change History ---` comment block to all shell library and test files (`config/*.sh`, `test/*.bats`), back-filled from PR history via GitHub API
- Add RST `..` comment block with plain-text change history table to all library documentation files (`docs/libraries/*.rst`); pipe-table format avoided — RST parser expands `|---|` as substitution references even inside comments
- Create `history.md` in each skill directory (7 files), never referenced from skill content; SCM skill uses a richer product→process causality schema
- Update `templates.md` with canonical history-section templates for all three file types (including the RST pipe-table warning)
- Update `implementation.md` to require updating history before opening a PR; update `integration.md` to validate history presence post-merge
- Add `test/test-file-structure.bats` (18 structural tests) that verify `return 0`, history blocks, and `history.md` files are in place

## Test plan

- [x] `bats test/test-command_guard.bats` — 86 tests pass (unchanged)
- [x] `bats test/test-hs_persist_state.bats` — 97 tests pass (unchanged)
- [x] `bats test/test-file-structure.bats` — 18 new structural tests all pass
- [x] Sphinx build (`python3 -m sphinx docs/ docs/_build/html`) — clean, only pre-existing `_static` warning

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)