### PR TITLE
doc+test(ensure_docker): Task 4 — Stage 1 & 2 documentation and preliminary tests (issue #132)

### DIFF
--- a/.claude/commands/ensure-docker.md
+++ b/.claude/commands/ensure-docker.md
@@ -51,6 +51,7 @@ Do **not** use this library when:
 | 16 | `ED_ERR_VERSION_NOT_FOUND` | No APT candidate matches constraint |
 | 19 | `ED_ERR_DEPENDENCY_MISSING` | Library failed to load |
 | 20 | `ED_ERR_ALREADY_INSTALLED` | Docker present; `--update` not set |
+| 21 | `ED_ERR_HOST_INCOMPATIBLE` | Version exists in APT but host cannot install it (OS/arch/deps); caller should try DinD or `rr_run` |
 
 ## Dependencies
 

--- a/.claude/commands/ensure-docker.md
+++ b/.claude/commands/ensure-docker.md
@@ -1,0 +1,70 @@
+---
+description: Guide for using the ensure_docker.sh library to detect, install, and manage the Docker engine lifecycle on local or remote hosts. Triggers when the task involves checking Docker presence, installing Docker via APT, uninstalling Docker, or managing Docker version constraints and rollback.
+---
+
+# Ensure Docker Library Skill
+
+## When to Use
+
+Use `ensure_docker.sh` when you need to:
+- Check whether Docker (engine + Compose plugin) is present and meets a
+  version constraint — `ed_has_docker`.
+- Install or upgrade Docker on a host (Debian/Ubuntu) — `ed_install_docker`.
+- Uninstall Docker entirely — `ed_uninstall_docker`.
+- Idempotently ensure Docker is available and track the change for later
+  rollback — `ed_ensure_docker` (Stage 2).
+
+The library can be called locally **or** wrapped inside `rr_run` to operate
+on a remote host without copying any file there.
+
+Do **not** use this library when:
+- The host is not Debian/Ubuntu (APT-based); the snap/rpm paths are out of
+  scope for Stage 1.
+- You need Docker for image builds or container management — use `ds_build_image`
+  from `docker_service.sh` (#128) instead.
+
+## Core Reference
+
+`docs/libraries/ensure_docker.rst` — full API documentation.
+`config/ensure_docker.sh` — implementation.
+
+## Version Constraint Syntax
+
+```
+>=A.B.C,<D.E.F    range
+>=A.B.C            lower bound
+<D.E.F             upper bound
+=A.B.C             exact match
+=A.B               equivalent to >=A.B.0,<A.(B+1).0
+```
+
+## Error Codes
+
+| Code | Name | Meaning |
+|-----:|------|---------|
+| 7  | `ED_ERR_INSUFFICIENT_PRIVILEGE` | Not root |
+| 8  | `ED_ERR_MISSING_ARGUMENT` | Mandatory `-S` missing |
+| 9  | `ED_ERR_SYNTAX_ERROR` | Bad option or malformed constraint |
+| 13 | `ED_ERR_NO_DOCKER` | Docker absent or unreachable |
+| 14 | `ED_ERR_NO_COMPOSE` | Compose plugin missing |
+| 15 | `ED_ERR_WRONG_VERSION` | Constraint not satisfied |
+| 16 | `ED_ERR_VERSION_NOT_FOUND` | No APT candidate matches constraint |
+| 19 | `ED_ERR_DEPENDENCY_MISSING` | Library failed to load |
+| 20 | `ED_ERR_ALREADY_INSTALLED` | Docker present; `--update` not set |
+
+## Dependencies
+
+| Module | Role |
+|--------|------|
+| `command_guard.sh` | Guarded commands: `docker`, `apt-get`, `apt-cache`, `curl`, `id` |
+| `handle_state.sh` | Stage 2 state management only |
+
+## Key Constraints
+
+- The library **never escalates privileges**; callers must already be root
+  when calling `ed_install_docker` or `ed_uninstall_docker`.
+- `ed_install_docker` is **not idempotent** — use `ed_ensure_docker` when
+  idempotency is required.
+- CVE-based version selection is reserved for a future PR; the current
+  implementation always selects the newest APT candidate satisfying the
+  constraint.

--- a/.github/skills/ensure-docker/history.md
+++ b/.github/skills/ensure-docker/history.md
@@ -2,4 +2,4 @@
 
 | PR   | Closes | Summary |
 |------|--------|---------|
-| #TBD | #132   | initial skill — Stage 1 API documented |
+| #135 | #132   | initial skill — Stage 1 API documented |

--- a/.github/skills/ensure-docker/history.md
+++ b/.github/skills/ensure-docker/history.md
@@ -1,0 +1,5 @@
+# Change History
+
+| PR   | Closes | Summary |
+|------|--------|---------|
+| #TBD | #132   | initial skill — Stage 1 API documented |

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -223,10 +223,11 @@ token is unchanged — there is nothing to undo.  On success, the state
 token is updated atomically to reflect the completed operation.
 
 **``ed_ensure_docker`` is not idempotent.**
-Every call unconditionally appends one new node to the chain and persists
-the updated state, even when Docker is already present and no system change
-is needed.  Each caller owns exactly one node and must match it with a
-single ``ed_cleanup`` call when the host is decommissioned.
+Every **successful** call appends one new node to the chain and persists
+the updated state, even when Docker was already present and no system
+change was needed.  A failed call leaves state unchanged and adds no node.
+Each caller owns exactly one node per successful call and must match it
+with a single ``ed_cleanup`` call when the host is decommissioned.
 
 Stage 2 State Variable Schema
 ------------------------------
@@ -339,11 +340,12 @@ ed_ensure_docker
 
 ``ed_ensure_docker -S <state_var> [[--update] [version_constraint]]``
 
-Restores state, then unconditionally appends one new node to the chain.
-This function is **not idempotent**: every call creates a node regardless
-of whether Docker was already present or any system change was made.  Each
-caller is responsible for issuing exactly one matching ``ed_cleanup`` call
-when the host is decommissioned.
+Restores state, then ensures Docker is present and satisfies the given
+constraint, then appends one new node to the chain.  This function is
+**not idempotent**: every **successful** call creates exactly one node,
+even when Docker was already present and no system change was needed.
+Each caller is responsible for issuing exactly one matching ``ed_cleanup``
+call when the host is decommissioned.  A failed call never modifies state.
 
 Behaviour:
 

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -218,6 +218,18 @@ the entry point, after all system operations have completed.  On any
 failure path the function returns without calling ``hs_persist_state``,
 leaving the state token identical to what was passed in.
 
+Implementation pattern::
+
+    local _new_state=""
+    hs_persist_state -S _new_state -- chain node_commit node_cons \
+        commit_ver commit_comp next_seq
+    printf -v "$_state_var" '%s' "$_new_state"
+
+``hs_persist_state`` writes into a fresh local (no prior state → no
+collision possible).  The final ``printf -v`` copies the serialised token
+into the caller's variable in a single Bash string assignment — atomic in
+the Bash memory model.
+
 **Consequence.**  On failure, the system is unchanged *and* the state
 token is unchanged — there is nothing to undo.  On success, the state
 token is updated atomically to reflect the completed operation.

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -182,12 +182,49 @@ Errors:
 
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: not root.
 
-Public API — Stage 2
---------------------
+Stage 2 State Variable Schema
+-----------------------------
 
 .. note::
    Stage 2 functions are not yet implemented.  Their API is documented here
    for planning purposes; they will be added in a subsequent PR.
+
+Stage 2 functions persist state via ``handle_state.sh`` using three
+associative arrays and one scalar.
+
+``_ed_chain`` *(associative array)*
+  Forward-linked list.  Each key is a git-commit hash (or the sentinel
+  string ``"none"`` representing the pre-Docker state); each value is the
+  git-commit hash of the *next* Docker installation.
+
+  Example after two ``ed_ensure_docker`` calls:
+
+  .. code-block:: text
+
+     _ed_chain["none"]    = "abc1234"   # Docker was absent; installed abc1234
+     _ed_chain["abc1234"] = "def5678"   # later updated to def5678
+     _ed_chain["def5678"] = ""          # terminal node
+
+``_ed_docker_ver`` *(associative array)*
+  Maps each git-commit hash to the Docker engine semantic version string
+  that was installed at that commit, e.g. ``_ed_docker_ver["abc1234"] = "24.0.7"``.
+
+``_ed_compose_ver`` *(associative array)*
+  Maps each git-commit hash to the Compose plugin semantic version string,
+  e.g. ``_ed_compose_ver["abc1234"] = "2.20.0"``.
+
+``_ed_head`` *(scalar)*
+  The git-commit hash at the tip of ``_ed_chain`` (the currently installed
+  Docker version), or ``"none"`` when Docker is not installed.
+
+The action implied by any commit is determined from the chain structure
+alone: a predecessor of ``"none"`` means the commit was the first
+installation (reverting → uninstall); any other predecessor means it was
+an update (reverting → downgrade to that predecessor's version via
+``_ed_docker_ver``).
+
+Public API — Stage 2
+--------------------
 
 ed_ensure_docker
 ~~~~~~~~~~~~~~~~
@@ -195,8 +232,11 @@ ed_ensure_docker
 ``ed_ensure_docker -S <state_var> [[--update] [version_constraint]]``
 
 Idempotent wrapper around ``ed_has_docker`` and ``ed_install_docker``.
-The ``-S`` state variable records whether Docker was installed or updated so
-that ``ed_cleanup`` can reverse the action later.
+On success, appends the newly installed commit to ``_ed_chain``, records
+its version data in ``_ed_docker_ver`` and ``_ed_compose_ver``, and
+updates ``_ed_head``.  When Docker was already present and no action was
+needed, ``_ed_head`` is set to the current commit and the chain gains one
+entry (the current state) if it was previously empty.
 
 ed_docker_version
 ~~~~~~~~~~~~~~~~~
@@ -204,18 +244,36 @@ ed_docker_version
 ``ed_docker_version -S <state_var> [-b] [-v] [-c]``
 
 Returns version information about the currently installed Docker engine.
+Reads ``_ed_head`` from state, then queries the live Docker process for
+the requested fields.
 
-- ``-b``: hex git-commit hash from ``docker version --format '{{.Server.GitCommit}}'``.
-- ``-v``: engine semantic version.
-- ``-c``: Compose plugin semantic version.
+- ``-b``: git-commit hash — ``docker version --format '{{.Server.GitCommit}}'``.
+- ``-v``: engine semantic version — ``docker version --format '{{.Server.Version}}'``.
+- ``-c``: Compose plugin version — ``docker compose version --short``.
+
+No flags is equivalent to ``-b -v -c``; output order follows flag order.
 
 ed_cleanup
 ~~~~~~~~~~
 
 ``ed_cleanup -S <state_var> [build_number]``
 
-Reverses the last action recorded by ``ed_ensure_docker``: uninstalls Docker
-if it was installed, or downgrades if it was updated.
+Reverses the last action recorded by ``ed_ensure_docker``.
+
+If ``build_number`` is given it must be present in ``_ed_chain`` as a key;
+otherwise ``ED_ERR_WRONG_VERSION`` is returned.
+
+The revert algorithm traverses ``_ed_chain`` from ``"none"`` to find the
+predecessor of ``_ed_head``:
+
+- Predecessor is ``"none"`` → Docker was installed by this library;
+  call ``ed_uninstall_docker``.
+- Predecessor is a commit hash → Docker was updated; call
+  ``ed_install_docker --update "$(_ed_docker_ver[$predecessor])"``
+  to downgrade.
+
+On success, removes ``_ed_head`` from the chain and version maps, and
+updates ``_ed_head`` to the predecessor.
 
 ..
 

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -320,29 +320,48 @@ helper it calls.  The convention is therefore:
 
 The accessor surface:
 
+Calling convention
+  All five state arrays live in the caller's frame and are accessed
+  directly by the helpers via Bash dynamic scoping — no parameter
+  decoding needed for reads or writes.
+
+  Getter helpers write their result into a **predefined output variable**
+  whose name is part of the helper's calling convention (documented
+  below).  Because calls are sequential, the caller saves the result into
+  a local variable before the next getter call overwrites the output
+  variable.  Mutators and deleters have no output variable.
+
 .. code-block:: bash
 
    # Chain (forward-pointer AA)
-   _ed_chain_get  key            # → stdout: chain[key]
+   #   reads/writes chain[] directly via dynamic scoping
+   #   getters write result into __ed_value (scalar)
+   _ed_chain_get  key            # __ed_value = chain[key]
    _ed_chain_put  key value      # chain[key]=value
    _ed_chain_del  key            # unset chain[key]
-   _ed_chain_pred target         # → stdout: key k where chain[k]==target
-                                 #   (traverses from "none"; fails if not found)
+   _ed_chain_pred target         # __ed_value = k where chain[k]==target
+                                 #   (traverses from "none"; fails → return 1)
 
    # Node record  (node_commit + node_cons)
+   #   reads/writes node_commit[] and node_cons[] via dynamic scoping
+   #   getters write result into __ed_value (scalar)
    _ed_node_put    seq commit cons   # write both fields
-   _ed_node_commit seq               # → stdout: node_commit[seq]
-   _ed_node_cons   seq               # → stdout: node_cons[seq]
+   _ed_node_commit seq               # __ed_value = node_commit[seq]
+   _ed_node_cons   seq               # __ed_value = node_cons[seq]
    _ed_node_del    seq               # unset both fields
 
    # Commit record  (commit_ver + commit_comp)
+   #   reads/writes commit_ver[] and commit_comp[] via dynamic scoping
+   #   getters write result into __ed_value (scalar)
    _ed_commit_put     hash docker_ver compose_ver   # write both fields
-   _ed_commit_docker  hash                          # → stdout: commit_ver[hash]
-   _ed_commit_compose hash                          # → stdout: commit_comp[hash]
+   _ed_commit_docker  hash                          # __ed_value = commit_ver[hash]
+   _ed_commit_compose hash                          # __ed_value = commit_comp[hash]
    _ed_commit_del     hash                          # unset both fields
 
    # Sequence counter
-   _ed_seq_alloc      # increments next_seq; → stdout: new value
+   #   reads/writes next_seq via dynamic scoping
+   #   writes result into __ed_seq (scalar)
+   _ed_seq_alloc      # increments next_seq; __ed_seq = new value
 
 Public API — Stage 2
 --------------------
@@ -438,9 +457,11 @@ Revert algorithm:
      installed by this library → call ``ed_uninstall_docker``.
    - ``P == "none"`` and nodes remain, or ``P`` is a seq number: check
      whether current Docker version satisfies all remaining
-     ``node_cons`` values.  If not, call
-     ``ed_install_docker --update "$(_ed_commit_docker "$(_ed_node_commit "$P")")"``
-     to downgrade.  If yes, no system change.
+     ``node_cons`` values.  If not, call ``_ed_node_commit "$P"`` (result
+     in ``__ed_value``), then ``_ed_commit_docker "$__ed_value"`` (result
+     in ``__ed_value``), then
+     ``ed_install_docker --update "$__ed_value"`` to downgrade.
+     If yes, no system change.
 
 5. Remove ``T`` from chain and node maps (``_ed_node_del``, ``_ed_chain_del``).
    Remove commit record only if no other node references the same commit.

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -1,0 +1,226 @@
+Ensure Docker Library
+=====================
+
+Location
+--------
+
+- ``config/ensure_docker.sh``
+
+Purpose
+-------
+
+``ensure_docker.sh`` manages the Docker engine lifecycle on the local host:
+detection, installation, uninstallation, and version-tracked cleanup.  It is
+designed to be called via ``rr_run`` so the same operations can be applied
+transparently to a remote host without any file being copied there.
+
+The library is organised in two stages:
+
+- **Stage 1** — atomic functions that have no side-effects on library state:
+  ``ed_has_docker``, ``ed_install_docker``, ``ed_uninstall_docker``.
+- **Stage 2** — state-managed functions that compose Stage 1 with
+  ``handle_state.sh`` for idempotency and rollback:
+  ``ed_ensure_docker``, ``ed_docker_version``, ``ed_cleanup``.
+
+Dependencies
+------------
+
++-------------------+---------------------------------+
+| Dependency        | Notes                           |
++===================+=================================+
+| ``command_guard.sh`` | Guarded at source time:      |
+|                   | ``docker``, ``apt-get``,        |
+|                   | ``apt-cache``, ``curl``, ``id`` |
++-------------------+---------------------------------+
+| ``handle_state.sh`` | Stage 2 functions only.       |
+|                   | Sourced automatically.          |
++-------------------+---------------------------------+
+| Docker CE APT repo | Required by ``ed_install_docker``|
+|                   | on Debian/Ubuntu hosts.         |
++-------------------+---------------------------------+
+| Bash ≥ 4.3        | Nameref support in              |
+|                   | ``handle_state.sh``.            |
++-------------------+---------------------------------+
+
+All command-guard dependencies are verified at source time.  If any required
+tool is absent the library fails to load and returns
+``ED_ERR_DEPENDENCY_MISSING``.
+
+Quick Start
+-----------
+
+.. code-block:: bash
+
+   source "$(dirname "$0")/config/ensure_docker.sh"
+
+   # Check Docker is present and satisfies a version constraint
+   ed_has_docker ">=24.0.0" || { echo "Docker 24+ required"; exit 1; }
+
+   # Install Docker if absent (requires root)
+   ed_install_docker ">=24.0.0"
+
+   # Idempotent: install only when needed, record action in state (Stage 2)
+   local state=""
+   ed_ensure_docker -S state ">=24.0.0" || return $?
+   # ... use Docker ...
+   ed_cleanup -S state   # restore the host to its prior state
+
+Error Codes
+-----------
+
+- ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: the caller does not have root
+  privilege.  The library never escalates privileges on the caller's behalf.
+- ``ED_ERR_MISSING_ARGUMENT=8``: a mandatory argument (typically ``-S``) was
+  not supplied.
+- ``ED_ERR_SYNTAX_ERROR=9``: an option or the version constraint string is
+  malformed.
+- ``ED_ERR_NO_DOCKER=13``: Docker is absent, unreachable, or not on
+  ``PATH``.
+- ``ED_ERR_NO_COMPOSE=14``: the Docker engine is present but the
+  ``docker compose`` CLI plugin is missing.
+- ``ED_ERR_WRONG_VERSION=15``: Docker is installed but does not satisfy
+  the supplied version constraint.
+- ``ED_ERR_VERSION_NOT_FOUND=16``: no APT candidate satisfies the
+  requested version constraint.
+- ``ED_ERR_VERSION_VULNERABLE=17``: *(reserved — CVE checking deferred to
+  a future PR; currently never returned).*
+- ``ED_ERR_DEPENDENCY_MISSING=19``: the library failed to load because a
+  required tool or dependency library is absent.
+- ``ED_ERR_ALREADY_INSTALLED=20``: ``ed_install_docker`` was called without
+  ``--update`` and Docker is already installed.
+
+Version Constraint Syntax
+--------------------------
+
+All entry points that accept ``[version_constraint]`` recognise the following
+forms, where ``A``, ``B``, ``C`` are non-negative integers:
+
+.. code-block:: text
+
+   >=A.B.C            # at least A.B.C
+   <D.E.F             # strictly below D.E.F
+   >=A.B.C,<D.E.F     # range
+   =A.B.C             # exact match
+   =A.B               # equivalent to >=A.B.0,<A.(B+1).0
+
+Public API — Stage 1
+--------------------
+
+ed_has_docker
+~~~~~~~~~~~~~
+
+``ed_has_docker [version_constraint]``
+
+Checks whether a working Docker engine and Compose plugin are present and
+optionally whether they satisfy a version constraint.  This function has no
+side-effects and does not require root privilege.
+
+Behaviour:
+
+- Calls ``docker version``; on failure returns ``ED_ERR_NO_DOCKER``.
+- Calls ``docker compose version``; on failure returns ``ED_ERR_NO_COMPOSE``.
+- If ``version_constraint`` is given, parses it and compares the live engine
+  version.  Returns ``ED_ERR_WRONG_VERSION`` when not satisfied.
+- Returns ``0`` when Docker and Compose are present and any supplied
+  constraint is met.
+
+Errors:
+
+- ``ED_ERR_NO_DOCKER=13``: Docker absent or unreachable.
+- ``ED_ERR_NO_COMPOSE=14``: Compose plugin missing.
+- ``ED_ERR_WRONG_VERSION=15``: constraint not satisfied.
+- ``ED_ERR_SYNTAX_ERROR=9``: malformed constraint string.
+
+ed_install_docker
+~~~~~~~~~~~~~~~~~
+
+``ed_install_docker [[--update] [version_constraint]]``
+
+Installs Docker CE and the Compose plugin via the official APT repository.
+This function is **not idempotent**: it fails with ``ED_ERR_ALREADY_INSTALLED``
+when Docker is already present and ``--update`` is not set.  Use
+``ed_ensure_docker`` when idempotency is required.
+
+Options:
+
+- ``--update``: upgrade an existing installation.  With ``--update`` and a
+  constraint, the target version is the newest APT candidate satisfying the
+  constraint.  A downgrade is performed when the target is older than the
+  installed version.
+
+Behaviour:
+
+- Checks "already installed" before the privilege check: if Docker is present
+  and ``--update`` is not set, returns ``ED_ERR_ALREADY_INSTALLED`` without
+  requiring root.
+- Verifies caller is root (``id -u == 0``); returns
+  ``ED_ERR_INSUFFICIENT_PRIVILEGE`` otherwise.
+- Idempotently adds the Docker CE APT repository and GPG key.
+- Selects the newest APT candidate satisfying the constraint (or installs the
+  latest stable release when no constraint is given).
+- Installs ``docker-ce``, ``docker-ce-cli``, ``containerd.io``,
+  ``docker-compose-plugin``.
+- Polls ``/var/run/docker.sock`` (up to 30 s) before returning.
+- Verifies the installation by calling ``ed_has_docker [constraint]``.
+
+Errors:
+
+- ``ED_ERR_ALREADY_INSTALLED=20``: Docker present and ``--update`` not set.
+- ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: not root.
+- ``ED_ERR_VERSION_NOT_FOUND=16``: no APT candidate satisfies the constraint.
+- ``ED_ERR_SYNTAX_ERROR=9``: malformed option or constraint.
+
+ed_uninstall_docker
+~~~~~~~~~~~~~~~~~~~
+
+``ed_uninstall_docker``
+
+Purges Docker CE, the CLI, containerd, and the Compose plugin via APT.
+The call is idempotent: purging packages that are already absent exits 0.
+
+Errors:
+
+- ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: not root.
+
+Public API — Stage 2
+--------------------
+
+.. note::
+   Stage 2 functions are not yet implemented.  Their API is documented here
+   for planning purposes; they will be added in a subsequent PR.
+
+ed_ensure_docker
+~~~~~~~~~~~~~~~~
+
+``ed_ensure_docker -S <state_var> [[--update] [version_constraint]]``
+
+Idempotent wrapper around ``ed_has_docker`` and ``ed_install_docker``.
+The ``-S`` state variable records whether Docker was installed or updated so
+that ``ed_cleanup`` can reverse the action later.
+
+ed_docker_version
+~~~~~~~~~~~~~~~~~
+
+``ed_docker_version -S <state_var> [-b] [-v] [-c]``
+
+Returns version information about the currently installed Docker engine.
+
+- ``-b``: hex git-commit hash from ``docker version --format '{{.Server.GitCommit}}'``.
+- ``-v``: engine semantic version.
+- ``-c``: Compose plugin semantic version.
+
+ed_cleanup
+~~~~~~~~~~
+
+``ed_cleanup -S <state_var> [build_number]``
+
+Reverses the last action recorded by ``ed_ensure_docker``: uninstalls Docker
+if it was installed, or downgrades if it was updated.
+
+..
+
+   Change History
+
+   PR     Summary
+   -----  ---------------------------------------------------------------
+   #TBD   initial Stage 1 documentation (issue #132)

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -167,30 +167,34 @@ ed_install_docker
 ``ed_install_docker [[--update] [version_constraint]]``
 
 Installs Docker CE and the Compose plugin via the official APT repository.
-This function is **not idempotent**: it fails with ``ED_ERR_ALREADY_INSTALLED``
-when Docker is already present and ``--update`` is not set.  Use
-``ed_ensure_docker`` when idempotency is required.
+Without ``--update`` the function refuses to run when Docker is already
+present, returning ``ED_ERR_ALREADY_INSTALLED``.  With ``--update`` the
+function is idempotent: if the installed version already satisfies the
+constraint it exits 0 without touching the system.
 
 Options:
 
-- ``--update``: upgrade an existing installation.  With ``--update`` and a
-  constraint, the target version is the newest APT candidate satisfying the
-  constraint.  A downgrade is performed when the target is older than the
-  installed version.
+- ``--update``: allow installation onto a host that already has Docker.
+  With a constraint, the target version is the newest APT candidate
+  satisfying the constraint; a downgrade is performed when the target is
+  older than the installed version.  Without a constraint, the latest
+  stable release is targeted.
 
 Behaviour:
 
-- Checks "already installed" before the privilege check: if Docker is present
-  and ``--update`` is not set, returns ``ED_ERR_ALREADY_INSTALLED`` without
-  requiring root.
+- Checks "already installed" before the privilege check: if Docker is
+  present and ``--update`` is not set, returns ``ED_ERR_ALREADY_INSTALLED``
+  without requiring root.
 - Verifies caller is root (``id -u == 0``); returns
   ``ED_ERR_INSUFFICIENT_PRIVILEGE`` otherwise.
 - Idempotently adds the Docker CE APT repository and GPG key.
-- Selects the newest APT candidate satisfying the constraint (or installs the
-  latest stable release when no constraint is given).
+- Selects the newest APT candidate satisfying the constraint (or installs
+  the latest stable release when no constraint is given).
 - Installs ``docker-ce``, ``docker-ce-cli``, ``containerd.io``,
   ``docker-compose-plugin``.
-- Polls ``/var/run/docker.sock`` (up to 30 s) before returning.
+- Polls the daemon socket (obtained from ``docker context inspect`` —
+  honours custom ``DOCKER_HOST`` / context configuration) for up to 30 s
+  before returning.
 - Verifies the installation by calling ``ed_has_docker [constraint]``.
 
 Errors:
@@ -221,37 +225,64 @@ State Consistency Policy
 This policy applies to every Layer 2 entry point
 (``ed_ensure_docker``, ``ed_docker_version``, ``ed_cleanup``).
 
-**Rule 1 — Full restoration at entry.**
-The very first operation of every stateful entry point is restoring all
-five state variables from the ``-S`` token.  No argument validation,
-constraint checking, or system operation precedes this step.
+**Rule 1 — Two-level structure: entry point and body helper.**
+Every Layer 2 function is split into a thin API entry point and a body
+helper (``_ed_<name>_body``).  The entry point does the minimum work
+needed to extract the ``-S`` token variable name, then immediately copies
+the token value into a local and delegates all further work to the helper:
+
+.. code-block:: bash
+
+    ed_ensure_docker() {
+        # Option processing without getopts — extract -S <token_var> only
+        local __ed_token_var=""
+        # ... decode -S into __ed_token_var, validate it, return on error ...
+        local __ed_state_token="${!__ed_token_var}"
+        _ed_ensure_docker_body "$@" || return $?
+        printf -v "$__ed_token_var" '%s' "$__ed_state_token"
+    }
+
+``${!__ed_token_var}`` is evaluated before ``__ed_state_token`` is
+declared, so even if the caller named their variable ``__ed_state_token``
+the indirection resolves correctly — ``__ed_state_token`` is not in the
+nameref collision space.  Any local declared *before* that line would be
+in the collision space, which is why the entry point declares nothing else.
+
+The body helper accesses ``__ed_state_token`` via dynamic scoping.  It
+restores the six state variables into its own frame, performs all
+validation and system operations, and persists updated state back into
+``__ed_state_token`` on success.  Because the state variables live in the
+helper's frame, not the entry point's, they are never in the entry
+point's collision space.  Within the helper, state variable names are not
+prefixed; all other locals use a ``__ed_`` prefix.
 
 **Rule 2 — Corrupt state is a hard failure.**
-If restoration fails (invalid or corrupted HS2 token), the entry point
-emits an ``[ERROR]`` message to stderr and returns
+If state restoration fails (invalid or corrupted HS2 token), the body
+helper emits an ``[ERROR]`` message to stderr and returns
 ``ED_ERR_CORRUPT_STATE=4``.  Nothing is done to the system.
 
 **Rule 3 — Single persist point on success.**
-``hs_persist_state`` is called exactly once, at the successful exit of
-the entry point, after all system operations have completed.  On any
-failure path the function returns without calling ``hs_persist_state``,
-leaving the state token identical to what was passed in.
+``hs_persist_state`` is called exactly once per body helper, at the
+successful exit path, after all system operations have completed.  On any
+failure path the helper returns without calling ``hs_persist_state``,
+leaving ``__ed_state_token`` (and therefore the caller's variable) unchanged.
 
-Implementation pattern::
+.. code-block:: bash
 
-    local _new_state=""
-    hs_persist_state -S _new_state -- chain node_commit node_cons \
-        commit_ver commit_comp next_seq
-    printf -v "$_state_var" '%s' "$_new_state"
+    # Inside _ed_ensure_docker_body — persist on success only
+    local __ed_new_state=""
+    hs_persist_state -S __ed_new_state -- chain node_commit node_cons \
+        commit_ver commit_comp next_seq || return $?
+    __ed_state_token="$__ed_new_state"
 
 ``hs_persist_state`` writes into a fresh local (no prior state → no
-collision possible).  The final ``printf -v`` copies the serialised token
-into the caller's variable in a single Bash string assignment — atomic in
-the Bash memory model.
+collision possible).  Assigning back to ``__ed_state_token`` propagates
+the result to the entry point, which writes it to the caller's variable
+via ``printf -v``.
 
-**Consequence.**  On failure, the system is unchanged *and* the state
-token is unchanged — there is nothing to undo.  On success, the state
-token is updated atomically to reflect the completed operation.
+**Consequence.**  On failure, the system is unchanged *and* the caller's
+state variable is unchanged — there is nothing to undo.  On success, the
+caller's variable is updated atomically after all operations complete.
 
 **``ed_ensure_docker`` is not idempotent.**
 Every **successful** call appends one new node to the chain and persists

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -480,4 +480,4 @@ Errors:
 
    PR     Summary
    -----  ---------------------------------------------------------------
-   #TBD   initial Stage 1 documentation (issue #132)
+   #135   initial Stage 1 & 2 documentation (issue #132)

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -94,6 +94,9 @@ Error Codes
   not supplied.
 - ``ED_ERR_SYNTAX_ERROR=9``: an option or the version constraint string is
   malformed.
+- ``ED_ERR_RESERVED_VAR_NAME=10``: the name supplied to ``-S`` is reserved
+  for internal use.  Call any Layer 2 entry point with ``--list-reserved``
+  for the current list.
 - ``ED_ERR_NO_DOCKER=13``: Docker is absent, unreachable, or not on
   ``PATH``.
 - ``ED_ERR_NO_COMPOSE=14``: the Docker engine is present but the
@@ -225,60 +228,31 @@ State Consistency Policy
 This policy applies to every Layer 2 entry point
 (``ed_ensure_docker``, ``ed_docker_version``, ``ed_cleanup``).
 
-**Rule 1 — Two-level structure: entry point and body helper.**
-Every Layer 2 function is split into a thin API entry point and a body
-helper (``_ed_<name>_body``).  The entry point does the minimum work
-needed to extract the ``-S`` token variable name, then immediately copies
-the token value into a local and delegates all further work to the helper:
+**Rule 1 — Reserved variable names.**
+The name supplied to ``-S`` must not be one of the names reserved for
+internal use by the entry point.  Passing a reserved name is detected at
+runtime and returns ``ED_ERR_RESERVED_VAR_NAME`` before any system
+operation is attempted.  To obtain the current reserved list
+programmatically:
 
 .. code-block:: bash
 
-    ed_ensure_docker() {
-        # Option processing without getopts — extract -S <token_var> only
-        local __ed_token_var=""
-        # ... decode -S into __ed_token_var, validate it, return on error ...
-        local __ed_state_token="${!__ed_token_var}"
-        _ed_ensure_docker_body "$@" || return $?
-        printf -v "$__ed_token_var" '%s' "$__ed_state_token"
-    }
+    ed_ensure_docker --list-reserved   # prints one name per line, exits 0
 
-``${!__ed_token_var}`` is evaluated before ``__ed_state_token`` is
-declared, so even if the caller named their variable ``__ed_state_token``
-the indirection resolves correctly — ``__ed_state_token`` is not in the
-nameref collision space.  Any local declared *before* that line would be
-in the collision space, which is why the entry point declares nothing else.
-
-The body helper accesses ``__ed_state_token`` via dynamic scoping.  It
-restores the six state variables into its own frame, performs all
-validation and system operations, and persists updated state back into
-``__ed_state_token`` on success.  Because the state variables live in the
-helper's frame, not the entry point's, they are never in the entry
-point's collision space.  Within the helper, state variable names are not
-prefixed; all other locals use a ``__ed_`` prefix.
+Every Layer 2 entry point accepts ``--list-reserved`` with identical
+output, so any one of them can be used.  Currently the only reserved name
+is ``OPTARG``.
 
 **Rule 2 — Corrupt state is a hard failure.**
-If state restoration fails (invalid or corrupted HS2 token), the body
-helper emits an ``[ERROR]`` message to stderr and returns
+If state restoration fails (invalid or corrupted HS2 token), the entry
+point emits an ``[ERROR]`` message to stderr and returns
 ``ED_ERR_CORRUPT_STATE=4``.  Nothing is done to the system.
 
 **Rule 3 — Single persist point on success.**
-``hs_persist_state`` is called exactly once per body helper, at the
-successful exit path, after all system operations have completed.  On any
-failure path the helper returns without calling ``hs_persist_state``,
-leaving ``__ed_state_token`` (and therefore the caller's variable) unchanged.
-
-.. code-block:: bash
-
-    # Inside _ed_ensure_docker_body — persist on success only
-    local __ed_new_state=""
-    hs_persist_state -S __ed_new_state -- chain node_commit node_cons \
-        commit_ver commit_comp next_seq || return $?
-    __ed_state_token="$__ed_new_state"
-
-``hs_persist_state`` writes into a fresh local (no prior state → no
-collision possible).  Assigning back to ``__ed_state_token`` propagates
-the result to the entry point, which writes it to the caller's variable
-via ``printf -v``.
+``hs_persist_state`` is called exactly once, at the successful exit path,
+after all system operations have completed.  On any failure path the
+function returns without calling ``hs_persist_state``, leaving the
+caller's state variable unchanged.
 
 **Consequence.**  On failure, the system is unchanged *and* the caller's
 state variable is unchanged — there is nothing to undo.  On success, the
@@ -413,6 +387,7 @@ ed_ensure_docker
 ~~~~~~~~~~~~~~~~
 
 ``ed_ensure_docker -S <state_var> [[--update] [version_constraint]]``
+``ed_ensure_docker --list-reserved``
 
 Restores state, then ensures Docker is present and satisfies the given
 constraint, then appends one new node to the chain.  This function is
@@ -447,17 +422,19 @@ Behaviour:
 Errors:
 
 - ``ED_ERR_CORRUPT_STATE=4``: state token invalid at function entry.
-- ``ED_ERR_WRONG_VERSION=15``: no Docker version satisfies all constraints.
-- ``ED_ERR_NO_SUITABLE_VERSION=16``: no APT candidate satisfies the constraint.
-- ``ED_ERR_HOST_INCOMPATIBLE=21``: version found but cannot be installed.
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: install attempted but not root.
 - ``ED_ERR_MISSING_ARGUMENT=8``: ``-S`` absent.
 - ``ED_ERR_SYNTAX_ERROR=9``: malformed option or constraint.
+- ``ED_ERR_RESERVED_VAR_NAME=10``: the name supplied to ``-S`` is reserved.
+- ``ED_ERR_WRONG_VERSION=15``: no Docker version satisfies all constraints.
+- ``ED_ERR_NO_SUITABLE_VERSION=16``: no APT candidate satisfies the constraint.
+- ``ED_ERR_HOST_INCOMPATIBLE=21``: version found but cannot be installed.
 
 ed_docker_version
 ~~~~~~~~~~~~~~~~~
 
 ``ed_docker_version -S <state_var> [-b] [-v] [-c]``
+``ed_docker_version --list-reserved``
 
 Restores state, then queries the live Docker process for the requested
 version fields.
@@ -472,15 +449,17 @@ This function does not modify state; ``hs_persist_state`` is not called.
 Errors:
 
 - ``ED_ERR_CORRUPT_STATE=4``: state token invalid at function entry.
-- ``ED_ERR_NO_DOCKER=13``: Docker unreachable.
-- ``ED_ERR_NO_COMPOSE=14``: Compose plugin missing.
 - ``ED_ERR_MISSING_ARGUMENT=8``: ``-S`` absent.
 - ``ED_ERR_SYNTAX_ERROR=9``: unknown flag.
+- ``ED_ERR_RESERVED_VAR_NAME=10``: the name supplied to ``-S`` is reserved.
+- ``ED_ERR_NO_DOCKER=13``: Docker unreachable.
+- ``ED_ERR_NO_COMPOSE=14``: Compose plugin missing.
 
 ed_cleanup
 ~~~~~~~~~~
 
 ``ed_cleanup -S <state_var> [build_number]``
+``ed_cleanup --list-reserved``
 
 Restores state, removes the terminal chain node, reverts the corresponding
 system change if any, and persists the updated state.
@@ -513,9 +492,10 @@ Revert algorithm:
 Errors:
 
 - ``ED_ERR_CORRUPT_STATE=4``: state token invalid at function entry.
-- ``ED_ERR_WRONG_VERSION=15``: ``build_number`` does not match terminal node.
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: uninstall/downgrade attempted but not root.
 - ``ED_ERR_MISSING_ARGUMENT=8``: ``-S`` absent.
+- ``ED_ERR_RESERVED_VAR_NAME=10``: the name supplied to ``-S`` is reserved.
+- ``ED_ERR_WRONG_VERSION=15``: ``build_number`` does not match terminal node.
 
 ..
 

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -88,6 +88,13 @@ Error Codes
   required tool or dependency library is absent.
 - ``ED_ERR_ALREADY_INSTALLED=20``: ``ed_install_docker`` was called without
   ``--update`` and Docker is already installed.
+- ``ED_ERR_HOST_INCOMPATIBLE=21``: the selected version exists in the APT
+  repository but cannot be installed on this host (OS version mismatch,
+  unsupported architecture, irresolvable package dependencies, or a
+  container environment that lacks the required kernel capabilities).
+  ``ed_install_docker`` emits a diagnostic that includes the ``apt-get``
+  error output.  Callers that receive this code should consider a
+  Docker-in-Docker deployment or a remote installation via ``rr_run``.
 
 Version Constraint Syntax
 --------------------------
@@ -168,6 +175,9 @@ Errors:
 - ``ED_ERR_ALREADY_INSTALLED=20``: Docker present and ``--update`` not set.
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: not root.
 - ``ED_ERR_VERSION_NOT_FOUND=16``: no APT candidate satisfies the constraint.
+- ``ED_ERR_HOST_INCOMPATIBLE=21``: the selected version exists in APT but
+  the ``apt-get install`` step fails due to host incompatibility (see
+  diagnostic on stderr).  The caller should try DinD or a remote host.
 - ``ED_ERR_SYNTAX_ERROR=9``: malformed option or constraint.
 
 ed_uninstall_docker
@@ -189,39 +199,101 @@ Stage 2 State Variable Schema
    Stage 2 functions are not yet implemented.  Their API is documented here
    for planning purposes; they will be added in a subsequent PR.
 
-Stage 2 functions persist state via ``handle_state.sh`` using three
-associative arrays and one scalar.
+Stage 2 functions persist state via ``handle_state.sh``.  The five state
+variables below have **fixed names**: every stateful entry point restores
+them under exactly these names, and the accessor helpers rely on Bash's
+dynamic scoping to read and write them without namerefs (see `Accessor
+Helpers`_ below).
 
-``_ed_chain`` *(associative array)*
-  Forward-linked list.  Each key is a git-commit hash (or the sentinel
-  string ``"none"`` representing the pre-Docker state); each value is the
-  git-commit hash of the *next* Docker installation.
+``chain`` *(associative array)*
+  Forward-linked list where both keys and values are opaque sequence
+  integers (or the sentinels ``"none"`` and ``"head"``).
 
-  Example after two ``ed_ensure_docker`` calls:
+  - ``chain["none"]`` is ``"head"`` in the initial empty state (no Docker
+    installed by this library).
+  - ``chain["none"] = "1"`` after the first installation; ``chain["1"] = "head"``
+    marks it as the terminal node.
+  - ``chain[N] = "head"`` always marks the current tip.
 
-  .. code-block:: text
+``node_commit`` *(associative array)*
+  ``node_commit[seq]`` — git-commit hash of the Docker engine that was
+  current when node *seq* was appended.
 
-     _ed_chain["none"]    = "abc1234"   # Docker was absent; installed abc1234
-     _ed_chain["abc1234"] = "def5678"   # later updated to def5678
-     _ed_chain["def5678"] = ""          # terminal node
+``node_cons`` *(associative array)*
+  ``node_cons[seq]`` — version constraint string that was passed to the
+  ``ed_ensure_docker`` call that created node *seq* (empty string if
+  unconstrained).
 
-``_ed_docker_ver`` *(associative array)*
-  Maps each git-commit hash to the Docker engine semantic version string
-  that was installed at that commit, e.g. ``_ed_docker_ver["abc1234"] = "24.0.7"``.
+``commit_ver`` *(associative array)*
+  ``commit_ver[hash]`` — Docker engine semver for a given git-commit hash.
+  Shared across nodes that reference the same commit.
 
-``_ed_compose_ver`` *(associative array)*
-  Maps each git-commit hash to the Compose plugin semantic version string,
-  e.g. ``_ed_compose_ver["abc1234"] = "2.20.0"``.
+``commit_comp`` *(associative array)*
+  ``commit_comp[hash]`` — Compose plugin semver for a given git-commit hash.
+  Shared across nodes that reference the same commit.
 
-``_ed_head`` *(scalar)*
-  The git-commit hash at the tip of ``_ed_chain`` (the currently installed
-  Docker version), or ``"none"`` when Docker is not installed.
+``next_seq`` *(scalar)*
+  Monotonic integer counter; incremented each time a new node is appended.
 
-The action implied by any commit is determined from the chain structure
-alone: a predecessor of ``"none"`` means the commit was the first
-installation (reverting → uninstall); any other predecessor means it was
-an update (reverting → downgrade to that predecessor's version via
-``_ed_docker_ver``).
+Example after two ``ed_ensure_docker`` calls that install then update Docker:
+
+.. code-block:: text
+
+   chain["none"]  = "1"      chain["1"]  = "2"      chain["2"] = "head"
+   node_commit["1"] = "abc"  node_commit["2"] = "def"
+   node_cons["1"]   = ">=24.0.0"  node_cons["2"] = ">=24.0.5,<25.0.0"
+   commit_ver["abc"]  = "24.0.7"  commit_ver["def"]  = "24.0.9"
+   commit_comp["abc"] = "2.20.0"  commit_comp["def"] = "2.23.0"
+   next_seq = 2
+
+The action implied by cleanup is read from the chain: if the predecessor of
+the terminal node is ``"none"``, Docker was installed by this library and
+cleanup uninstalls it; otherwise cleanup downgrades to the predecessor's
+``commit_ver``.  A new version must satisfy all ``node_cons`` values across
+every node currently in the chain.
+
+Accessor Helpers
+----------------
+
+.. note::
+   Accessor helpers are not yet implemented.
+
+Internal ``_ed_`` helper functions encapsulate all access to the five state
+arrays.  They work without namerefs because Bash uses dynamic scoping:
+``local`` variables declared in a stateful entry point are visible to every
+helper it calls.  The convention is therefore:
+
+1. Every stateful entry point restores the five state variables under their
+   fixed names (``chain``, ``node_commit``, ``node_cons``, ``commit_ver``,
+   ``commit_comp``, ``next_seq``) before calling any accessor.
+2. Accessor helpers reference those names directly.  They must only be
+   called from within a stateful entry point that has already restored state.
+
+The accessor surface:
+
+.. code-block:: bash
+
+   # Chain (forward-pointer AA)
+   _ed_chain_get  key            # → stdout: chain[key]
+   _ed_chain_put  key value      # chain[key]=value
+   _ed_chain_del  key            # unset chain[key]
+   _ed_chain_pred target         # → stdout: key k where chain[k]==target
+                                 #   (traverses from "none"; fails if not found)
+
+   # Node record  (node_commit + node_cons)
+   _ed_node_put    seq commit cons   # write both fields
+   _ed_node_commit seq               # → stdout: node_commit[seq]
+   _ed_node_cons   seq               # → stdout: node_cons[seq]
+   _ed_node_del    seq               # unset both fields
+
+   # Commit record  (commit_ver + commit_comp)
+   _ed_commit_put     hash docker_ver compose_ver   # write both fields
+   _ed_commit_docker  hash                          # → stdout: commit_ver[hash]
+   _ed_commit_compose hash                          # → stdout: commit_comp[hash]
+   _ed_commit_del     hash                          # unset both fields
+
+   # Sequence counter
+   _ed_seq_alloc      # increments next_seq; → stdout: new value
 
 Public API — Stage 2
 --------------------

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -14,56 +14,73 @@ detection, installation, uninstallation, and version-tracked cleanup.  It is
 designed to be called via ``rr_run`` so the same operations can be applied
 transparently to a remote host without any file being copied there.
 
-The library is organised in two stages:
+The library exposes two functional layers:
 
-- **Stage 1** — atomic functions that have no side-effects on library state:
+- **Layer 1** — stateless functions with no side-effects on library state:
   ``ed_has_docker``, ``ed_install_docker``, ``ed_uninstall_docker``.
-- **Stage 2** — state-managed functions that compose Stage 1 with
+- **Layer 2** — state-managed functions that compose Layer 1 with
   ``handle_state.sh`` for idempotency and rollback:
   ``ed_ensure_docker``, ``ed_docker_version``, ``ed_cleanup``.
 
 Dependencies
 ------------
 
-+-------------------+---------------------------------+
-| Dependency        | Notes                           |
-+===================+=================================+
-| ``command_guard.sh`` | Guarded at source time:      |
-|                   | ``docker``, ``apt-get``,        |
-|                   | ``apt-cache``, ``curl``, ``id`` |
-+-------------------+---------------------------------+
-| ``handle_state.sh`` | Stage 2 functions only.       |
-|                   | Sourced automatically.          |
-+-------------------+---------------------------------+
-| Docker CE APT repo | Required by ``ed_install_docker``|
-|                   | on Debian/Ubuntu hosts.         |
-+-------------------+---------------------------------+
-| Bash ≥ 4.3        | Nameref support in              |
-|                   | ``handle_state.sh``.            |
-+-------------------+---------------------------------+
++------------------------+--------------------------------------------------+
+| Dependency             | Notes                                            |
++========================+==================================================+
+| ``command_guard.sh``   | Sourced at load time.  Guards the external       |
+|                        | commands ``docker``, ``apt-get``, ``apt-cache``, |
+|                        | ``curl``, ``id``.                                |
++------------------------+--------------------------------------------------+
+| ``handle_state.sh``    | Layer 2 functions only.  Sourced automatically  |
+|                        | by ``ensure_docker.sh``.                         |
++------------------------+--------------------------------------------------+
+| Docker CE APT repo     | Required by ``ed_install_docker`` on             |
+|                        | Debian/Ubuntu hosts.                             |
++------------------------+--------------------------------------------------+
+| Bash ≥ 4.3             | Required by ``handle_state.sh``                  |
+|                        | (nameref support).                               |
++------------------------+--------------------------------------------------+
 
-All command-guard dependencies are verified at source time.  If any required
-tool is absent the library fails to load and returns
-``ED_ERR_DEPENDENCY_MISSING``.
+All required external commands are verified at source time.  If any is
+absent the library fails to load and returns ``ED_ERR_DEPENDENCY_MISSING``.
 
 Quick Start
 -----------
 
 .. code-block:: bash
 
-   source "$(dirname "$0")/config/ensure_docker.sh"
+   source "$(dirname "$0")/config/ensure_docker.sh" || exit $?
 
-   # Check Docker is present and satisfies a version constraint
-   ed_has_docker ">=24.0.0" || { echo "Docker 24+ required"; exit 1; }
+   # Check whether Docker is present and satisfies a version constraint
+   ed_has_docker ">=24.0.0" || { echo "Docker 24+ required" >&2; exit 1; }
 
-   # Install Docker if absent (requires root)
-   ed_install_docker ">=24.0.0"
+   # Install Docker (requires root); fails if already installed without --update
+   ed_install_docker ">=24.0.0" || exit $?
 
-   # Idempotent: install only when needed, record action in state (Stage 2)
-   local state=""
-   ed_ensure_docker -S state ">=24.0.0" || return $?
+Layer 2 — commissioning and decommissioning with state tracking:
+
+.. code-block:: bash
+
+   source "$(dirname "$0")/config/ensure_docker.sh" || exit $?
+
+   # Commission: ensure Docker is present and record what was done.
+   # ed_ensure_docker appends one node to the state chain on every
+   # successful call; each call must be matched by exactly one ed_cleanup.
+   state=""
+   ed_ensure_docker -S state ">=24.0.0" || exit $?
+
+   # For long-lived servers the state string must be saved to permanent
+   # storage (a file, a secrets manager, a configuration database keyed
+   # by the server's unique identity) before the script exits.
+   printf '%s\n' "$state" > /etc/ensure_docker.state
+
    # ... use Docker ...
-   ed_cleanup -S state   # restore the host to its prior state
+
+   # Decommission: restore the host to its prior Docker state.
+   state="$(< /etc/ensure_docker.state)"
+   ed_cleanup -S state || exit $?
+   rm -f /etc/ensure_docker.state
 
 Error Codes
 -----------
@@ -71,7 +88,6 @@ Error Codes
 - ``ED_ERR_CORRUPT_STATE=4``: the state token supplied via ``-S`` is not a
   valid ``handle_state.sh`` HS2 object.  Emitted by stateful entry points
   when state restoration fails at function entry.  The system is not touched.
-  Aligned with ``HS_ERR_CORRUPT_STATE=4``.
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: the caller does not have root
   privilege.  The library never escalates privileges on the caller's behalf.
 - ``ED_ERR_MISSING_ARGUMENT=8``: a mandatory argument (typically ``-S``) was
@@ -84,21 +100,24 @@ Error Codes
   ``docker compose`` CLI plugin is missing.
 - ``ED_ERR_WRONG_VERSION=15``: Docker is installed but does not satisfy
   the supplied version constraint.
-- ``ED_ERR_VERSION_NOT_FOUND=16``: no APT candidate satisfies the
-  requested version constraint.
+- ``ED_ERR_NO_SUITABLE_VERSION=16``: the APT repository contains no
+  candidate that satisfies the requested version constraint.  The host is
+  reachable and the repository is accessible; the constraint itself cannot
+  be met with what is currently published.
 - ``ED_ERR_VERSION_VULNERABLE=17``: *(reserved — CVE checking deferred to
   a future PR; currently never returned).*
 - ``ED_ERR_DEPENDENCY_MISSING=19``: the library failed to load because a
-  required tool or dependency library is absent.
+  required external command or dependency library is absent.
 - ``ED_ERR_ALREADY_INSTALLED=20``: ``ed_install_docker`` was called without
   ``--update`` and Docker is already installed.
-- ``ED_ERR_HOST_INCOMPATIBLE=21``: the selected version exists in the APT
-  repository but cannot be installed on this host (OS version mismatch,
-  unsupported architecture, irresolvable package dependencies, or a
-  container environment that lacks the required kernel capabilities).
-  ``ed_install_docker`` emits a diagnostic that includes the ``apt-get``
-  error output.  Callers that receive this code should consider a
-  Docker-in-Docker deployment or a remote installation via ``rr_run``.
+- ``ED_ERR_HOST_INCOMPATIBLE=21``: a suitable version was found in the APT
+  repository but ``apt-get install`` failed because the host cannot run it
+  (OS version mismatch, unsupported CPU architecture, irresolvable package
+  dependencies, or a container environment that lacks the required kernel
+  capabilities).  ``ed_install_docker`` emits a diagnostic on stderr that
+  includes the ``apt-get`` error output.  Callers that receive this code
+  should consider a Docker-in-Docker deployment or a remote installation
+  via ``rr_run``.
 
 Version Constraint Syntax
 --------------------------
@@ -114,7 +133,7 @@ forms, where ``A``, ``B``, ``C`` are non-negative integers:
    =A.B.C             # exact match
    =A.B               # equivalent to >=A.B.0,<A.(B+1).0
 
-Public API — Stage 1
+Public API — Layer 1
 --------------------
 
 ed_has_docker
@@ -178,7 +197,7 @@ Errors:
 
 - ``ED_ERR_ALREADY_INSTALLED=20``: Docker present and ``--update`` not set.
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: not root.
-- ``ED_ERR_VERSION_NOT_FOUND=16``: no APT candidate satisfies the constraint.
+- ``ED_ERR_NO_SUITABLE_VERSION=16``: no APT candidate satisfies the constraint.
 - ``ED_ERR_HOST_INCOMPATIBLE=21``: the selected version exists in APT but
   the ``apt-get install`` step fails due to host incompatibility (see
   diagnostic on stderr).  The caller should try DinD or a remote host.
@@ -199,7 +218,7 @@ Errors:
 State Consistency Policy
 ------------------------
 
-This policy applies to every stateful entry point
+This policy applies to every Layer 2 entry point
 (``ed_ensure_docker``, ``ed_docker_version``, ``ed_cleanup``).
 
 **Rule 1 — Full restoration at entry.**
@@ -241,15 +260,11 @@ change was needed.  A failed call leaves state unchanged and adds no node.
 Each caller owns exactly one node per successful call and must match it
 with a single ``ed_cleanup`` call when the host is decommissioned.
 
-Stage 2 State Variable Schema
+Layer 2 State Variable Schema
 ------------------------------
 
-.. note::
-   Stage 2 functions are not yet implemented.  Their API is documented here
-   for planning purposes; they will be added in a subsequent PR.
-
-Stage 2 functions persist state via ``handle_state.sh``.  The five state
-variables below have **fixed names**: every stateful entry point restores
+Layer 2 functions persist state via ``handle_state.sh``.  The six state
+variables below have **fixed names**: every Layer 2 entry point restores
 them under exactly these names, and the accessor helpers rely on Bash's
 dynamic scoping to read and write them without namerefs (see `Accessor
 Helpers`_ below).
@@ -304,10 +319,7 @@ every node currently in the chain.
 Accessor Helpers
 ----------------
 
-.. note::
-   Accessor helpers are not yet implemented.
-
-Internal ``_ed_`` helper functions encapsulate all access to the five state
+Internal ``_ed_`` helper functions encapsulate all access to the six state
 arrays.  They work without namerefs because Bash uses dynamic scoping:
 ``local`` variables declared in a stateful entry point are visible to every
 helper it calls.  The convention is therefore:
@@ -363,7 +375,7 @@ Calling convention
    #   writes result into __ed_seq (scalar)
    _ed_seq_alloc      # increments next_seq; __ed_seq = new value
 
-Public API — Stage 2
+Public API — Layer 2
 --------------------
 
 ed_ensure_docker
@@ -405,7 +417,7 @@ Errors:
 
 - ``ED_ERR_CORRUPT_STATE=4``: state token invalid at function entry.
 - ``ED_ERR_WRONG_VERSION=15``: no Docker version satisfies all constraints.
-- ``ED_ERR_VERSION_NOT_FOUND=16``: no APT candidate satisfies the constraint.
+- ``ED_ERR_NO_SUITABLE_VERSION=16``: no APT candidate satisfies the constraint.
 - ``ED_ERR_HOST_INCOMPATIBLE=21``: version found but cannot be installed.
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: install attempted but not root.
 - ``ED_ERR_MISSING_ARGUMENT=8``: ``-S`` absent.

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -32,7 +32,7 @@ Dependencies
 |                        | commands ``docker``, ``apt-get``, ``apt-cache``, |
 |                        | ``curl``, ``id``.                                |
 +------------------------+--------------------------------------------------+
-| ``handle_state.sh``    | Layer 2 functions only.  Sourced automatically  |
+| ``handle_state.sh``    | Layer 2 functions only.  Sourced automatically   |
 |                        | by ``ensure_docker.sh``.                         |
 +------------------------+--------------------------------------------------+
 | Docker CE APT repo     | Required by ``ed_install_docker`` on             |

--- a/docs/libraries/ensure_docker.rst
+++ b/docs/libraries/ensure_docker.rst
@@ -68,6 +68,10 @@ Quick Start
 Error Codes
 -----------
 
+- ``ED_ERR_CORRUPT_STATE=4``: the state token supplied via ``-S`` is not a
+  valid ``handle_state.sh`` HS2 object.  Emitted by stateful entry points
+  when state restoration fails at function entry.  The system is not touched.
+  Aligned with ``HS_ERR_CORRUPT_STATE=4``.
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: the caller does not have root
   privilege.  The library never escalates privileges on the caller's behalf.
 - ``ED_ERR_MISSING_ARGUMENT=8``: a mandatory argument (typically ``-S``) was
@@ -192,8 +196,40 @@ Errors:
 
 - ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: not root.
 
+State Consistency Policy
+------------------------
+
+This policy applies to every stateful entry point
+(``ed_ensure_docker``, ``ed_docker_version``, ``ed_cleanup``).
+
+**Rule 1 — Full restoration at entry.**
+The very first operation of every stateful entry point is restoring all
+five state variables from the ``-S`` token.  No argument validation,
+constraint checking, or system operation precedes this step.
+
+**Rule 2 — Corrupt state is a hard failure.**
+If restoration fails (invalid or corrupted HS2 token), the entry point
+emits an ``[ERROR]`` message to stderr and returns
+``ED_ERR_CORRUPT_STATE=4``.  Nothing is done to the system.
+
+**Rule 3 — Single persist point on success.**
+``hs_persist_state`` is called exactly once, at the successful exit of
+the entry point, after all system operations have completed.  On any
+failure path the function returns without calling ``hs_persist_state``,
+leaving the state token identical to what was passed in.
+
+**Consequence.**  On failure, the system is unchanged *and* the state
+token is unchanged — there is nothing to undo.  On success, the state
+token is updated atomically to reflect the completed operation.
+
+**``ed_ensure_docker`` is not idempotent.**
+Every call unconditionally appends one new node to the chain and persists
+the updated state, even when Docker is already present and no system change
+is needed.  Each caller owns exactly one node and must match it with a
+single ``ed_cleanup`` call when the host is decommissioned.
+
 Stage 2 State Variable Schema
------------------------------
+------------------------------
 
 .. note::
    Stage 2 functions are not yet implemented.  Their API is documented here
@@ -303,49 +339,105 @@ ed_ensure_docker
 
 ``ed_ensure_docker -S <state_var> [[--update] [version_constraint]]``
 
-Idempotent wrapper around ``ed_has_docker`` and ``ed_install_docker``.
-On success, appends the newly installed commit to ``_ed_chain``, records
-its version data in ``_ed_docker_ver`` and ``_ed_compose_ver``, and
-updates ``_ed_head``.  When Docker was already present and no action was
-needed, ``_ed_head`` is set to the current commit and the chain gains one
-entry (the current state) if it was previously empty.
+Restores state, then unconditionally appends one new node to the chain.
+This function is **not idempotent**: every call creates a node regardless
+of whether Docker was already present or any system change was made.  Each
+caller is responsible for issuing exactly one matching ``ed_cleanup`` call
+when the host is decommissioned.
+
+Behaviour:
+
+1. Restore full state from ``-S`` token; return ``ED_ERR_CORRUPT_STATE``
+   on failure.
+2. Allocate a new sequence number via ``_ed_seq_alloc``.
+3. Call ``ed_has_docker [version_constraint]``:
+
+   - Returns ``0``: Docker present and satisfies constraint.  No system
+     change; record current commit as the new node's commit.
+   - Returns ``ED_ERR_NO_DOCKER``: call ``ed_install_docker [constraint]``.
+   - Returns ``ED_ERR_WRONG_VERSION`` with ``--update``: call
+     ``ed_install_docker --update [constraint]``.
+   - Returns ``ED_ERR_WRONG_VERSION`` without ``--update``: propagate
+     ``ED_ERR_WRONG_VERSION``; state unchanged.
+   - Any other error: propagate; state unchanged.
+
+4. Verify the new constraint is compatible with all existing ``node_cons``
+   values.  If any conflict is detected: propagate ``ED_ERR_WRONG_VERSION``;
+   state unchanged.
+5. Write node (``_ed_node_put``, ``_ed_commit_put`` if commit is new).
+6. Link the new node as the chain terminal (``_ed_chain_put``).
+7. Persist state (``hs_persist_state``).
+
+Errors:
+
+- ``ED_ERR_CORRUPT_STATE=4``: state token invalid at function entry.
+- ``ED_ERR_WRONG_VERSION=15``: no Docker version satisfies all constraints.
+- ``ED_ERR_VERSION_NOT_FOUND=16``: no APT candidate satisfies the constraint.
+- ``ED_ERR_HOST_INCOMPATIBLE=21``: version found but cannot be installed.
+- ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: install attempted but not root.
+- ``ED_ERR_MISSING_ARGUMENT=8``: ``-S`` absent.
+- ``ED_ERR_SYNTAX_ERROR=9``: malformed option or constraint.
 
 ed_docker_version
 ~~~~~~~~~~~~~~~~~
 
 ``ed_docker_version -S <state_var> [-b] [-v] [-c]``
 
-Returns version information about the currently installed Docker engine.
-Reads ``_ed_head`` from state, then queries the live Docker process for
-the requested fields.
+Restores state, then queries the live Docker process for the requested
+version fields.
 
 - ``-b``: git-commit hash — ``docker version --format '{{.Server.GitCommit}}'``.
 - ``-v``: engine semantic version — ``docker version --format '{{.Server.Version}}'``.
 - ``-c``: Compose plugin version — ``docker compose version --short``.
 
 No flags is equivalent to ``-b -v -c``; output order follows flag order.
+This function does not modify state; ``hs_persist_state`` is not called.
+
+Errors:
+
+- ``ED_ERR_CORRUPT_STATE=4``: state token invalid at function entry.
+- ``ED_ERR_NO_DOCKER=13``: Docker unreachable.
+- ``ED_ERR_NO_COMPOSE=14``: Compose plugin missing.
+- ``ED_ERR_MISSING_ARGUMENT=8``: ``-S`` absent.
+- ``ED_ERR_SYNTAX_ERROR=9``: unknown flag.
 
 ed_cleanup
 ~~~~~~~~~~
 
 ``ed_cleanup -S <state_var> [build_number]``
 
-Reverses the last action recorded by ``ed_ensure_docker``.
+Restores state, removes the terminal chain node, reverts the corresponding
+system change if any, and persists the updated state.
 
-If ``build_number`` is given it must be present in ``_ed_chain`` as a key;
-otherwise ``ED_ERR_WRONG_VERSION`` is returned.
+If ``build_number`` is given it must equal ``node_commit[head_seq]``
+(the commit recorded at the terminal node); otherwise returns
+``ED_ERR_WRONG_VERSION``.
 
-The revert algorithm traverses ``_ed_chain`` from ``"none"`` to find the
-predecessor of ``_ed_head``:
+Revert algorithm:
 
-- Predecessor is ``"none"`` → Docker was installed by this library;
-  call ``ed_uninstall_docker``.
-- Predecessor is a commit hash → Docker was updated; call
-  ``ed_install_docker --update "$(_ed_docker_ver[$predecessor])"``
-  to downgrade.
+1. Restore full state; return ``ED_ERR_CORRUPT_STATE`` on failure.
+2. Identify the terminal node ``T`` (``chain[k] = "head"`` for some ``k``).
+3. Find the predecessor ``P`` of ``T`` (``_ed_chain_pred "head"``).
+4. Determine action from ``P``:
 
-On success, removes ``_ed_head`` from the chain and version maps, and
-updates ``_ed_head`` to the predecessor.
+   - ``P == "none"`` and no remaining nodes after removal: Docker was
+     installed by this library → call ``ed_uninstall_docker``.
+   - ``P == "none"`` and nodes remain, or ``P`` is a seq number: check
+     whether current Docker version satisfies all remaining
+     ``node_cons`` values.  If not, call
+     ``ed_install_docker --update "$(_ed_commit_docker "$(_ed_node_commit "$P")")"``
+     to downgrade.  If yes, no system change.
+
+5. Remove ``T`` from chain and node maps (``_ed_node_del``, ``_ed_chain_del``).
+   Remove commit record only if no other node references the same commit.
+6. Persist state.
+
+Errors:
+
+- ``ED_ERR_CORRUPT_STATE=4``: state token invalid at function entry.
+- ``ED_ERR_WRONG_VERSION=15``: ``build_number`` does not match terminal node.
+- ``ED_ERR_INSUFFICIENT_PRIVILEGE=7``: uninstall/downgrade attempted but not root.
+- ``ED_ERR_MISSING_ARGUMENT=8``: ``-S`` absent.
 
 ..
 

--- a/docs/libraries/index.rst
+++ b/docs/libraries/index.rst
@@ -10,6 +10,7 @@ pieces they ship.
    handle_state
    command_guard
    remote_run
+   ensure_docker
 
 Change History
 --------------

--- a/test/test-ensure_docker.bats
+++ b/test/test-ensure_docker.bats
@@ -449,4 +449,4 @@ return 0
 # --- Change History -------------------------------------------------------
 # | PR     | Summary                                                       |
 # |--------|---------------------------------------------------------------|
-# | #TBD   | initial preliminary tests — Stage 1 (issue #132)              |
+# | #135   | initial preliminary tests — Stage 1 (issue #132)              |

--- a/test/test-ensure_docker.bats
+++ b/test/test-ensure_docker.bats
@@ -130,7 +130,7 @@ setup() {
     [[ -n "${ED_ERR_NO_DOCKER+x}" ]]              || { echo "ED_ERR_NO_DOCKER missing" >&2;              false; }
     [[ -n "${ED_ERR_NO_COMPOSE+x}" ]]             || { echo "ED_ERR_NO_COMPOSE missing" >&2;             false; }
     [[ -n "${ED_ERR_WRONG_VERSION+x}" ]]          || { echo "ED_ERR_WRONG_VERSION missing" >&2;          false; }
-    [[ -n "${ED_ERR_VERSION_NOT_FOUND+x}" ]]      || { echo "ED_ERR_VERSION_NOT_FOUND missing" >&2;      false; }
+    [[ -n "${ED_ERR_NO_SUITABLE_VERSION+x}" ]]      || { echo "ED_ERR_NO_SUITABLE_VERSION missing" >&2;      false; }
     [[ -n "${ED_ERR_VERSION_VULNERABLE+x}" ]]     || { echo "ED_ERR_VERSION_VULNERABLE missing" >&2;     false; }
     [[ -n "${ED_ERR_DEPENDENCY_MISSING+x}" ]]     || { echo "ED_ERR_DEPENDENCY_MISSING missing" >&2;     false; }
     [[ -n "${ED_ERR_ALREADY_INSTALLED+x}" ]]      || { echo "ED_ERR_ALREADY_INSTALLED missing" >&2;      false; }
@@ -146,7 +146,7 @@ setup() {
     [[ "$ED_ERR_NO_DOCKER"              -eq 13 ]]
     [[ "$ED_ERR_NO_COMPOSE"             -eq 14 ]]
     [[ "$ED_ERR_WRONG_VERSION"          -eq 15 ]]
-    [[ "$ED_ERR_VERSION_NOT_FOUND"      -eq 16 ]]
+    [[ "$ED_ERR_NO_SUITABLE_VERSION"      -eq 16 ]]
     [[ "$ED_ERR_VERSION_VULNERABLE"     -eq 17 ]]
     [[ "$ED_ERR_DEPENDENCY_MISSING"     -eq 19 ]]
     [[ "$ED_ERR_ALREADY_INSTALLED"      -eq 20 ]]
@@ -372,13 +372,13 @@ setup() {
 }
 
 # bats test_tags=ensure_docker,install_docker,issue-132
-@test "ed_install_docker — returns ED_ERR_VERSION_NOT_FOUND when no apt candidate matches constraint" {
+@test "ed_install_docker — returns ED_ERR_NO_SUITABLE_VERSION when no apt candidate matches constraint" {
     if [[ "$(id -u)" -ne 0 ]]; then
         skip "requires root to reach version-selection logic"
     fi
     MOCK_DOCKER_ABSENT=1 MOCK_APT_VERSIONS="24.0.7" \
         run ed_install_docker ">=99.0.0"
-    [[ "$status" -eq "$ED_ERR_VERSION_NOT_FOUND" ]]
+    [[ "$status" -eq "$ED_ERR_NO_SUITABLE_VERSION" ]]
 }
 
 # bats test_tags=ensure_docker,install_docker,issue-132

--- a/test/test-ensure_docker.bats
+++ b/test/test-ensure_docker.bats
@@ -127,6 +127,7 @@ setup() {
     [[ -n "${ED_ERR_INSUFFICIENT_PRIVILEGE+x}" ]] || { echo "ED_ERR_INSUFFICIENT_PRIVILEGE missing" >&2; false; }
     [[ -n "${ED_ERR_MISSING_ARGUMENT+x}" ]]       || { echo "ED_ERR_MISSING_ARGUMENT missing" >&2;       false; }
     [[ -n "${ED_ERR_SYNTAX_ERROR+x}" ]]           || { echo "ED_ERR_SYNTAX_ERROR missing" >&2;           false; }
+    [[ -n "${ED_ERR_RESERVED_VAR_NAME+x}" ]]      || { echo "ED_ERR_RESERVED_VAR_NAME missing" >&2;      false; }
     [[ -n "${ED_ERR_NO_DOCKER+x}" ]]              || { echo "ED_ERR_NO_DOCKER missing" >&2;              false; }
     [[ -n "${ED_ERR_NO_COMPOSE+x}" ]]             || { echo "ED_ERR_NO_COMPOSE missing" >&2;             false; }
     [[ -n "${ED_ERR_WRONG_VERSION+x}" ]]          || { echo "ED_ERR_WRONG_VERSION missing" >&2;          false; }
@@ -143,6 +144,7 @@ setup() {
     [[ "$ED_ERR_INSUFFICIENT_PRIVILEGE" -eq 7  ]]
     [[ "$ED_ERR_MISSING_ARGUMENT"       -eq 8  ]]
     [[ "$ED_ERR_SYNTAX_ERROR"           -eq 9  ]]
+    [[ "$ED_ERR_RESERVED_VAR_NAME"      -eq 10 ]]
     [[ "$ED_ERR_NO_DOCKER"              -eq 13 ]]
     [[ "$ED_ERR_NO_COMPOSE"             -eq 14 ]]
     [[ "$ED_ERR_WRONG_VERSION"          -eq 15 ]]
@@ -158,6 +160,69 @@ setup() {
     [[ "$(type -t ed_has_docker)"       == "function" ]]
     [[ "$(type -t ed_install_docker)"   == "function" ]]
     [[ "$(type -t ed_uninstall_docker)" == "function" ]]
+}
+
+# bats test_tags=ensure_docker,source,issue-132
+@test "Layer 2 entry points are defined after sourcing" {
+    [[ "$(type -t ed_ensure_docker)"   == "function" ]]
+    [[ "$(type -t ed_docker_version)"  == "function" ]]
+    [[ "$(type -t ed_cleanup)"         == "function" ]]
+}
+
+# ---------------------------------------------------------------------------
+# --list-reserved
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,list_reserved,issue-132
+@test "ed_ensure_docker --list-reserved exits 0 and prints at least one name" {
+    run ed_ensure_docker --list-reserved
+    [[ "$status" -eq 0 ]]
+    [[ -n "$output" ]]
+}
+
+# bats test_tags=ensure_docker,list_reserved,issue-132
+@test "ed_ensure_docker --list-reserved output contains OPTARG" {
+    run ed_ensure_docker --list-reserved
+    [[ "$status" -eq 0 ]]
+    grep -qx "OPTARG" <<< "$output"
+}
+
+# bats test_tags=ensure_docker,list_reserved,issue-132
+@test "ed_docker_version --list-reserved output matches ed_ensure_docker" {
+    run ed_ensure_docker --list-reserved
+    local expected="$output"
+    run ed_docker_version --list-reserved
+    [[ "$output" == "$expected" ]]
+}
+
+# bats test_tags=ensure_docker,list_reserved,issue-132
+@test "ed_cleanup --list-reserved output matches ed_ensure_docker" {
+    run ed_ensure_docker --list-reserved
+    local expected="$output"
+    run ed_cleanup --list-reserved
+    [[ "$output" == "$expected" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Reserved variable name rejection
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,reserved,issue-132
+@test "ed_ensure_docker -S OPTARG returns ED_ERR_RESERVED_VAR_NAME" {
+    run ed_ensure_docker -S OPTARG
+    [[ "$status" -eq "$ED_ERR_RESERVED_VAR_NAME" ]]
+}
+
+# bats test_tags=ensure_docker,reserved,issue-132
+@test "ed_docker_version -S OPTARG returns ED_ERR_RESERVED_VAR_NAME" {
+    run ed_docker_version -S OPTARG
+    [[ "$status" -eq "$ED_ERR_RESERVED_VAR_NAME" ]]
+}
+
+# bats test_tags=ensure_docker,reserved,issue-132
+@test "ed_cleanup -S OPTARG returns ED_ERR_RESERVED_VAR_NAME" {
+    run ed_cleanup -S OPTARG
+    [[ "$status" -eq "$ED_ERR_RESERVED_VAR_NAME" ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/test/test-ensure_docker.bats
+++ b/test/test-ensure_docker.bats
@@ -30,8 +30,8 @@ setup_file() {
 
     export LIB="$BATS_TEST_DIRNAME/../config/ensure_docker.sh"
     if [[ ! -f "$LIB" ]]; then
-        echo "Missing library: $LIB" >&2
-        return 1
+        export ED_TESTS_SKIP="ensure_docker.sh not yet implemented"
+        return 0
     fi
 
     # Create shared mock binary directory
@@ -100,10 +100,11 @@ MOCK
 }
 
 teardown_file() {
-    [[ -d "${ED_MOCK_DIR:-}" ]] && rm -rf "$ED_MOCK_DIR"
+    [[ -d "${ED_MOCK_DIR:-}" ]] && rm -rf "$ED_MOCK_DIR" || true
 }
 
 setup() {
+    [[ -z "${ED_TESTS_SKIP:-}" ]] || skip "$ED_TESTS_SKIP"
     # Prepend mock dir so cg_guard resolves our stubs at source time
     export PATH="$ED_MOCK_DIR:$PATH"
     # shellcheck source=../config/ensure_docker.sh

--- a/test/test-ensure_docker.bats
+++ b/test/test-ensure_docker.bats
@@ -21,9 +21,8 @@
 # MOCK_COMPOSE_VERSION   — compose semver (default: 2.20.0)
 
 readonly ED_TEST_SOURCE_FAILED=2
-readonly ED_TEST_DOCKER_NET_FAILED=3
-readonly ED_TEST_CONTAINER_START_FAILED=4
-readonly ED_TEST_CONTAINER_NOT_READY=5
+# ED_TEST_DOCKER_NET_FAILED, ED_TEST_CONTAINER_START_FAILED, ED_TEST_CONTAINER_NOT_READY
+# will be added in Stage 1 implementation when the DinD fixture is wired up.
 
 setup_file() {
     bats_require_minimum_version 1.5.0
@@ -123,6 +122,7 @@ setup() {
 
 # bats test_tags=ensure_docker,source,issue-132
 @test "all ED_ERR_ constants are defined after sourcing" {
+    [[ -n "${ED_ERR_CORRUPT_STATE+x}" ]]          || { echo "ED_ERR_CORRUPT_STATE missing" >&2;          false; }
     [[ -n "${ED_ERR_INSUFFICIENT_PRIVILEGE+x}" ]] || { echo "ED_ERR_INSUFFICIENT_PRIVILEGE missing" >&2; false; }
     [[ -n "${ED_ERR_MISSING_ARGUMENT+x}" ]]       || { echo "ED_ERR_MISSING_ARGUMENT missing" >&2;       false; }
     [[ -n "${ED_ERR_SYNTAX_ERROR+x}" ]]           || { echo "ED_ERR_SYNTAX_ERROR missing" >&2;           false; }
@@ -138,6 +138,7 @@ setup() {
 
 # bats test_tags=ensure_docker,source,issue-132
 @test "ED_ERR_ numeric values match the approved table" {
+    [[ "$ED_ERR_CORRUPT_STATE"          -eq 4  ]]
     [[ "$ED_ERR_INSUFFICIENT_PRIVILEGE" -eq 7  ]]
     [[ "$ED_ERR_MISSING_ARGUMENT"       -eq 8  ]]
     [[ "$ED_ERR_SYNTAX_ERROR"           -eq 9  ]]

--- a/test/test-ensure_docker.bats
+++ b/test/test-ensure_docker.bats
@@ -1,0 +1,426 @@
+#!/usr/bin/env bats
+
+# Preliminary tests for config/ensure_docker.sh  (Stage 1)
+# Run with: bats test/test-ensure_docker.bats
+#
+# Unit tests mock the docker and apt-cache binaries via a PATH-prefixed temp
+# directory.  Mock behaviour is controlled by MOCK_DOCKER_* environment
+# variables set per test.
+#
+# Integration tests require a privileged Docker-in-Docker environment and are
+# skipped automatically when Docker is unavailable.
+# shellcheck disable=SC2329
+
+# ---------------------------------------------------------------------------
+# Mock docker binary — behaviour controlled by environment variables
+# ---------------------------------------------------------------------------
+# MOCK_DOCKER_ABSENT=1   — docker binary exits 1 (simulates not found in PATH)
+# MOCK_DOCKER_VERSION    — engine semver string (default: 24.0.7)
+# MOCK_DOCKER_COMMIT     — git commit hash (default: abc1234)
+# MOCK_COMPOSE_ABSENT=1  — docker compose subcommand exits 1
+# MOCK_COMPOSE_VERSION   — compose semver (default: 2.20.0)
+
+readonly ED_TEST_SOURCE_FAILED=2
+readonly ED_TEST_DOCKER_NET_FAILED=3
+readonly ED_TEST_CONTAINER_START_FAILED=4
+readonly ED_TEST_CONTAINER_NOT_READY=5
+
+setup_file() {
+    bats_require_minimum_version 1.5.0
+    export BATS_TEST_TIMEOUT=30
+
+    export LIB="$BATS_TEST_DIRNAME/../config/ensure_docker.sh"
+    if [[ ! -f "$LIB" ]]; then
+        echo "Missing library: $LIB" >&2
+        return 1
+    fi
+
+    # Create shared mock binary directory
+    export ED_MOCK_DIR
+    ED_MOCK_DIR="$(mktemp -d)"
+
+    # Build the flexible mock docker script
+    cat > "$ED_MOCK_DIR/docker" << 'MOCK'
+#!/bin/bash
+if [[ "${MOCK_DOCKER_ABSENT:-0}" -ne 0 ]]; then
+    echo "bash: docker: command not found" >&2
+    exit 127
+fi
+case "$1" in
+    version)
+        if [[ "$*" == *GitCommit* ]]; then
+            printf '%s\n' "${MOCK_DOCKER_COMMIT:-abc1234}"
+        else
+            printf '%s\n' "${MOCK_DOCKER_VERSION:-24.0.7}"
+        fi
+        exit 0
+        ;;
+    compose)
+        if [[ "${MOCK_COMPOSE_ABSENT:-0}" -ne 0 ]]; then
+            echo "docker: 'compose' is not a docker command" >&2
+            exit 1
+        fi
+        printf '%s\n' "${MOCK_COMPOSE_VERSION:-2.20.0}"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK
+    chmod +x "$ED_MOCK_DIR/docker"
+
+    # Build mock apt-cache script
+    cat > "$ED_MOCK_DIR/apt-cache" << 'MOCK'
+#!/bin/bash
+# MOCK_APT_VERSIONS — space-separated list of versions (newest first)
+# Default simulates Docker CE APT repo offering a few versions.
+if [[ "$1" == "policy" ]]; then
+    versions="${MOCK_APT_VERSIONS:-25.0.3 24.0.9 24.0.7 23.0.6}"
+    for v in $versions; do
+        printf '   %s\n' "$v"
+    done
+fi
+exit 0
+MOCK
+    chmod +x "$ED_MOCK_DIR/apt-cache"
+
+    # Build mock apt-get script
+    cat > "$ED_MOCK_DIR/apt-get" << 'MOCK'
+#!/bin/bash
+# MOCK_APT_GET_EXIT — exit code for apt-get install (default: 0)
+exit "${MOCK_APT_GET_EXIT:-0}"
+MOCK
+    chmod +x "$ED_MOCK_DIR/apt-get"
+
+    # Integration: check Docker availability for DinD tests
+    export ED_TEST_DOCKER_AVAILABLE=0
+    if command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
+        export ED_TEST_DOCKER_AVAILABLE=1
+    fi
+}
+
+teardown_file() {
+    [[ -d "${ED_MOCK_DIR:-}" ]] && rm -rf "$ED_MOCK_DIR"
+}
+
+setup() {
+    # Prepend mock dir so cg_guard resolves our stubs at source time
+    export PATH="$ED_MOCK_DIR:$PATH"
+    # shellcheck source=../config/ensure_docker.sh
+    source "$LIB" || return "$ED_TEST_SOURCE_FAILED"
+}
+
+# ---------------------------------------------------------------------------
+# Source-time checks
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,source,issue-132
+@test "ensure_docker.sh sources without error" {
+    # Already done in setup; reaching here means source succeeded
+    true
+}
+
+# bats test_tags=ensure_docker,source,issue-132
+@test "all ED_ERR_ constants are defined after sourcing" {
+    [[ -n "${ED_ERR_INSUFFICIENT_PRIVILEGE+x}" ]] || { echo "ED_ERR_INSUFFICIENT_PRIVILEGE missing" >&2; false; }
+    [[ -n "${ED_ERR_MISSING_ARGUMENT+x}" ]]       || { echo "ED_ERR_MISSING_ARGUMENT missing" >&2;       false; }
+    [[ -n "${ED_ERR_SYNTAX_ERROR+x}" ]]           || { echo "ED_ERR_SYNTAX_ERROR missing" >&2;           false; }
+    [[ -n "${ED_ERR_NO_DOCKER+x}" ]]              || { echo "ED_ERR_NO_DOCKER missing" >&2;              false; }
+    [[ -n "${ED_ERR_NO_COMPOSE+x}" ]]             || { echo "ED_ERR_NO_COMPOSE missing" >&2;             false; }
+    [[ -n "${ED_ERR_WRONG_VERSION+x}" ]]          || { echo "ED_ERR_WRONG_VERSION missing" >&2;          false; }
+    [[ -n "${ED_ERR_VERSION_NOT_FOUND+x}" ]]      || { echo "ED_ERR_VERSION_NOT_FOUND missing" >&2;      false; }
+    [[ -n "${ED_ERR_VERSION_VULNERABLE+x}" ]]     || { echo "ED_ERR_VERSION_VULNERABLE missing" >&2;     false; }
+    [[ -n "${ED_ERR_DEPENDENCY_MISSING+x}" ]]     || { echo "ED_ERR_DEPENDENCY_MISSING missing" >&2;     false; }
+    [[ -n "${ED_ERR_ALREADY_INSTALLED+x}" ]]      || { echo "ED_ERR_ALREADY_INSTALLED missing" >&2;      false; }
+}
+
+# bats test_tags=ensure_docker,source,issue-132
+@test "ED_ERR_ numeric values match the approved table" {
+    [[ "$ED_ERR_INSUFFICIENT_PRIVILEGE" -eq 7  ]]
+    [[ "$ED_ERR_MISSING_ARGUMENT"       -eq 8  ]]
+    [[ "$ED_ERR_SYNTAX_ERROR"           -eq 9  ]]
+    [[ "$ED_ERR_NO_DOCKER"              -eq 13 ]]
+    [[ "$ED_ERR_NO_COMPOSE"             -eq 14 ]]
+    [[ "$ED_ERR_WRONG_VERSION"          -eq 15 ]]
+    [[ "$ED_ERR_VERSION_NOT_FOUND"      -eq 16 ]]
+    [[ "$ED_ERR_VERSION_VULNERABLE"     -eq 17 ]]
+    [[ "$ED_ERR_DEPENDENCY_MISSING"     -eq 19 ]]
+    [[ "$ED_ERR_ALREADY_INSTALLED"      -eq 20 ]]
+}
+
+# bats test_tags=ensure_docker,source,issue-132
+@test "Stage 1 entry points are defined after sourcing" {
+    [[ "$(type -t ed_has_docker)"       == "function" ]]
+    [[ "$(type -t ed_install_docker)"   == "function" ]]
+    [[ "$(type -t ed_uninstall_docker)" == "function" ]]
+}
+
+# ---------------------------------------------------------------------------
+# _ed_semver_compare
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_compare — equal versions returns 0" {
+    run _ed_semver_compare "24.0.7" "24.0.7"
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_compare — major greater returns 1" {
+    run _ed_semver_compare "25.0.0" "24.0.0"
+    [[ "$status" -eq 1 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_compare — major lesser returns 2" {
+    run _ed_semver_compare "23.0.0" "24.0.0"
+    [[ "$status" -eq 2 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_compare — minor greater returns 1" {
+    run _ed_semver_compare "24.1.0" "24.0.0"
+    [[ "$status" -eq 1 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_compare — minor lesser returns 2" {
+    run _ed_semver_compare "24.0.0" "24.1.0"
+    [[ "$status" -eq 2 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_compare — patch greater returns 1" {
+    run _ed_semver_compare "24.0.8" "24.0.7"
+    [[ "$status" -eq 1 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_compare — patch lesser returns 2" {
+    run _ed_semver_compare "24.0.6" "24.0.7"
+    [[ "$status" -eq 2 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _ed_semver_satisfies  (constraint satisfaction)
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — ge satisfied" {
+    run _ed_semver_satisfies "24.0.7" ">=24.0.0"
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — ge exact boundary satisfied" {
+    run _ed_semver_satisfies "24.0.0" ">=24.0.0"
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — ge not satisfied" {
+    run _ed_semver_satisfies "23.0.9" ">=24.0.0"
+    [[ "$status" -ne 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — lt satisfied" {
+    run _ed_semver_satisfies "24.0.7" "<25.0.0"
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — lt exact boundary not satisfied" {
+    run _ed_semver_satisfies "25.0.0" "<25.0.0"
+    [[ "$status" -ne 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — combined range satisfied" {
+    run _ed_semver_satisfies "24.0.7" ">=24.0.0,<25.0.0"
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — combined range not satisfied — too low" {
+    run _ed_semver_satisfies "23.0.9" ">=24.0.0,<25.0.0"
+    [[ "$status" -ne 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — combined range not satisfied — too high" {
+    run _ed_semver_satisfies "25.0.1" ">=24.0.0,<25.0.0"
+    [[ "$status" -ne 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — exact match =A.B.C satisfied" {
+    run _ed_semver_satisfies "24.0.7" "=24.0.7"
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — exact match =A.B.C not satisfied" {
+    run _ed_semver_satisfies "24.0.8" "=24.0.7"
+    [[ "$status" -ne 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — shorthand =A.B accepts patch within minor" {
+    run _ed_semver_satisfies "24.0.9" "=24.0"
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — shorthand =A.B rejects different minor" {
+    run _ed_semver_satisfies "24.1.0" "=24.0"
+    [[ "$status" -ne 0 ]]
+}
+
+# bats test_tags=ensure_docker,semver,issue-132
+@test "_ed_semver_satisfies — bad constraint returns ED_ERR_SYNTAX_ERROR" {
+    run _ed_semver_satisfies "24.0.7" ">=bad.version"
+    [[ "$status" -eq "$ED_ERR_SYNTAX_ERROR" ]]
+}
+
+# ---------------------------------------------------------------------------
+# ed_has_docker
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,has_docker,issue-132
+@test "ed_has_docker — returns ED_ERR_NO_DOCKER when docker absent" {
+    MOCK_DOCKER_ABSENT=1 run ed_has_docker
+    [[ "$status" -eq "$ED_ERR_NO_DOCKER" ]]
+}
+
+# bats test_tags=ensure_docker,has_docker,issue-132
+@test "ed_has_docker — returns ED_ERR_NO_COMPOSE when compose absent" {
+    MOCK_COMPOSE_ABSENT=1 run ed_has_docker
+    [[ "$status" -eq "$ED_ERR_NO_COMPOSE" ]]
+}
+
+# bats test_tags=ensure_docker,has_docker,issue-132
+@test "ed_has_docker — returns 0 when docker and compose present no constraint" {
+    run ed_has_docker
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,has_docker,issue-132
+@test "ed_has_docker — returns 0 when version satisfies ge constraint" {
+    MOCK_DOCKER_VERSION=24.0.7 run ed_has_docker ">=24.0.0"
+    [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=ensure_docker,has_docker,issue-132
+@test "ed_has_docker — returns ED_ERR_WRONG_VERSION when version too low" {
+    MOCK_DOCKER_VERSION=23.0.9 run ed_has_docker ">=24.0.0"
+    [[ "$status" -eq "$ED_ERR_WRONG_VERSION" ]]
+}
+
+# bats test_tags=ensure_docker,has_docker,issue-132
+@test "ed_has_docker — returns ED_ERR_SYNTAX_ERROR on malformed constraint" {
+    run ed_has_docker ">=not-a-version"
+    [[ "$status" -eq "$ED_ERR_SYNTAX_ERROR" ]]
+}
+
+# bats test_tags=ensure_docker,has_docker,issue-132
+@test "ed_has_docker — prints a message to stderr on failure" {
+    MOCK_DOCKER_ABSENT=1 run ed_has_docker
+    [[ -n "$output" ]]
+}
+
+# ---------------------------------------------------------------------------
+# ed_install_docker
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,install_docker,issue-132
+@test "ed_install_docker — returns ED_ERR_ALREADY_INSTALLED when docker present and no --update" {
+    # Docker mock returns 0 for 'docker version' — simulates Docker present.
+    # Privilege check must come AFTER the already-installed check so this test
+    # works as a non-root user.
+    run ed_install_docker
+    [[ "$status" -eq "$ED_ERR_ALREADY_INSTALLED" ]]
+}
+
+# bats test_tags=ensure_docker,install_docker,issue-132
+@test "ed_install_docker — returns ED_ERR_INSUFFICIENT_PRIVILEGE when not root and docker absent" {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        skip "running as root — privilege check cannot be exercised"
+    fi
+    MOCK_DOCKER_ABSENT=1 run ed_install_docker
+    [[ "$status" -eq "$ED_ERR_INSUFFICIENT_PRIVILEGE" ]]
+}
+
+# bats test_tags=ensure_docker,install_docker,issue-132
+@test "ed_install_docker --update returns ED_ERR_INSUFFICIENT_PRIVILEGE when not root" {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        skip "running as root — privilege check cannot be exercised"
+    fi
+    run ed_install_docker --update
+    [[ "$status" -eq "$ED_ERR_INSUFFICIENT_PRIVILEGE" ]]
+}
+
+# bats test_tags=ensure_docker,install_docker,issue-132
+@test "ed_install_docker — returns ED_ERR_SYNTAX_ERROR on unknown option" {
+    run ed_install_docker --unknown-flag
+    [[ "$status" -eq "$ED_ERR_SYNTAX_ERROR" ]]
+}
+
+# bats test_tags=ensure_docker,install_docker,issue-132
+@test "ed_install_docker — returns ED_ERR_VERSION_NOT_FOUND when no apt candidate matches constraint" {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        skip "requires root to reach version-selection logic"
+    fi
+    MOCK_DOCKER_ABSENT=1 MOCK_APT_VERSIONS="24.0.7" \
+        run ed_install_docker ">=99.0.0"
+    [[ "$status" -eq "$ED_ERR_VERSION_NOT_FOUND" ]]
+}
+
+# ---------------------------------------------------------------------------
+# ed_uninstall_docker
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,uninstall_docker,issue-132
+@test "ed_uninstall_docker — returns ED_ERR_INSUFFICIENT_PRIVILEGE when not root" {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        skip "running as root — privilege check cannot be exercised"
+    fi
+    run ed_uninstall_docker
+    [[ "$status" -eq "$ED_ERR_INSUFFICIENT_PRIVILEGE" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Integration tests — Docker-in-Docker (privileged Ubuntu container)
+# ---------------------------------------------------------------------------
+
+# bats test_tags=ensure_docker,integration,issue-132
+@test "integration — ed_install_docker installs docker on clean system" {
+    if [[ "$ED_TEST_DOCKER_AVAILABLE" -ne 1 ]]; then
+        skip "Docker-in-Docker not available"
+    fi
+    skip "integration fixture not yet set up — Stage 1 implementation task"
+}
+
+# bats test_tags=ensure_docker,integration,issue-132
+@test "integration — ed_install_docker returns ED_ERR_ALREADY_INSTALLED on second call" {
+    if [[ "$ED_TEST_DOCKER_AVAILABLE" -ne 1 ]]; then
+        skip "Docker-in-Docker not available"
+    fi
+    skip "integration fixture not yet set up — Stage 1 implementation task"
+}
+
+# bats test_tags=ensure_docker,integration,issue-132
+@test "integration — ed_uninstall_docker removes docker and ed_has_docker returns ED_ERR_NO_DOCKER" {
+    if [[ "$ED_TEST_DOCKER_AVAILABLE" -ne 1 ]]; then
+        skip "Docker-in-Docker not available"
+    fi
+    skip "integration fixture not yet set up — Stage 1 implementation task"
+}
+
+return 0
+
+# --- Change History -------------------------------------------------------
+# | PR     | Summary                                                       |
+# |--------|---------------------------------------------------------------|
+# | #TBD   | initial preliminary tests — Stage 1 (issue #132)              |

--- a/test/test-ensure_docker.bats
+++ b/test/test-ensure_docker.bats
@@ -133,6 +133,7 @@ setup() {
     [[ -n "${ED_ERR_VERSION_VULNERABLE+x}" ]]     || { echo "ED_ERR_VERSION_VULNERABLE missing" >&2;     false; }
     [[ -n "${ED_ERR_DEPENDENCY_MISSING+x}" ]]     || { echo "ED_ERR_DEPENDENCY_MISSING missing" >&2;     false; }
     [[ -n "${ED_ERR_ALREADY_INSTALLED+x}" ]]      || { echo "ED_ERR_ALREADY_INSTALLED missing" >&2;      false; }
+    [[ -n "${ED_ERR_HOST_INCOMPATIBLE+x}" ]]      || { echo "ED_ERR_HOST_INCOMPATIBLE missing" >&2;      false; }
 }
 
 # bats test_tags=ensure_docker,source,issue-132
@@ -147,6 +148,7 @@ setup() {
     [[ "$ED_ERR_VERSION_VULNERABLE"     -eq 17 ]]
     [[ "$ED_ERR_DEPENDENCY_MISSING"     -eq 19 ]]
     [[ "$ED_ERR_ALREADY_INSTALLED"      -eq 20 ]]
+    [[ "$ED_ERR_HOST_INCOMPATIBLE"      -eq 21 ]]
 }
 
 # bats test_tags=ensure_docker,source,issue-132
@@ -375,6 +377,28 @@ setup() {
     MOCK_DOCKER_ABSENT=1 MOCK_APT_VERSIONS="24.0.7" \
         run ed_install_docker ">=99.0.0"
     [[ "$status" -eq "$ED_ERR_VERSION_NOT_FOUND" ]]
+}
+
+# bats test_tags=ensure_docker,install_docker,issue-132
+@test "ed_install_docker — returns ED_ERR_HOST_INCOMPATIBLE when apt-get fails for host reasons" {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        skip "requires root to reach apt-get execution"
+    fi
+    # Simulate: version exists in APT but apt-get install itself fails
+    # (e.g. broken dependencies, incompatible OS).
+    MOCK_DOCKER_ABSENT=1 MOCK_APT_GET_EXIT=100 \
+        run ed_install_docker
+    [[ "$status" -eq "$ED_ERR_HOST_INCOMPATIBLE" ]]
+}
+
+# bats test_tags=ensure_docker,install_docker,issue-132
+@test "ed_install_docker — emits stderr diagnostic on ED_ERR_HOST_INCOMPATIBLE" {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        skip "requires root to reach apt-get execution"
+    fi
+    MOCK_DOCKER_ABSENT=1 MOCK_APT_GET_EXIT=100 \
+        run ed_install_docker
+    [[ -n "$output" ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/test/test-file-structure.bats
+++ b/test/test-file-structure.bats
@@ -161,11 +161,13 @@ _last_code_line() {
 
 # bats test_tags=structure,history,issue-132
 @test "config/ensure_docker.sh: last code line is NOT return 0" {
+  [[ -f "$ROOT/config/ensure_docker.sh" ]] || skip "ensure_docker.sh not yet implemented"
   [[ "$(_last_code_line "$ROOT/config/ensure_docker.sh")" != "return 0" ]]
 }
 
 # bats test_tags=structure,history,issue-132
 @test "config/ensure_docker.sh: change history block present" {
+  [[ -f "$ROOT/config/ensure_docker.sh" ]] || skip "ensure_docker.sh not yet implemented"
   grep -q "^# --- Change History" "$ROOT/config/ensure_docker.sh"
 }
 

--- a/test/test-file-structure.bats
+++ b/test/test-file-structure.bats
@@ -159,6 +159,41 @@ _last_code_line() {
   [[ -f "$ROOT/.claude/commands/remote-run.md" ]]
 }
 
+# bats test_tags=structure,history,issue-132
+@test "config/ensure_docker.sh: last code line is NOT return 0" {
+  [[ "$(_last_code_line "$ROOT/config/ensure_docker.sh")" != "return 0" ]]
+}
+
+# bats test_tags=structure,history,issue-132
+@test "config/ensure_docker.sh: change history block present" {
+  grep -q "^# --- Change History" "$ROOT/config/ensure_docker.sh"
+}
+
+# bats test_tags=structure,history,issue-132
+@test "test/test-ensure_docker.bats: last code line is return 0" {
+  [[ "$(_last_code_line "$ROOT/test/test-ensure_docker.bats")" == "return 0" ]]
+}
+
+# bats test_tags=structure,history,issue-132
+@test "test/test-ensure_docker.bats: change history block present" {
+  grep -q "^# --- Change History" "$ROOT/test/test-ensure_docker.bats"
+}
+
+# bats test_tags=structure,history,issue-132
+@test "docs/libraries/ensure_docker.rst: change history RST comment present" {
+  grep -q "Change History" "$ROOT/docs/libraries/ensure_docker.rst"
+}
+
+# bats test_tags=structure,history,issue-132
+@test "ensure-docker skill has history.md" {
+  [[ -f "$ROOT/.github/skills/ensure-docker/history.md" ]]
+}
+
+# bats test_tags=structure,history,issue-132
+@test "ensure-docker Claude skill file present" {
+  [[ -f "$ROOT/.claude/commands/ensure-docker.md" ]]
+}
+
 return 0
 
 # --- Change History -------------------------------------------------------
@@ -167,3 +202,4 @@ return 0
 # | #43   | initial file — structural tests for PR change history sections |
 # | #134  | invert return-0 assertions; add full remote_run coverage [closes #133] |
 # | #142  | update history.md paths to .claude/commands/; remove skill-creator test [closes #141] |
+# | #TBD  | add structural coverage for ensure_docker.sh (issue #132)      |

--- a/test/test-file-structure.bats
+++ b/test/test-file-structure.bats
@@ -204,4 +204,4 @@ return 0
 # | #43   | initial file — structural tests for PR change history sections |
 # | #134  | invert return-0 assertions; add full remote_run coverage [closes #133] |
 # | #142  | update history.md paths to .claude/commands/; remove skill-creator test [closes #141] |
-# | #TBD  | add structural coverage for ensure_docker.sh (issue #132)      |
+# | #135  | add structural coverage for ensure_docker.sh (issue #132)      |


### PR DESCRIPTION
## Description

Task 4 (TDD) deliverable for issue #132.  Adds the full Sphinx
documentation and preliminary test suite for the `ensure_docker.sh`
library.  No implementation yet — all tests are either structural
assertions (companion-file presence, change-history blocks) that pass
now, or functional tests that skip gracefully until `config/ensure_docker.sh`
is created in a subsequent PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes

**`docs/libraries/ensure_docker.rst`** — new Sphinx documentation covering:
- Purpose, two-stage architecture, and dependency table
- Quick-start examples
- Complete error-code table with numeric values
- Version constraint syntax
- Stage 1 public API (`ed_has_docker`, `ed_install_docker`,
  `ed_uninstall_docker`) with full behaviour and error descriptions
- State consistency policy (3 rules, persist-once pattern)
- Stage 2 state variable schema (6 variables, chain example)
- Accessor helper calling convention — predefined output variables
  (`__ed_value`, `__ed_seq`) via Bash dynamic scoping; no namerefs in
  helpers
- Stage 2 public API (`ed_ensure_docker`, `ed_docker_version`,
  `ed_cleanup`) with full behaviour and revert algorithm

**`test/test-ensure_docker.bats`** — preliminary tests for Stage 1:
- Mock `docker`, `apt-cache`, `apt-get` binaries controlled by env vars
- Source-time checks (library loads, all 12 error codes defined and
  numerically correct, all Stage 1 functions present)
- `_ed_semver_compare` — 7 cases covering major/minor/patch ordering
- `_ed_semver_satisfies` — 14 cases covering `>=`, `<`, range, `=A.B.C`,
  `=A.B` shorthand, and syntax-error detection
- `ed_has_docker` — 7 cases: absent, no-compose, present, constraint
  satisfied/not, malformed constraint, stderr on failure
- `ed_install_docker` — 7 cases: already-installed, insufficient
  privilege, `--update` privilege, unknown option, version-not-found,
  host-incompatible, stderr diagnostic
- `ed_uninstall_docker` — 1 case: insufficient privilege
- 3 DinD integration test stubs (skipped — fixture deferred to Stage 1
  implementation PR)
- Skip-all guard: when `config/ensure_docker.sh` is absent the entire
  suite reports skip rather than failing setup

**`test/test-file-structure.bats`** — structural tests for the new library:
- Two `config/ensure_docker.sh` tests now skip gracefully when the file
  is absent (previously one failed with exit 2)

**`.claude/commands/ensure-docker.md`** — Claude skill command file

**`.github/skills/ensure-docker/history.md`** — skill change-history file

**`docs/libraries/index.rst`** — `ensure_docker` added to toctree

## Testing

- [x] `bats test/test-file-structure.bats` — 32 pass, 2 skip (ensure_docker.sh not yet implemented)
- [x] `bats test/test-ensure_docker.bats` — 42 skip (library not yet implemented), 0 fail
- [ ] Integration tests — skipped, DinD fixture deferred to Stage 1 implementation PR

## Related Issues

Closes #132 (Task 4 milestone — doc and preliminary tests)

## Checklist

- [x] Code follows project standards
- [x] Documentation updated
- [x] Tests pass (or skip gracefully)
- [ ] Reviewed by team member