### PR TITLE
bug(scm): remove top-level return 0 from library files; fix SC2317

### DIFF
--- a/.github/skills/remote-run/history.md
+++ b/.github/skills/remote-run/history.md
@@ -3,4 +3,4 @@
 | PR   | Closes | Summary |
 |------|--------|---------|
 | #126 | #58    | initial skill — rr_init / rr_run / rr_resolve / rr_cleanup API |
-| #TBD | #133   | add history.md; add structural tests in test-file-structure.bats |
+| #134 | #133   | add history.md; add structural tests in test-file-structure.bats |

--- a/.github/skills/remote-run/history.md
+++ b/.github/skills/remote-run/history.md
@@ -1,0 +1,6 @@
+# Change History
+
+| PR   | Closes | Summary |
+|------|--------|---------|
+| #126 | #58    | initial skill — rr_init / rr_run / rr_resolve / rr_cleanup API |
+| #TBD | #133   | add history.md; add structural tests in test-file-structure.bats |

--- a/.github/skills/software-configuration-management/history.md
+++ b/.github/skills/software-configuration-management/history.md
@@ -15,4 +15,4 @@ from skill content and is not loaded into Claude's context.
 | #52 | #51    | ALL references | restructure task selection; add TDD, planning, integration phases |
 | #114 | #112  | references/pr-threads.sh | add pr-threads helper script (added during PATH enforcement PR) |
 | #43 | —      | templates.md, implementation.md, integration.md | introduce per-file change history sections |
-| #TBD | #133  | implementation.md | add new-library checklist: skill command + history.md + structural tests |
+| #134 | #133  | implementation.md | add new-library checklist: skill command + history.md + structural tests |

--- a/.github/skills/software-configuration-management/history.md
+++ b/.github/skills/software-configuration-management/history.md
@@ -15,3 +15,4 @@ from skill content and is not loaded into Claude's context.
 | #52 | #51    | ALL references | restructure task selection; add TDD, planning, integration phases |
 | #114 | #112  | references/pr-threads.sh | add pr-threads helper script (added during PATH enforcement PR) |
 | #43 | —      | templates.md, implementation.md, integration.md | introduce per-file change history sections |
+| #TBD | #133  | implementation.md | add new-library checklist: skill command + history.md + structural tests |

--- a/.github/skills/software-configuration-management/references/implementation.md
+++ b/.github/skills/software-configuration-management/references/implementation.md
@@ -32,6 +32,12 @@ This task covers source code implementation, edge-cases tests expansion, testing
 - **Objective**: Surface the work for maintainers' review.
 - **Activities**:
   - Update the change history section of every file modified by this PR, following the templates in `templates.md`. For skill files, update the skill directory's `history.md` instead of the skill file itself. Use `gh api repos/{owner}/{repo}/pulls/{n}/files` to confirm the exact set of changed files — do not rely on `git log`.
+  - **New library checklist** — when a PR introduces a new library (a new `.sh` file in `config/`), verify all of the following are present before opening the PR:
+    - `docs/libraries/<name>.rst` — Sphinx documentation
+    - `test/test-<name>.bats` — test suite
+    - `.claude/commands/<name>.md` — Claude skill command file
+    - `.github/skills/<name>/history.md` — skill change-history file
+    - Structural tests in `test/test-file-structure.bats` covering all four companion files above and the library `.sh` itself (last code line NOT `return 0`, change history block present).
   - Open a PR with a descriptive title and body referencing the issue.
   - Assign the **maintainers team** as reviewers (@CriticalOptimisation/maintainers).
   - Link the original issue and summarize the changes.

--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -468,8 +468,6 @@ if ! declare -f guard >/dev/null 2>&1; then
     guard() { cg_guard "$@"; }
 fi
 
-return 0
-
 # --- Change History -------------------------------------------------------
 # | PR    | Summary                                                        |
 # |-------|----------------------------------------------------------------|
@@ -482,3 +480,4 @@ return 0
 # | #114  | PATH enforcement API — cg_safe_run, cg_unsafe [closes #112]    |
 # | #118  | name filter and snap search API [closes #116, #117]            |
 # | #127  | gated trap-EXIT wrapper for async kill-propagation [closes #127] |
+# | #TBD  | remove top-level return 0 — fixes SC2317 in sourcing files [closes #133] |

--- a/config/command_guard.sh
+++ b/config/command_guard.sh
@@ -480,4 +480,4 @@ fi
 # | #114  | PATH enforcement API — cg_safe_run, cg_unsafe [closes #112]    |
 # | #118  | name filter and snap search API [closes #116, #117]            |
 # | #127  | gated trap-EXIT wrapper for async kill-propagation [closes #127] |
-# | #TBD  | remove top-level return 0 — fixes SC2317 in sourcing files [closes #133] |
+# | #134  | remove top-level return 0 — fixes SC2317 in sourcing files [closes #133] |

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -817,8 +817,6 @@ _hs_hs2_parse() {
     IFS="$__hs2p_old_ifs"
 }
 
-return 0
-
 # --- Change History -------------------------------------------------------
 # | PR    | Summary                                                        |
 # |-------|----------------------------------------------------------------|
@@ -838,3 +836,4 @@ return 0
 # | #105  | fix hs_persist_state dropping indexed array elements [cls #3]  |
 # | #109  | reduce nameref collision surface [closes #104]                 |
 # | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |
+# | #TBD  | remove top-level return 0 — fixes SC2317 in sourcing files [closes #133] |

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -836,4 +836,4 @@ _hs_hs2_parse() {
 # | #105  | fix hs_persist_state dropping indexed array elements [cls #3]  |
 # | #109  | reduce nameref collision surface [closes #104]                 |
 # | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |
-# | #TBD  | remove top-level return 0 — fixes SC2317 in sourcing files [closes #133] |
+# | #134  | remove top-level return 0 — fixes SC2317 in sourcing files [closes #133] |

--- a/config/remote_run.sh
+++ b/config/remote_run.sh
@@ -628,4 +628,4 @@ rr_cleanup() {
 # | PR    | Summary                                                        |
 # |-------|----------------------------------------------------------------|
 # | #126  | initial library — rr_init, rr_run, rr_resolve, rr_cleanup      |
-# | #TBD  | no top-level return 0; SC2015 suppressions; change history [closes #133] |
+# | #134  | no top-level return 0; SC2015 suppressions; change history [closes #133] |

--- a/config/remote_run.sh
+++ b/config/remote_run.sh
@@ -496,10 +496,12 @@ rr_run() {
     # FIFOs avoid coproc fd-inheritance races.  Both are opened O_RDWR so that
     # neither open(2) blocks waiting for the other side.
     local _fifo_in _fifo_out
+    # shellcheck disable=SC2015 # Error handler runs if mktemp or mkfifo fails
     _fifo_in=$(mktemp -u) && mkfifo "$_fifo_in" || {
         echo "[ERROR] rr_run: cannot create protocol FIFO" >&2
         return 1
     }
+    # shellcheck disable=SC2015 # Error handler runs if mktemp or mkfifo fails
     _fifo_out=$(mktemp -u) && mkfifo "$_fifo_out" || {
         rm -f "$_fifo_in"
         echo "[ERROR] rr_run: cannot create protocol FIFO" >&2
@@ -621,3 +623,9 @@ rr_cleanup() {
         hs_destroy_state -S "$_out_var" -- _rr_ssh_opts_str _rr_whitelist_str || return $?
     fi
 }
+
+# --- Change History -------------------------------------------------------
+# | PR    | Summary                                                        |
+# |-------|----------------------------------------------------------------|
+# | #126  | initial library — rr_init, rr_run, rr_resolve, rr_cleanup      |
+# | #TBD  | no top-level return 0; SC2015 suppressions; change history [closes #133] |

--- a/test/test-file-structure.bats
+++ b/test/test-file-structure.bats
@@ -170,4 +170,4 @@ return 0
 # | PR    | Summary                                                        |
 # |-------|----------------------------------------------------------------|
 # | #43   | initial file — structural tests for PR change history sections |
-# | #TBD  | invert return-0 assertions; add full remote_run coverage [closes #133] |
+# | #134  | invert return-0 assertions; add full remote_run coverage [closes #133] |

--- a/test/test-file-structure.bats
+++ b/test/test-file-structure.bats
@@ -17,13 +17,18 @@ _last_code_line() {
 }
 
 # ---------------------------------------------------------------------------
-# Shell / BATS files — must end with "return 0" then a history block
+# Library .sh files — must NOT end with "return 0"
+#   Static analysis inlines sourced files (# shellcheck source=); a top-level
+#   "return 0" at the end of the inlined content is treated as an unconditional
+#   return in the calling file, making every subsequent definition unreachable
+#   (SC2317).  The implicit exit-0 of the last function definition suffices.
+# BATS test files — must end with "return 0" then a history block
+#   (bats sources test files; explicit return 0 keeps source exit-clean)
 # ---------------------------------------------------------------------------
 
-
-# bats test_tags=structure,history,issue-43
-@test "config/command_guard.sh: last code line is return 0" {
-  [[ "$(_last_code_line "$ROOT/config/command_guard.sh")" == "return 0" ]]
+# bats test_tags=structure,history,issue-43,issue-133
+@test "config/command_guard.sh: last code line is NOT return 0" {
+  [[ "$(_last_code_line "$ROOT/config/command_guard.sh")" != "return 0" ]]
 }
 
 # bats test_tags=structure,history,issue-43
@@ -31,14 +36,24 @@ _last_code_line() {
   grep -q "^# --- Change History" "$ROOT/config/command_guard.sh"
 }
 
-# bats test_tags=structure,history,issue-43
-@test "config/handle_state.sh: last code line is return 0" {
-  [[ "$(_last_code_line "$ROOT/config/handle_state.sh")" == "return 0" ]]
+# bats test_tags=structure,history,issue-43,issue-133
+@test "config/handle_state.sh: last code line is NOT return 0" {
+  [[ "$(_last_code_line "$ROOT/config/handle_state.sh")" != "return 0" ]]
 }
 
 # bats test_tags=structure,history,issue-43
 @test "config/handle_state.sh: change history block present" {
   grep -q "^# --- Change History" "$ROOT/config/handle_state.sh"
+}
+
+# bats test_tags=structure,history,issue-133
+@test "config/remote_run.sh: last code line is NOT return 0" {
+  [[ "$(_last_code_line "$ROOT/config/remote_run.sh")" != "return 0" ]]
+}
+
+# bats test_tags=structure,history,issue-131,issue-133
+@test "config/remote_run.sh: change history block present" {
+  grep -q "^# --- Change History" "$ROOT/config/remote_run.sh"
 }
 
 # bats test_tags=structure,history,issue-43
@@ -61,6 +76,16 @@ _last_code_line() {
   grep -q "^# --- Change History" "$ROOT/test/test-hs_persist_state.bats"
 }
 
+# bats test_tags=structure,history,issue-131,issue-133
+@test "test/test-remote_run.bats: last code line is return 0" {
+  [[ "$(_last_code_line "$ROOT/test/test-remote_run.bats")" == "return 0" ]]
+}
+
+# bats test_tags=structure,history,issue-131,issue-133
+@test "test/test-remote_run.bats: change history block present" {
+  grep -q "^# --- Change History" "$ROOT/test/test-remote_run.bats"
+}
+
 # ---------------------------------------------------------------------------
 # RST files — must contain an RST comment block with "Change History"
 # ---------------------------------------------------------------------------
@@ -78,6 +103,11 @@ _last_code_line() {
 # bats test_tags=structure,history,issue-43
 @test "docs/libraries/index.rst: change history RST comment present" {
   grep -q "Change History" "$ROOT/docs/libraries/index.rst"
+}
+
+# bats test_tags=structure,history,issue-131,issue-133
+@test "docs/libraries/remote_run.rst: change history RST comment present" {
+  grep -q "Change History" "$ROOT/docs/libraries/remote_run.rst"
 }
 
 # ---------------------------------------------------------------------------
@@ -120,9 +150,24 @@ _last_code_line() {
   [[ -f "$ROOT/.github/skills/sphinx-docs/history.md" ]]
 }
 
+# bats test_tags=structure,history,issue-131,issue-133
+@test "remote-run skill has history.md" {
+  [[ -f "$ROOT/.github/skills/remote-run/history.md" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Claude skill files (.claude/commands/) — must be present for each library
+# ---------------------------------------------------------------------------
+
+# bats test_tags=structure,history,issue-131,issue-133
+@test "remote-run Claude skill file present" {
+  [[ -f "$ROOT/.claude/commands/remote-run.md" ]]
+}
+
 return 0
 
 # --- Change History -------------------------------------------------------
 # | PR    | Summary                                                        |
 # |-------|----------------------------------------------------------------|
 # | #43   | initial file — structural tests for PR change history sections |
+# | #TBD  | invert return-0 assertions; add full remote_run coverage [closes #133] |


### PR DESCRIPTION
Closes #133
Also closes #131 (adds missing `config/remote_run.sh` change history section)

## Summary

- `config/command_guard.sh`, `config/handle_state.sh`: remove terminal `return 0` — ShellCheck inlines sourced files via `# shellcheck source=`; the top-level `return 0` at the end of the inlined content was treated as an unconditional return in `remote_run.sh`'s scope, flagging every subsequent `rr_*` function as SC2317 (unreachable). The statement was never needed for correctness.
- `config/remote_run.sh`: add two `# shellcheck disable=SC2015` suppressions for `mktemp && mkfifo || { … }` error handlers; add the missing change history section (issue #131).
- `test/test-file-structure.bats`: invert "last code line is return 0" to "is NOT return 0" for library `.sh` files (regression guard); add full structural coverage for `remote_run.sh` and its four companion files; add a new "Claude skill files" section with a test for `.claude/commands/remote-run.md`.
- `.github/skills/remote-run/history.md`: create missing skill history file.
- `implementation.md` (SCM skill): add **new-library checklist** so future library additions cannot silently omit the companion RST doc, test bats, Claude command file, `history.md`, and structural tests.

## Test plan

- [x] `bats test/test-file-structure.bats` — 25/25 pass
- [x] Two inverted tests (tests 1 & 3) confirmed **failing** before `return 0` removal, **passing** after (TDD red→green)
- [ ] Full test suite (`bats test/`) passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)