### PR TITLE
feat(handle_state): hs_extract_token and hs_write_token token-utility entry-point pattern (closes #136)

### DIFF
--- a/.claude/agent-memory/library-skill-updater/project_issue136.md
+++ b/.claude/agent-memory/library-skill-updater/project_issue136.md
@@ -1,0 +1,19 @@
+---
+name: issue-136 hs_extract_token and hs_write_token
+description: Two zero-collision token routing helpers added to handle_state.sh in issue #136; document all three call forms
+type: project
+---
+
+Issue #136 adds `hs_extract_token` and `hs_write_token` to `config/handle_state.sh` to eliminate the nameref collision surface identified in issue #104 (PR #109).
+
+**Why:** Public entry points that accept `-S <statevar>` were using namerefs, which risk collision when a caller names their variable the same as a nameref local. The subshell-based `eval "$(...)"` pattern isolates the token extraction into a subprocess with zero collision surface.
+
+**How to apply:** When writing or updating the handle-state library skill, document `hs_extract_token` with all three call forms (direct `--list-reserved`, normal eval, eval with `--list-reserved` splice) and `hs_write_token` with its two forms. Always show the canonical read-write and read-only entry-point patterns as the preferred approach for any public function accepting `-S`.
+
+Key facts:
+- `hs_extract_token` Form 2: `eval "$(hs_extract_token <local_name> "$@")"` — emits `local <local_name>='<value>'`
+- `hs_extract_token` Form 3: `eval "$(hs_extract_token <local_name> --list-reserved "$@")"` — emits `local list_reserved=1` sentinel when `--list-reserved` detected
+- `hs_write_token`: `eval "$(hs_write_token <source_local> "$@")"` — emits `<statevar>=<value>` (no `local`)
+- Both helpers use `bash -c 'exit N'` to signal errors through eval
+- `_hs_local_exists "$(local -p)" <name>` detects presence of sentinel locals
+- OPTARG remains the only universally reserved name that cannot be used as an entry-point local

--- a/.claude/agent-memory/library-skill-updater/project_issue136.md
+++ b/.claude/agent-memory/library-skill-updater/project_issue136.md
@@ -11,9 +11,12 @@ Issue #136 adds `hs_extract_token` and `hs_write_token` to `config/handle_state.
 **How to apply:** When writing or updating the handle-state library skill, document `hs_extract_token` with all three call forms (direct `--list-reserved`, normal eval, eval with `--list-reserved` splice) and `hs_write_token` with its two forms. Always show the canonical read-write and read-only entry-point patterns as the preferred approach for any public function accepting `-S`.
 
 Key facts:
-- `hs_extract_token` Form 2: `eval "$(hs_extract_token <local_name> "$@")"` — emits `local <local_name>='<value>'`
-- `hs_extract_token` Form 3: `eval "$(hs_extract_token <local_name> --list-reserved "$@")"` — emits `local list_reserved=1` sentinel when `--list-reserved` detected
-- `hs_write_token`: `eval "$(hs_write_token <source_local> "$@")"` — emits `<statevar>=<value>` (no `local`)
+- `hs_extract_token` has two forms:
+  - Form 1 (direct query): `hs_extract_token --list-reserved` — prints collision surface names
+  - Form 2 (eval): `eval "$(hs_extract_token <local_name> "$@")"` — auto-detects `--list-reserved`
+    at `$2` (when the caller passes it as their first arg); emits `local list_reserved=1` +
+    `local <local_name>=''` in that mode, or `local <local_name>='<value>'` in normal mode
+- `hs_write_token`: `eval "$(hs_write_token <source_local> "$@")"` — emits `<statevar>='<value>'` (no `local`)
 - Both helpers use `bash -c 'exit N'` to signal errors through eval
-- `_hs_local_exists "$(local -p)" <name>` detects presence of sentinel locals
+- `[[ -n "${varname@A}" ]]` detects whether a variable is declared (even if unset) — use instead of any internal function call
 - OPTARG remains the only universally reserved name that cannot be used as an entry-point local

--- a/.claude/agent-memory/library-skill-updater/project_issue136.md
+++ b/.claude/agent-memory/library-skill-updater/project_issue136.md
@@ -1,22 +1,24 @@
 ---
 name: issue-136 hs_extract_token and hs_write_token
-description: Two zero-collision token routing helpers added to handle_state.sh in issue #136; document all three call forms
+description: Two minimum-collision-surface token routing helpers added to handle_state.sh in issue #136; two call forms (direct and eval), eval form has two operational modes
 type: project
 ---
 
-Issue #136 adds `hs_extract_token` and `hs_write_token` to `config/handle_state.sh` to eliminate the nameref collision surface identified in issue #104 (PR #109).
+Issue #136 adds `hs_extract_token` and `hs_write_token` to `config/handle_state.sh` to reduce the name-collision surface for public entry points identified in issue #104 (PR #109).
 
-**Why:** Public entry points that accept `-S <statevar>` were using namerefs, which risk collision when a caller names their variable the same as a nameref local. The subshell-based `eval "$(...)"` pattern isolates the token extraction into a subprocess with zero collision surface.
+**Why:** Public entry points that accept `-S <statevar>` were using direct variable assignment via dynamic scoping, which risks collision when a caller names their variable the same as a local in the entry point. The subshell-based `eval "$(...)"` pattern isolates token access into a subprocess with a **minimal** (not zero) collision surface: `hs_extract_token` still declares `__hs_processed` and `__hs_remaining` in the subshell frame, but those are `__hs_`-prefixed and documented.
 
-**How to apply:** When writing or updating the handle-state library skill, document `hs_extract_token` with all three call forms (direct `--list-reserved`, normal eval, eval with `--list-reserved` splice) and `hs_write_token` with its two forms. Always show the canonical read-write and read-only entry-point patterns as the preferred approach for any public function accepting `-S`.
+**How to apply:** When writing or updating the handle-state library skill, document `hs_extract_token` with its **two** call forms (direct `--list-reserved` and eval) and note that the eval form has two operational modes (normal and auto-`--list-reserved`). Document `hs_write_token` with its two forms (direct query and eval). Always show the canonical read-write and read-only entry-point patterns as the preferred approach for any public function accepting `-S`.
+
+> **IMPORTANT:** Never call `_hs_*` or `__hs_*` internal functions from library code or documentation examples. Only call public API functions. Do not read the library source to infer behavior — rely solely on the documented public API.
 
 Key facts:
-- `hs_extract_token` has two forms:
+- `hs_extract_token` has two call forms:
   - Form 1 (direct query): `hs_extract_token --list-reserved` — prints collision surface names
   - Form 2 (eval): `eval "$(hs_extract_token <local_name> "$@")"` — auto-detects `--list-reserved`
     at `$2` (when the caller passes it as their first arg); emits `local list_reserved=1` +
     `local <local_name>=''` in that mode, or `local <local_name>='<value>'` in normal mode
 - `hs_write_token`: `eval "$(hs_write_token <source_local> "$@")"` — emits `<statevar>='<value>'` (no `local`)
 - Both helpers use `bash -c 'exit N'` to signal errors through eval
-- `[[ -n "${varname@A}" ]]` detects whether a variable is declared (even if unset) — use instead of any internal function call
+- To detect if a variable is declared locally, use `local -p <name> >/dev/null 2>&1` (returns 0 if declared, 1 if not)
 - OPTARG remains the only universally reserved name that cannot be used as an entry-point local

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -9,6 +9,10 @@ description: Expert guidance for implementing and using the handle_state.sh Bash
 Use `docs/libraries/handle_state.rst` as the canonical local reference for the
 API, warnings, and limitations.
 
+> **IMPORTANT:** Never call `_hs_*` or `__hs_*` internal functions from library code or
+> documentation examples. Do not read the library source to infer behavior — use only the
+> documented public API.
+
 ## Quick Workflow
 
 - Source `config/handle_state.sh` once in the main script or library entrypoint.
@@ -16,7 +20,7 @@ API, warnings, and limitations.
 - In body helpers, call `hs_persist_state -S __mylib_state_token -- <local1> <local2> ...`
   to save state and `hs_read_persisted_state -S __mylib_state_token -- <local1> <local2> ...`
   to restore it. Body helpers hardcode the state variable name because it is a library
-  constant declared in the entry-point frame (not user-supplied), and its name is part of
+  constant defined in the entry-point frame (not user-defined), and its name is part of
   the calling convention of the helper.
 - New libraries must expose `-S` and must not carry state via stdout.
 - The state token is an opaque string assigned to the named variable; never interpret or
@@ -77,9 +81,13 @@ Two call forms:
 ```bash
 hs_extract_token --list-reserved
 ```
-Prints every local in `hs_extract_token`'s own frame, one per line. These are the names
-forming the collision surface of this function itself — prohibited as the `-S` argument to
-any entry point that delegates to `hs_extract_token`.
+Prints the names forming the collision surface of `hs_extract_token` itself, one per line.
+As of the current release the output is:
+
+```
+__hs_processed
+__hs_remaining
+```
 
 **Form 2 — eval form** (`$1` is local name, `${@:2}` are the forwarded args):
 ```bash
@@ -89,6 +97,7 @@ The eval form has two operational modes selected automatically by the caller's a
 
 - **Normal mode** (`$2` is not `--list-reserved`): parses `-S <statevar>` from `${@:2}`
   and emits `local __mylib_state_token='<value>'` on success, or `bash -c 'exit N'` on error.
+  The collision surface at fork time consists of `hs_extract_token`'s own locals only.
 
 - **Auto `--list-reserved` mode** (`$2 == --list-reserved`): activated when the caller passes
   `--list-reserved` as their first argument, making `$2` of `hs_extract_token` equal to
@@ -97,7 +106,7 @@ The eval form has two operational modes selected automatically by the caller's a
   local list_reserved=1
   local __mylib_state_token=''
   ```
-  No further arguments (`$3..`) are valid in this mode.
+  No further arguments are valid in this mode.
 
 ### `hs_write_token` — token write-back for entry points
 
@@ -107,13 +116,15 @@ eval "$(hs_write_token __mylib_state_token "$@")" || return $?
 ```
 Parses `-S <statevar>` from `${@:2}` (the forwarded args, which include `-S`) and emits
 `<statevar>='<value>'` (plain assignment, not `local`) on success, or `bash -c 'exit N'`
-on error. The collision surface depends on the locals declared in the entry-point frame
-before this call. When the proper helper pattern has been followed, the token has already
-been updated and the surface equals that of `hs_extract_token`.
+on error. The collision surface includes at minimum `__mylib_state_token` plus
+`hs_extract_token`'s own locals. Any other locals declared in the entry-point frame before
+this call also add to the surface. When the body-helper pattern is followed strictly, only
+the token local is declared, keeping the surface to those three names.
 
 **`--list-reserved` form** (when `$2 == --list-reserved`):
-Prints the function's own frame locals plus `$1` (the source local, which is in the
-entry-point's collision space for read-write functions).
+Computes the collision surface at the point of the call (via `local -p` in the subshell
+frame) and prints it plus `$1` (the source local name, which is in the entry-point's
+collision space for read-write functions).
 
 Note: `hs_write_token` cannot avoid a name collision if the `-S` state variable and the
 source local share a name. This edge case is addressed in issue #139.
@@ -124,18 +135,18 @@ source local share a name. This edge case is addressed in issue #139.
 
 ```bash
 mylib_func() {
+    # No extra locals; hs_extract_token emits __mylib_state_token via eval.
     eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-    if [[ -z "${list_reserved@A}" ]]; then
-        # __mylib_state_token accessible by _mylib_func_body via dynamic scoping.
-        # _mylib_func_body calls hs_read_persisted_state -S __mylib_state_token directly.
-        _mylib_func_body || return $?
+    if ! local -p list_reserved >/dev/null 2>&1; then
+        # __mylib_state_token accessible by _mylib_func via dynamic scoping.
+        # Body helper calls hs_read_persisted_state and hs_persist_state -S __mylib_state_token directly.
+        _mylib_func "$@" || return $?
     fi
-    # hs_write_token reports the full reserved list (including __mylib_state_token)
-    # when --list-reserved is in $@, otherwise writes the token back.
+    # hs_write_token handles --list-reserved when active; otherwise writes the token back.
     eval "$(hs_write_token __mylib_state_token "$@")" || return $?
 }
 
-_mylib_func_body() {
+_mylib_func() {
     local var1 var2
     hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
     # ... work ...
@@ -152,11 +163,11 @@ so it delegates `--list-reserved` reporting directly to `hs_extract_token --list
 ```bash
 mylib_ro_func() {
     eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-    [[ -n "${list_reserved@A}" ]] && { hs_extract_token --list-reserved; return 0; }
-    _mylib_ro_func_body || return $?
+    local -p list_reserved >/dev/null 2>&1 && { hs_extract_token --list-reserved; return 0; }
+    _mylib_ro_func "$@" || return $?
 }
 
-_mylib_ro_func_body() {
+_mylib_ro_func() {
     local var1 var2
     hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
     # ... read-only work ...
@@ -173,14 +184,15 @@ from its caller, it must destroy those variables before re-persisting them.
 
 ```bash
 mylib_update_func() {
+    # No extra locals; hs_extract_token emits __mylib_state_token via eval.
     eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-    if [[ -z "${list_reserved@A}" ]]; then
-        _mylib_update_func_body || return $?
+    if ! local -p list_reserved >/dev/null 2>&1; then
+        _mylib_update_func "$@" || return $?
     fi
     eval "$(hs_write_token __mylib_state_token "$@")" || return $?
 }
 
-_mylib_update_func_body() {
+_mylib_update_func() {
     local var1 var2
     hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
     # ... mutate var1, var2 ...
@@ -195,23 +207,23 @@ _mylib_update_func_body() {
 source "$(dirname "$0")/config/handle_state.sh"
 
 mylib_init() {
-  local temp_file="/tmp/resource"
-  local resource_id="abc123"
-  local -a items=(one two three)
-  hs_persist_state "$@" -- temp_file resource_id items
+  local mylib_temp_file="/tmp/resource"
+  local mylib_resource_id="abc123"
+  local -a mylib_items=(one two three)
+  hs_persist_state "$@" -- mylib_temp_file mylib_resource_id mylib_items
 }
 
 mylib_cleanup() {
-  local temp_file resource_id
-  local -a items
+  local mylib_temp_file mylib_resource_id
+  local -a mylib_items
   eval "$(hs_read_persisted_state "$@")" || return $?   # implicit form preferred
-  rm -f "$temp_file"
-  hs_destroy_state "$@" -- temp_file resource_id items
+  rm -f "$mylib_temp_file"
+  hs_destroy_state "$@" -- mylib_temp_file mylib_resource_id mylib_items
 }
 
-local state
-mylib_init    -S state
-mylib_cleanup -S state
+local mylib_state
+mylib_init    -S mylib_state
+mylib_cleanup -S mylib_state
 ```
 
 ## Supported Variable Types
@@ -244,8 +256,9 @@ All Bash variable types are supported:
 
 ## Safety Notes
 
-- Avoid name collisions when chaining state through a shared state variable; prefer separate
-  state variables if libraries overlap variable names.
+- Think of a state variable as a session with a library. Mixing libraries into one
+  session exposes the caller to name collisions between libraries from different sources;
+  prefer separate state variables per library.
 - Do not require stdout to carry state as part of a library API; reserve stdout for normal
   user-visible output.
 - `hs_read_persisted_state` (implicit form) uses `local -p` to restrict restore to the
@@ -260,3 +273,12 @@ All Bash variable types are supported:
 - **To emit results from a subshell**, use the `hs_write_token` eval pattern: inside
   `$(...)` emit `<statevar>='<value>'` to stdout so the caller's `eval` writes the result
   back. On error emit `bash -c 'exit N'` so the caller's `eval` propagates the exit code.
+  Example:
+  ```bash
+  my_subshell_func() {
+      # runs inside $(...)
+      local result="computed-value"
+      printf '%s=%s\n' "$1" "$(printf '%q' "$result")"
+  }
+  eval "$(my_subshell_func __mylib_state_token)" || return $?
+  ```

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -1,5 +1,5 @@
 ---
-description: Expert guidance for implementing and using the handle_state.sh Bash library to persist initialization state to cleanup functions, centered on the -S state-variable pattern. Triggers on requests like "pass information", "write initialization function" or "write cleanup function" while developing a library or code module.
+description: Expert guidance for implementing and using the handle_state.sh Bash library to persist state among a group of library calls from initialization to cleanup, centered on the -S state-variable pattern. Triggers on requests like "pass information", "write initialization function" or "write cleanup function" while developing a library or code module.
 ---
 
 # Handle State Library Skill
@@ -12,22 +12,30 @@ API, warnings, and limitations.
 ## Quick Workflow
 
 - Source `config/handle_state.sh` once in the main script or library entrypoint.
-- Use `hs_extract_token` + `hs_write_token` in entry points to eliminate nameref collision risk.
-- In body helpers, call `hs_persist_state "$@" -- <local1> <local2> ...` to save state and `hs_read_persisted_state "$@" -- <local1> <local2> ...` to restore it.
+- Use `hs_extract_token` + `hs_write_token` in entry points to minimize name collision risk.
+- In body helpers, call `hs_persist_state -S __mylib_state_token -- <local1> <local2> ...`
+  to save state and `hs_read_persisted_state -S __mylib_state_token -- <local1> <local2> ...`
+  to restore it. Body helpers hardcode the state variable name because it is a library
+  constant declared in the entry-point frame (not user-supplied), and its name is part of
+  the calling convention of the helper.
 - New libraries must expose `-S` and must not carry state via stdout.
-- The state token is an opaque string assigned to the named variable; never interpret or construct it manually.
+- The state token is an opaque string assigned to the named variable; never interpret or
+  construct it manually.
 - If the same state variable must be reused across several init/cleanup cycles,
   call `hs_destroy_state` before the next init to remove the library's vars from
   the state vector and avoid `HS_ERR_VAR_NAME_COLLISION`.
+- In a library, call `hs_destroy_state -S __mylib_state_token -- var1 var2 ...` from the
+  cleanup function to expunge all state variables declared by init or any other library
+  function. The token must be fully cleared before the cleanup function returns.
 
 ## Primary Interface
 
 ### `hs_persist_state` — serialize locals into the state token
 
 ```bash
-hs_persist_state "$@" -- var1 var2        # forwarded-args form (preferred)
-hs_persist_state -S state_var -- var1     # explicit -S form
-hs_persist_state --list-reserved          # print internal reserved names
+hs_persist_state -S __mylib_state_token -- var1 var2   # explicit -S (preferred in body helpers)
+hs_persist_state "$@" -- var1 var2                      # forwarded-args form (entry-point delegation)
+hs_persist_state --list-reserved                        # print internal reserved names
 ```
 
 Supports scalars, indexed arrays (`-a`), associative arrays (`-A`), and namerefs
@@ -40,100 +48,118 @@ Two forms:
 
 **Implicit form** (preferred) — no variable list, emits a restore snippet to stdout:
 ```bash
-eval "$(hs_read_persisted_state "$@")" || return $?
+eval "$(hs_read_persisted_state -S __mylib_state_token)" || return $?
 ```
 Targets only the caller's own unset locals (via `local -p`); cannot pollute global scope.
 
 **Explicit form** — variable names after `--`:
 ```bash
-hs_read_persisted_state "$@" -- var1 var2 || return $?
+hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
 ```
-Traverses the full dynamic scope; use when targeting variables in a higher-level caller or declared globals.
+Traverses the full dynamic scope; use when targeting variables in a higher-level caller or
+declared globals.
 
 Both forms support `-q` to suppress warnings for missing variables.
 
 ### `hs_destroy_state` — remove variables from the state token
 
 ```bash
-hs_destroy_state "$@" -- var1 var2 || return $?
+hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
 ```
-Removes named entries from the state vector. Required before re-initializing against the same token.
+Removes named entries from the state vector. Required before re-initializing against the
+same token.
 
-### `hs_extract_token` — zero-collision token extraction for entry points
+### `hs_extract_token` — token extraction for entry points
 
-Three call forms depending on position of `--list-reserved`:
+Two call forms:
 
 **Form 1 — direct query** (`$1 == --list-reserved`):
 ```bash
 hs_extract_token --list-reserved
 ```
-Prints every local in `hs_extract_token`'s own frame, one per line.
+Prints every local in `hs_extract_token`'s own frame, one per line. These are the names
+forming the collision surface of this function itself — prohibited as the `-S` argument to
+any entry point that delegates to `hs_extract_token`.
 
-**Form 2 — normal eval form** (`$1` is local name, `$2..` are forwarded args):
+**Form 2 — eval form** (`$1` is local name, `${@:2}` are the forwarded args):
 ```bash
 eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
 ```
-Runs in a subshell. Parses `-S <statevar>` from forwarded args and emits
-`local <local_name>='<value>'` on success or `bash -c 'exit N'` on error.
-Collision space at fork: zero.
+The eval form has two operational modes selected automatically by the caller's argument list:
 
-**Form 3 — eval-code `--list-reserved`** (`$1` is local name, `$2 == --list-reserved`, `$3..` are forwarded args):
-```bash
-eval "$(hs_extract_token __mylib_state_token --list-reserved "$@")" || return $?
-```
-When `--list-reserved` appears in `$3..`, emits two sentinels:
-```bash
-local list_reserved=1
-local __mylib_state_token=''
-```
-If absent, falls through to Form 2 using `$3..` as the argument list.
+- **Normal mode** (`$2` is not `--list-reserved`): parses `-S <statevar>` from `${@:2}`
+  and emits `local __mylib_state_token='<value>'` on success, or `bash -c 'exit N'` on error.
 
-### `hs_write_token` — zero-collision token write-back for entry points
+- **Auto `--list-reserved` mode** (`$2 == --list-reserved`): activated when the caller passes
+  `--list-reserved` as their first argument, making `$2` of `hs_extract_token` equal to
+  `--list-reserved`. Emits two sentinels into the entry-point frame:
+  ```bash
+  local list_reserved=1
+  local __mylib_state_token=''
+  ```
+  No further arguments (`$3..`) are valid in this mode.
+
+### `hs_write_token` — token write-back for entry points
 
 **Normal eval form**:
 ```bash
 eval "$(hs_write_token __mylib_state_token "$@")" || return $?
 ```
-Runs in a subshell. Parses `-S <statevar>` from forwarded args and emits
-`<statevar>=<value>` (plain assignment, not `local`) on success or `bash -c 'exit N'` on error.
+Parses `-S <statevar>` from `${@:2}` (the forwarded args, which include `-S`) and emits
+`<statevar>='<value>'` (plain assignment, not `local`) on success, or `bash -c 'exit N'`
+on error. The collision surface depends on the locals declared in the entry-point frame
+before this call. When the proper helper pattern has been followed, the token has already
+been updated and the surface equals that of `hs_extract_token`.
 
 **`--list-reserved` form** (when `$2 == --list-reserved`):
-Emits a `printf` statement that, when `eval`ed, prints the function's own frame
-locals plus `$1` (the source local — which is in the entry-point's collision space).
+Prints the function's own frame locals plus `$1` (the source local, which is in the
+entry-point's collision space for read-write functions).
+
+Note: `hs_write_token` cannot avoid a name collision if the `-S` state variable and the
+source local share a name. This edge case is addressed in issue #139.
 
 ## Entry-Point Patterns
 
 ### Read-write entry point (restores and persists state)
 
 ```bash
-my_func() {
+mylib_func() {
     eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-    if ! _hs_local_exists "$(local -p)" list_reserved; then
-        _my_func_body "$@" || return $?
+    if [[ -z "${list_reserved@A}" ]]; then
+        # __mylib_state_token accessible by _mylib_func_body via dynamic scoping.
+        # _mylib_func_body calls hs_read_persisted_state -S __mylib_state_token directly.
+        _mylib_func_body || return $?
     fi
+    # hs_write_token reports the full reserved list (including __mylib_state_token)
+    # when --list-reserved is in $@, otherwise writes the token back.
     eval "$(hs_write_token __mylib_state_token "$@")" || return $?
 }
 
-_my_func_body() {
+_mylib_func_body() {
     local var1 var2
     hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
     # ... work ...
-    __mylib_state_token=""
-    hs_persist_state -S __mylib_state_token -- var1 var2 || return $?
+    hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
+    hs_persist_state  -S __mylib_state_token -- var1 var2 || return $?
 }
 ```
 
 ### Read-only entry point (restores state, does not persist)
 
+A well-designed read-only entry point has the same collision surface as `hs_extract_token`,
+so it delegates `--list-reserved` reporting directly to `hs_extract_token --list-reserved`.
+
 ```bash
-my_ro_func() {
-    eval "$(hs_extract_token __mylib_state_token --list-reserved "$@")" || return $?
-    if _hs_local_exists "$(local -p)" list_reserved; then
-        local lp_snapshot="$(local -p)"
-        _hs_print_reserved_names "$lp_snapshot" list_reserved
-        return 0
-    fi
-    _my_ro_func_body "$@" || return $?
+mylib_ro_func() {
+    eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+    [[ -n "${list_reserved@A}" ]] && { hs_extract_token --list-reserved; return 0; }
+    _mylib_ro_func_body || return $?
+}
+
+_mylib_ro_func_body() {
+    local var1 var2
+    hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+    # ... read-only work ...
 }
 ```
 
@@ -146,18 +172,20 @@ from its caller, it must destroy those variables before re-persisting them.
 `hs_write_token` propagates an incomplete token back.
 
 ```bash
-my_update_func() {
+mylib_update_func() {
     eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-    _my_update_func_body "$@" || return $?
+    if [[ -z "${list_reserved@A}" ]]; then
+        _mylib_update_func_body || return $?
+    fi
     eval "$(hs_write_token __mylib_state_token "$@")" || return $?
 }
 
-_my_update_func_body() {
+_mylib_update_func_body() {
     local var1 var2
     hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
     # ... mutate var1, var2 ...
     hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
-    hs_persist_state -S __mylib_state_token -- var1 var2 || return $?
+    hs_persist_state  -S __mylib_state_token -- var1 var2 || return $?
 }
 ```
 
@@ -166,24 +194,24 @@ _my_update_func_body() {
 ```bash
 source "$(dirname "$0")/config/handle_state.sh"
 
-init_function() {
+mylib_init() {
   local temp_file="/tmp/resource"
   local resource_id="abc123"
   local -a items=(one two three)
   hs_persist_state "$@" -- temp_file resource_id items
 }
 
-cleanup_function() {
+mylib_cleanup() {
   local temp_file resource_id
   local -a items
-  eval "$(hs_read_persisted_state "$@")" || return $?
+  eval "$(hs_read_persisted_state "$@")" || return $?   # implicit form preferred
   rm -f "$temp_file"
   hs_destroy_state "$@" -- temp_file resource_id items
 }
 
 local state
-init_function -S state
-cleanup_function -S state
+mylib_init    -S state
+mylib_cleanup -S state
 ```
 
 ## Supported Variable Types
@@ -216,8 +244,19 @@ All Bash variable types are supported:
 
 ## Safety Notes
 
-- `hs_persist_state` and `hs_read_persisted_state` use `eval` internally; treat state tokens as trusted input only.
-- Avoid name collisions when chaining state through a shared state variable; prefer separate state variables if libraries overlap variable names.
-- Do not require stdout to carry state as part of a library API; reserve stdout for normal user-visible output.
-- `hs_read_persisted_state` (implicit form) uses `local -p` to restrict restore to the immediate caller's own unset locals — this is the safe default. Use the explicit form only when you need to target higher-scope variables.
-- **Subshells cannot update the parent shell's token.** A `$(...)` command substitution or `( )` subshell group inherits a copy of the parent environment. Any `hs_persist_state` call inside a subshell writes only into that copy; the parent's token variable is never modified. Functions that run in a subshell cannot advance library state even if they call `hs_persist_state` successfully. Design stateful code paths to run directly in the shell process, not inside command substitutions.
+- Avoid name collisions when chaining state through a shared state variable; prefer separate
+  state variables if libraries overlap variable names.
+- Do not require stdout to carry state as part of a library API; reserve stdout for normal
+  user-visible output.
+- `hs_read_persisted_state` (implicit form) uses `local -p` to restrict restore to the
+  immediate caller's own unset locals — this is the safe default. Use the explicit form
+  only when you need to target higher-scope variables.
+- **Subshells cannot update the parent shell's token.** A `$(...)` command substitution or
+  `( )` subshell group inherits a copy of the parent environment. Any `hs_persist_state`
+  call inside a subshell writes only into that copy; the parent's token variable is never
+  modified. Functions that run in a subshell cannot advance library state even if they call
+  `hs_persist_state` successfully. Design stateful code paths to run directly in the shell
+  process, not inside command substitutions.
+- **To emit results from a subshell**, use the `hs_write_token` eval pattern: inside
+  `$(...)` emit `<statevar>='<value>'` to stdout so the caller's `eval` writes the result
+  back. On error emit `bash -c 'exit N'` so the caller's `eval` propagates the exit code.

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -89,18 +89,18 @@ __hs_processed
 __hs_remaining
 ```
 
-**Form 2 — eval form** (`$1` is local name, `${@:2}` are the forwarded args):
+**Form 2 — eval form** (`$1` is calling function name, `$2` is local name, `${@:3}` are the forwarded args):
 ```bash
-eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+eval "$(hs_extract_token mylib_func __mylib_state_token "$@")" || return $?
 ```
 The eval form has two operational modes selected automatically by the caller's argument list:
 
-- **Normal mode** (`$2` is not `--list-reserved`): parses `-S <statevar>` from `${@:2}`
+- **Normal mode** (`$3` is not `--list-reserved`): parses `-S <statevar>` from `${@:3}`
   and emits `local __mylib_state_token='<value>'` on success, or `bash -c 'exit N'` on error.
   The collision surface at fork time consists of `hs_extract_token`'s own locals only.
 
-- **Auto `--list-reserved` mode** (`$2 == --list-reserved`): activated when the caller passes
-  `--list-reserved` as their first argument, making `$2` of `hs_extract_token` equal to
+- **Auto `--list-reserved` mode** (`$3 == --list-reserved`): activated when the caller passes
+  `--list-reserved` as their first argument, making `$3` of `hs_extract_token` equal to
   `--list-reserved`. Emits two sentinels into the entry-point frame:
   ```bash
   local list_reserved=1
@@ -112,16 +112,16 @@ The eval form has two operational modes selected automatically by the caller's a
 
 **Normal eval form**:
 ```bash
-eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+eval "$(hs_write_token mylib_func __mylib_state_token "$@")" || return $?
 ```
-Parses `-S <statevar>` from `${@:2}` (the forwarded args, which include `-S`) and emits
+Parses `-S <statevar>` from `${@:3}` (the forwarded args, which include `-S`) and emits
 `<statevar>='<value>'` (plain assignment, not `local`) on success, or `bash -c 'exit N'`
 on error. The collision surface includes at minimum `__mylib_state_token` plus
 `hs_extract_token`'s own locals. Any other locals declared in the entry-point frame before
 this call also add to the surface. When the body-helper pattern is followed strictly, only
 the token local is declared, keeping the surface to those three names.
 
-**`--list-reserved` form** (when `$2 == --list-reserved`):
+**`--list-reserved` form** (when `$3 == --list-reserved`):
 Computes the collision surface at the point of the call (via `local -p` in the subshell
 frame) and prints it plus `$1` (the source local name, which is in the entry-point's
 collision space for read-write functions).
@@ -136,14 +136,14 @@ source local share a name. This edge case is addressed in issue #139.
 ```bash
 mylib_func() {
     # No extra locals; hs_extract_token emits __mylib_state_token via eval.
-    eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+    eval "$(hs_extract_token mylib_func __mylib_state_token "$@")" || return $?
     if ! local -p list_reserved >/dev/null 2>&1; then
         # __mylib_state_token accessible by _mylib_func via dynamic scoping.
         # Body helper calls hs_read_persisted_state and hs_persist_state -S __mylib_state_token directly.
         _mylib_func "$@" || return $?
     fi
     # hs_write_token handles --list-reserved when active; otherwise writes the token back.
-    eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+    eval "$(hs_write_token mylib_func __mylib_state_token "$@")" || return $?
 }
 
 _mylib_func() {
@@ -162,7 +162,7 @@ so it delegates `--list-reserved` reporting directly to `hs_extract_token --list
 
 ```bash
 mylib_ro_func() {
-    eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+    eval "$(hs_extract_token mylib_ro_func __mylib_state_token "$@")" || return $?
     local -p list_reserved >/dev/null 2>&1 && { hs_extract_token --list-reserved; return 0; }
     _mylib_ro_func "$@" || return $?
 }
@@ -185,11 +185,11 @@ from its caller, it must destroy those variables before re-persisting them.
 ```bash
 mylib_update_func() {
     # No extra locals; hs_extract_token emits __mylib_state_token via eval.
-    eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+    eval "$(hs_extract_token mylib_update_func __mylib_state_token "$@")" || return $?
     if ! local -p list_reserved >/dev/null 2>&1; then
         _mylib_update_func "$@" || return $?
     fi
-    eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+    eval "$(hs_write_token mylib_update_func __mylib_state_token "$@")" || return $?
 }
 
 _mylib_update_func() {

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -148,7 +148,7 @@ mylib_func() {
 
 _mylib_func() {
     local var1 var2
-    hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+    eval "$(hs_read_persisted_state -S __mylib_state_token)" || return $?   # implicit form preferred
     # ... work ...
     hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
     hs_persist_state  -S __mylib_state_token -- var1 var2 || return $?
@@ -169,7 +169,7 @@ mylib_ro_func() {
 
 _mylib_ro_func() {
     local var1 var2
-    hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+    eval "$(hs_read_persisted_state -S __mylib_state_token)" || return $?   # implicit form preferred
     # ... read-only work ...
 }
 ```

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -1,5 +1,5 @@
 ---
-description: Expert guidance for implementing and using the handle_state.sh Bash library to persist initialization state to cleanup functions, centered on the -S state-variable pattern and limitations/workarounds for unsupported variable types. Triggers on requests like "pass information", "write initialization function" or "write cleanup function" while developing a library or code module.
+description: Expert guidance for implementing and using the handle_state.sh Bash library to persist initialization state to cleanup functions, centered on the -S state-variable pattern. Triggers on requests like "pass information", "write initialization function" or "write cleanup function" while developing a library or code module.
 ---
 
 # Handle State Library Skill
@@ -12,18 +12,156 @@ API, warnings, and limitations.
 ## Quick Workflow
 
 - Source `config/handle_state.sh` once in the main script or library entrypoint.
-- In init/setup or wherever the state information is created, define local scalar
-  variables holding the state, then call
-  `hs_persist_state_as_code "$@" -- <local1> <local2> ...`.
-- Future libraries using `handle_state` are only required to support `-S`.
-- The state snippet is assigned directly to the specified variable; stdout-based state transport is obsolete and should not be supported in library APIs.
-- Pass the state variable to cleanup or any API function which needs state information.
-- In cleanup, restore the needed locals with `hs_read_persisted_state "$@" -- <local1> <local2> ...`.
+- Use `hs_extract_token` + `hs_write_token` in entry points to eliminate nameref collision risk.
+- In body helpers, call `hs_persist_state "$@" -- <local1> <local2> ...` to save state and `hs_read_persisted_state "$@" -- <local1> <local2> ...` to restore it.
+- New libraries must expose `-S` and must not carry state via stdout.
+- The state token is an opaque string assigned to the named variable; never interpret or construct it manually.
 - If the same state variable must be reused across several init/cleanup cycles,
-  provide a matching state-destruction path that removes the library's vars
-  from the state vector before the next init.
+  call `hs_destroy_state` before the next init to remove the library's vars from
+  the state vector and avoid `HS_ERR_VAR_NAME_COLLISION`.
 
-## Standard Pattern
+## Primary Interface
+
+### `hs_persist_state` — serialize locals into the state token
+
+```bash
+hs_persist_state "$@" -- var1 var2        # forwarded-args form (preferred)
+hs_persist_state -S state_var -- var1     # explicit -S form
+hs_persist_state --list-reserved          # print internal reserved names
+```
+
+Supports scalars, indexed arrays (`-a`), associative arrays (`-A`), and namerefs
+(`-n`). Namerefs: the target variable must be persisted in the same call or
+already present in the prior state, otherwise `HS_ERR_NAMEREF_TARGET_NOT_PERSISTED`.
+
+### `hs_read_persisted_state` — restore locals from the state token
+
+Two forms:
+
+**Implicit form** (preferred) — no variable list, emits a restore snippet to stdout:
+```bash
+eval "$(hs_read_persisted_state "$@")" || return $?
+```
+Targets only the caller's own unset locals (via `local -p`); cannot pollute global scope.
+
+**Explicit form** — variable names after `--`:
+```bash
+hs_read_persisted_state "$@" -- var1 var2 || return $?
+```
+Traverses the full dynamic scope; use when targeting variables in a higher-level caller or declared globals.
+
+Both forms support `-q` to suppress warnings for missing variables.
+
+### `hs_destroy_state` — remove variables from the state token
+
+```bash
+hs_destroy_state "$@" -- var1 var2 || return $?
+```
+Removes named entries from the state vector. Required before re-initializing against the same token.
+
+### `hs_extract_token` — zero-collision token extraction for entry points
+
+Three call forms depending on position of `--list-reserved`:
+
+**Form 1 — direct query** (`$1 == --list-reserved`):
+```bash
+hs_extract_token --list-reserved
+```
+Prints every local in `hs_extract_token`'s own frame, one per line.
+
+**Form 2 — normal eval form** (`$1` is local name, `$2..` are forwarded args):
+```bash
+eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+```
+Runs in a subshell. Parses `-S <statevar>` from forwarded args and emits
+`local <local_name>='<value>'` on success or `bash -c 'exit N'` on error.
+Collision space at fork: zero.
+
+**Form 3 — eval-code `--list-reserved`** (`$1` is local name, `$2 == --list-reserved`, `$3..` are forwarded args):
+```bash
+eval "$(hs_extract_token __mylib_state_token --list-reserved "$@")" || return $?
+```
+When `--list-reserved` appears in `$3..`, emits two sentinels:
+```bash
+local list_reserved=1
+local __mylib_state_token=''
+```
+If absent, falls through to Form 2 using `$3..` as the argument list.
+
+### `hs_write_token` — zero-collision token write-back for entry points
+
+**Normal eval form**:
+```bash
+eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+```
+Runs in a subshell. Parses `-S <statevar>` from forwarded args and emits
+`<statevar>=<value>` (plain assignment, not `local`) on success or `bash -c 'exit N'` on error.
+
+**`--list-reserved` form** (when `$2 == --list-reserved`):
+Emits a `printf` statement that, when `eval`ed, prints the function's own frame
+locals plus `$1` (the source local — which is in the entry-point's collision space).
+
+## Entry-Point Patterns
+
+### Read-write entry point (restores and persists state)
+
+```bash
+my_func() {
+    eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+    if ! _hs_local_exists "$(local -p)" list_reserved; then
+        _my_func_body "$@" || return $?
+    fi
+    eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+}
+
+_my_func_body() {
+    local var1 var2
+    hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+    # ... work ...
+    __mylib_state_token=""
+    hs_persist_state -S __mylib_state_token -- var1 var2 || return $?
+}
+```
+
+### Read-only entry point (restores state, does not persist)
+
+```bash
+my_ro_func() {
+    eval "$(hs_extract_token __mylib_state_token --list-reserved "$@")" || return $?
+    if _hs_local_exists "$(local -p)" list_reserved; then
+        local lp_snapshot="$(local -p)"
+        _hs_print_reserved_names "$lp_snapshot" list_reserved
+        return 0
+    fi
+    _my_ro_func_body "$@" || return $?
+}
+```
+
+### Read/modify/write entry point (updates variables inside an existing token)
+
+When a function must mutate variables already stored in a token it received
+from its caller, it must destroy those variables before re-persisting them.
+`hs_destroy_state` modifies the token immediately, so always pair it with
+`hs_persist_state` in the same body helper so a failure aborts before
+`hs_write_token` propagates an incomplete token back.
+
+```bash
+my_update_func() {
+    eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+    _my_update_func_body "$@" || return $?
+    eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+}
+
+_my_update_func_body() {
+    local var1 var2
+    hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+    # ... mutate var1, var2 ...
+    hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
+    hs_persist_state -S __mylib_state_token -- var1 var2 || return $?
+}
+```
+
+### Plain init/cleanup (no entry-point wrapper needed)
 
 ```bash
 source "$(dirname "$0")/config/handle_state.sh"
@@ -31,68 +169,55 @@ source "$(dirname "$0")/config/handle_state.sh"
 init_function() {
   local temp_file="/tmp/resource"
   local resource_id="abc123"
-  hs_persist_state_as_code "$@" -- temp_file resource_id
+  local -a items=(one two three)
+  hs_persist_state "$@" -- temp_file resource_id items
 }
 
 cleanup_function() {
   local temp_file resource_id
-  hs_read_persisted_state "$@" -- temp_file resource_id
+  local -a items
+  eval "$(hs_read_persisted_state "$@")" || return $?
   rm -f "$temp_file"
-  echo "Cleaned $resource_id"
-  hs_destroy_state "$@" -- temp_file resource_id
+  hs_destroy_state "$@" -- temp_file resource_id items
 }
 
 local state
 init_function -S state
 cleanup_function -S state
-init_function -S state
 ```
 
-**API Documentation Note**: New libraries should expose `-S` directly and should not preserve the older stdout-based calling convention. Pass the full parameter set to `hs_persist_state_as_code`, `hs_read_persisted_state`, and `hs_destroy_state`, then use `--` as the separator before the list of local variable names.
+## Supported Variable Types
 
-When a library needs to reinitialize against the same state variable after
-cleanup, the cleanup function must call `hs_destroy_state` to remove the
-library's variables from the state vector before the next init call. This
-avoids collision errors from repeated `hs_persist_state_as_code` calls on the
-same state variable.
+All Bash variable types are supported:
+- **Scalars** (string/integer) — fully supported
+- **Indexed arrays** (`local -a`) — fully supported; all elements round-trip
+- **Associative arrays** (`local -A`) — fully supported
+- **Namerefs** (`local -n`) — fully supported; the nameref target must be
+  persisted in the same call or already present in the prior state
+  (`HS_ERR_NAMEREF_TARGET_NOT_PERSISTED` otherwise)
 
-If a library function consumes some of its own arguments before calling
-`handle_state`, preserve the remaining parameter list and still pass the full
-residual `"$@"` to the helper. Use `--` before the local variable list so
-future helper options cannot collide with local variable names or parameter
-values. The last `--` is the effective separator; earlier ones may belong to the
-library's own API.
+## Error Codes
 
-## Supported Variables
-
-- Only local scalar variables (strings or numbers) are reliably preserved.
-- Encode any other state variable as a string. See encoding templates in
-  `.claude/commands/handle-state/references/templates.md`.
-- Re-declare the same locals in cleanup before `hs_read_persisted_state`.
-
-## Known Limitations (Tracked)
-
-The following behaviors are tracked in GitHub; avoid them or apply workarounds.
-
-- Unknown variable names are silently ignored (Issue #1).
-- Function names are silently ignored (Issue #2).
-- Indexed arrays only preserve the first element — major (Issue #3).
-- Associative arrays are silently ignored (Issue #4).
-- Namerefs are persisted as scalars, indirection is lost (Issue #5).
-
-## Workarounds
-
-- Represent associative arrays as two indexed arrays (keys and values).
-- Represent indexed arrays as a single scalar string (encode/decode) or as an
-  associative array if appropriate.
-- Convert other complex constructs into strings and rebuild them in cleanup.
-- See `.claude/commands/handle-state/references/templates.md` for encoding examples.
+| Code | Constant | Meaning |
+|------|----------|---------|
+| 1 | `HS_ERR_RESERVED_VAR_NAME` | Name starts with `__hs_` |
+| 2 | `HS_ERR_VAR_NAME_COLLISION` | Name already present in state |
+| 3 | `HS_ERR_MULTIPLE_STATE_INPUTS` | `-S` given more than once |
+| 4 | `HS_ERR_CORRUPT_STATE` | State not in HS2 format or checksum mismatch |
+| 5 | `HS_ERR_INVALID_VAR_NAME` | Not a valid Bash identifier |
+| 6 | `HS_ERR_VAR_NAME_NOT_IN_STATE` | Requested name absent from state |
+| 7 | `HS_ERR_STATE_VAR_UNINITIALIZED` | `-S` var is unset or empty |
+| 8 | `HS_ERR_MISSING_ARGUMENT` | `-S` not supplied |
+| 9 | `HS_ERR_INVALID_ARGUMENT_TYPE` | Wrong argument type |
+| 10 | `HS_ERR_UNKNOWN_VAR_NAME` | Name not declared in scope, or is a function |
+| 11 | `HS_ERR_VAR_ALREADY_SET` | Explicit restore target is already set |
+| 12 | `HS_ERR_NAMEREF_TARGET_NOT_PERSISTED` | Nameref target not in state |
+| 19 | `HS_ERR_DEPENDENCY_MISSING` | `command_guard.sh` not loadable |
 
 ## Safety Notes
 
-- Avoid direct `eval` of the raw state string in new library code.
-- `hs_persist_state_as_code` and `hs_read_persisted_state` still rely on `eval`
-  internally; treat state strings as trusted input only.
-- Avoid name collisions when chaining state through a shared state variable; prefer separate state
-  variables if libraries overlap variable names.
+- `hs_persist_state` and `hs_read_persisted_state` use `eval` internally; treat state tokens as trusted input only.
+- Avoid name collisions when chaining state through a shared state variable; prefer separate state variables if libraries overlap variable names.
 - Do not require stdout to carry state as part of a library API; reserve stdout for normal user-visible output.
+- `hs_read_persisted_state` (implicit form) uses `local -p` to restrict restore to the immediate caller's own unset locals — this is the safe default. Use the explicit form only when you need to target higher-scope variables.
+- **Subshells cannot update the parent shell's token.** A `$(...)` command substitution or `( )` subshell group inherits a copy of the parent environment. Any `hs_persist_state` call inside a subshell writes only into that copy; the parent's token variable is never modified. Functions that run in a subshell cannot advance library state even if they call `hs_persist_state` successfully. Design stateful code paths to run directly in the shell process, not inside command substitutions.

--- a/.claude/commands/handle-state.md
+++ b/.claude/commands/handle-state.md
@@ -103,7 +103,7 @@ The eval form has two operational modes selected automatically by the caller's a
   `--list-reserved` as their first argument, making `$3` of `hs_extract_token` equal to
   `--list-reserved`. Emits two sentinels into the entry-point frame:
   ```bash
-  local list_reserved=1
+  local list_reserved=$'__hs_processed\n__hs_remaining'  # own reserved names; merged by hs_write_token
   local __mylib_state_token=''
   ```
   No further arguments are valid in this mode.
@@ -122,9 +122,10 @@ this call also add to the surface. When the body-helper pattern is followed stri
 the token local is declared, keeping the surface to those three names.
 
 **`--list-reserved` form** (when `$3 == --list-reserved`):
-Computes the collision surface at the point of the call (via `local -p` in the subshell
-frame) and prints it plus `$1` (the source local name, which is in the entry-point's
-collision space for read-write functions).
+Computes own collision surface, merges it with `list_reserved` from the inherited
+entry-point frame (set by `hs_extract_token`'s eval-code form when present), adds `$2`
+(the source-local name), and emits eval-code that prints all merged names and returns 0.
+After `eval`, the entry-point prints the complete collision surface and exits.
 
 Note: `hs_write_token` cannot avoid a name collision if the `-S` state variable and the
 source local share a name. This edge case is addressed in issue #139.

--- a/.claude/commands/handle-state/history.md
+++ b/.claude/commands/handle-state/history.md
@@ -6,3 +6,4 @@
 | #38 | —      | do not return state via stdout |
 | #63 | #62    | refactor safer handle-state restoration flow |
 | #140 | #136  | add hs_extract_token and hs_write_token; API_function name as $1 |
+| #140 | —     | fix --list-reserved merge for read-write entry points            |

--- a/.claude/commands/handle-state/history.md
+++ b/.claude/commands/handle-state/history.md
@@ -5,3 +5,4 @@
 | #23 | —      | feature/skills update |
 | #38 | —      | do not return state via stdout |
 | #63 | #62    | refactor safer handle-state restoration flow |
+| #140 | #136  | add hs_extract_token and hs_write_token; API_function name as $1 |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
     ],
     "git.branchProtectionPrompt": "always",
     "files.readonlyFromPermissions": true,
-    "shellcheck.useWorkspaceRootAsCwd": false
+    "shellcheck.useWorkspaceRootAsCwd": false,
+    "workbench.editor.autoLockGroups": {
+        "workbench.editor.browser": true
+    }
 }

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -460,7 +460,7 @@ hs_extract_token() {
     fi
     if [[ "${3-}" == "--list-reserved" ]]; then
         if [[ $# -gt 3 ]]; then
-            echo "[ERROR] hs_extract_token: --list-reserved takes no other arguments." >&2
+            echo "[ERROR] $1: --list-reserved takes no other arguments." >&2
             printf 'bash -c '\''exit %d'\''\n' "$HS_ERR_INVALID_ARGUMENT_TYPE"
             return 0
         fi
@@ -522,7 +522,7 @@ hs_write_token() {
     fi
     if [[ "${3-}" == "--list-reserved" ]]; then
         if [[ $# -gt 3 ]]; then
-            echo "[ERROR] hs_write_token: --list-reserved takes no other arguments." >&2
+            echo "[ERROR] $1: --list-reserved takes no other arguments." >&2
             printf 'bash -c '\''exit %d'\''\n' "$HS_ERR_INVALID_ARGUMENT_TYPE"
             return 0
         fi

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -455,7 +455,7 @@ hs_extract_token() {
         # Direct query form: print own collision surface, one name per line.
         # shellcheck disable=SC2155
         local lp_snapshot="$(local -p)"
-        _hs_print_reserved_names "$lp_snapshot" lp_snapshot
+        _hs_print_reserved_names "$lp_snapshot"
         return 0
     fi
     if [[ "${3-}" == "--list-reserved" ]]; then
@@ -465,9 +465,13 @@ hs_extract_token() {
             return 0
         fi
         # Eval-code --list-reserved form: emit sentinels into the entry-point frame.
-        # list_reserved=1 marks --list-reserved mode; local $2='' ensures the token
-        # local is already declared when _hs_print_reserved_names snapshots the frame.
-        printf 'local list_reserved=1\n'
+        # list_reserved holds own reserved names so hs_write_token can merge them;
+        # local $2='' ensures the token local is declared in the entry-point frame.
+        # shellcheck disable=SC2155
+        local lp_snapshot="$(local -p)"
+        local hs_et_names
+        hs_et_names="$(_hs_print_reserved_names "$lp_snapshot")"
+        printf 'local list_reserved=%s\n' "$(printf '%q' "$hs_et_names")"
         printf 'local %s=%s\n' "$2" "''"
         return 0
     fi
@@ -490,9 +494,10 @@ hs_extract_token() {
 #     _hs_resolve_state_inputs to build the collision-section guard.
 #     Returns HS_ERR_INVALID_ARGUMENT_TYPE if any extra arguments are present.
 #
-#   With-source-local form ($1 is API function name, $2 is source_local, $3 == --list-reserved, no $4):
-#     Prints own collision surface plus $2 (the source-local name, which is
-#     part of the entry-point's collision section for read-write functions).
+#   Eval-code --list-reserved form ($1 is API function name, $2 is source_local, $3 == --list-reserved):
+#     Computes own surface, merges with list_reserved from the inherited entry-point frame
+#     (populated by hs_extract_token in read-write patterns), adds $2, and emits eval-code
+#     that prints all merged names and returns 0 from the entry-point.
 #     Returns HS_ERR_INVALID_ARGUMENT_TYPE (via eval-code) if any $4.. present.
 #
 #   Normal eval form ($1 is API function name, $2 is source_local, $3 is not --list-reserved):
@@ -517,7 +522,7 @@ hs_write_token() {
         # Direct query form: print own collision surface, one name per line.
         # shellcheck disable=SC2155
         local lp_snapshot="$(local -p)"
-        _hs_print_reserved_names "$lp_snapshot" lp_snapshot
+        _hs_print_reserved_names "$lp_snapshot"
         return 0
     fi
     if [[ "${3-}" == "--list-reserved" ]]; then
@@ -526,12 +531,28 @@ hs_write_token() {
             printf 'bash -c '\''exit %d'\''\n' "$HS_ERR_INVALID_ARGUMENT_TYPE"
             return 0
         fi
-        # With-source-local form: print own collision surface plus $2 (the
-        # source-local name, which is part of the entry-point's collision section).
+        # Eval-code --list-reserved form: compute own surface, merge with
+        # list_reserved from the entry-point frame (set by hs_extract_token in
+        # read-write patterns), add source-local, emit printf + return 0.
         # shellcheck disable=SC2155
         local lp_snapshot="$(local -p)"
-        _hs_print_reserved_names "$lp_snapshot" lp_snapshot
-        printf '%s\n' "$2"
+        local hs_wt_names _hs_name
+        hs_wt_names="$(_hs_print_reserved_names "$lp_snapshot")"
+        local -A _hs_merged=()
+        while IFS= read -r _hs_name; do
+            [[ -n "$_hs_name" ]] && _hs_merged["$_hs_name"]=1
+        done <<< "$hs_wt_names"
+        if [[ -v list_reserved ]]; then
+            while IFS= read -r _hs_name; do
+                [[ -n "$_hs_name" ]] && _hs_merged["$_hs_name"]=1
+            done <<< "$list_reserved"
+        fi
+        _hs_merged["$2"]=1
+        printf "printf '%%s\\n'"
+        for _hs_name in "${!_hs_merged[@]}"; do
+            printf ' %s' "$(printf '%q' "$_hs_name")"
+        done
+        printf '\nreturn 0\n'
         return 0
     fi
     _hs_resolve_state_inputs "$1" S: "${@:3}" \
@@ -966,3 +987,4 @@ _hs_hs2_parse() {
 # | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |
 # | #134  | remove top-level return 0 — fixes SC2317 in sourcing files [closes #133] |
 # | #140  | add hs_extract_token and hs_write_token; API_function name as $1 [closes #136] |
+# | #140  | fix --list-reserved merge for read-write entry points             |

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -422,27 +422,28 @@ hs_read_persisted_state() {
 #     output to hs_persist_state --list-reserved. Names are derived from local -p
 #     so future edits are automatically reflected.
 #
-#   Eval-code --list-reserved form ($1 is API function name, $2 is local_name, $3 == --list-reserved, no $3):
+#   Eval-code --list-reserved form ($1 is API function name, $2 is local_name, $3 == --list-reserved, no $4):
 #     eval "$(hs_extract_token mod_entry_point __mod_state_token --list-reserved)"
 #     Emits two sentinel declarations for the calling entry-point frame:
 #       local list_reserved=""     -- marks --list-reserved mode
 #       local <local_name>=''     -- token local pre-declared so it appears in
 #                                    the lp_snapshot the entry-point takes next
-#     Returns HS_ERR_INVALID_ARGUMENT_TYPE if any $3.. are present.
+#     Returns HS_ERR_INVALID_ARGUMENT_TYPE if any $4.. are present.
 #     The entry-point detects list_reserved with _hs_local_exists, then takes
 #     a combined lp_snapshot and calls _hs_print_reserved_names to report every
 #     local except list_reserved (lp_snapshot excluded by the combined form).
 #
-#   Normal eval form ($1 is local_name, $2 is not --list-reserved):
-#     eval "$(hs_extract_token __mod_state_token "$@")"
-#     Parses -S <statevar> from forwarded opts ($2..) and prints either:
+#   Normal eval form ($1 is API function name, $2 is local_name, $3 is not --list-reserved):
+#     eval "$(hs_extract_token mod_entry_point __mod_state_token "$@")"
+#     Parses -S <statevar> from forwarded opts ($3..) and prints either:
 #       local <local_name>='<token_value>'   on success
 #       bash -c 'exit N'                     on error (causes eval to return N)
 #     Runs in a subshell: no caller local visible at fork, collision space = 0.
 # Arguments:
-#   $1  - --list-reserved (direct query) OR name of the local to declare
-#   $2  - --list-reserved (eval-code mode, no further args allowed) OR first forwarded opt
-#   $3..- forwarded parameter list (normal eval form only)
+#   $1  - --list-reserved (direct query) OR name of the calling API function
+#   $2  - name of the local to declare (eval forms only)
+#   $3  - --list-reserved (eval-code mode, no further args) OR first forwarded opt
+#   $4..- forwarded parameter list (normal eval form only)
 hs_extract_token() {
     local -a __hs_remaining=()
     local -A __hs_processed=()
@@ -457,31 +458,31 @@ hs_extract_token() {
         _hs_print_reserved_names "$lp_snapshot" lp_snapshot
         return 0
     fi
-    if [[ "${2-}" == "--list-reserved" ]]; then
-        if [[ $# -gt 2 ]]; then
+    if [[ "${3-}" == "--list-reserved" ]]; then
+        if [[ $# -gt 3 ]]; then
             echo "[ERROR] hs_extract_token: --list-reserved takes no other arguments." >&2
             printf 'bash -c '\''exit %d'\''\n' "$HS_ERR_INVALID_ARGUMENT_TYPE"
             return 0
         fi
         # Eval-code --list-reserved form: emit sentinels into the entry-point frame.
-        # list_reserved=1 marks --list-reserved mode; local $1='' ensures the token
+        # list_reserved=1 marks --list-reserved mode; local $2='' ensures the token
         # local is already declared when _hs_print_reserved_names snapshots the frame.
         printf 'local list_reserved=1\n'
-        printf 'local %s=%s\n' "$1" "''"
+        printf 'local %s=%s\n' "$2" "''"
         return 0
     fi
-    _hs_resolve_state_inputs hs_extract_token S: "${@:2}" \
+    _hs_resolve_state_inputs "$1" S: "${@:3}" \
         || { printf 'bash -c '\''exit %d'\''\n' "$?"; return 0; }
     # shellcheck disable=SC2155  # value read from inherited frame; name checked above
     local __hs_et_value="${!__hs_processed[state]}"
-    printf 'local %s=%s\n' "$1" "$(printf '%q' "$__hs_et_value")"
+    printf 'local %s=%s\n' "$2" "$(printf '%q' "$__hs_et_value")"
 }
 
 # --- hs_write_token -----------------------------------------------------------
 # Function:
 #   hs_write_token --list-reserved
-#   hs_write_token <source_local> --list-reserved
-#   hs_write_token <source_local> [forwarded options] -S <statevar>
+#   hs_write_token <API_function> <source_local> --list-reserved
+#   hs_write_token <API_function> <source_local> [forwarded options] -S <statevar>
 # Description:
 #   Direct query form ($1 == --list-reserved, no further args):
 #     Prints every local in this function's own frame, one per line; identical
@@ -489,21 +490,22 @@ hs_extract_token() {
 #     _hs_resolve_state_inputs to build the collision-section guard.
 #     Returns HS_ERR_INVALID_ARGUMENT_TYPE if any extra arguments are present.
 #
-#   With-source-local form ($1 is source_local, $2 == --list-reserved, no $3):
-#     Prints own collision surface plus $1 (the source-local name, which is
+#   With-source-local form ($1 is API function name, $2 is source_local, $3 == --list-reserved, no $4):
+#     Prints own collision surface plus $2 (the source-local name, which is
 #     part of the entry-point's collision section for read-write functions).
-#     Returns HS_ERR_INVALID_ARGUMENT_TYPE (via eval-code) if any $3.. present.
+#     Returns HS_ERR_INVALID_ARGUMENT_TYPE (via eval-code) if any $4.. present.
 #
-#   Normal eval form ($1 is source_local, $2 is not --list-reserved):
-#     eval "$(hs_write_token __mod_state_token "$@")"
-#     Parses -S <statevar> from forwarded opts ($2..) and prints either:
+#   Normal eval form ($1 is API function name, $2 is source_local, $3 is not --list-reserved):
+#     eval "$(hs_write_token mod_entry_point __mod_state_token "$@")"
+#     Parses -S <statevar> from forwarded opts ($3..) and prints either:
 #       <statevar>='<updated_value>'   on success (plain assignment, not local)
 #       bash -c 'exit N'              on error (causes eval to return N)
 #     Runs in a subshell: no caller local visible at fork, collision space = 0.
 # Arguments:
-#   $1          - --list-reserved (direct query) OR name of the local holding
-#                 the updated token value
-#   $2..        - forwarded parameter list (normal eval form: must contain -S)
+#   $1          - --list-reserved (direct query) OR name of the calling API function
+#   $2          - name of the local holding the updated token value (eval forms only)
+#   $3          - --list-reserved (with-source-local mode, no further args) OR first forwarded opt
+#   $4..        - forwarded parameter list (normal eval form: must contain -S)
 hs_write_token() {
     local -a __hs_remaining=()
     local -A __hs_processed=()
@@ -518,23 +520,23 @@ hs_write_token() {
         _hs_print_reserved_names "$lp_snapshot" lp_snapshot
         return 0
     fi
-    if [[ "${2-}" == "--list-reserved" ]]; then
-        if [[ $# -gt 2 ]]; then
+    if [[ "${3-}" == "--list-reserved" ]]; then
+        if [[ $# -gt 3 ]]; then
             echo "[ERROR] hs_write_token: --list-reserved takes no other arguments." >&2
             printf 'bash -c '\''exit %d'\''\n' "$HS_ERR_INVALID_ARGUMENT_TYPE"
             return 0
         fi
-        # With-source-local form: print own collision surface plus $1 (the
+        # With-source-local form: print own collision surface plus $2 (the
         # source-local name, which is part of the entry-point's collision section).
         # shellcheck disable=SC2155
         local lp_snapshot="$(local -p)"
         _hs_print_reserved_names "$lp_snapshot" lp_snapshot
-        printf '%s\n' "$1"
+        printf '%s\n' "$2"
         return 0
     fi
-    _hs_resolve_state_inputs hs_write_token S: "${@:2}" \
+    _hs_resolve_state_inputs "$1" S: "${@:3}" \
         || { printf 'bash -c '\''exit %d'\''\n' "$?"; return 0; }
-    printf '%s=%s\n' "${__hs_processed[state]}" "$(printf '%q' "${!1}")"
+    printf '%s=%s\n' "${__hs_processed[state]}" "$(printf '%q' "${!2}")"
 }
 
 # _hs_rr_explicit_stmts <state_var> <quiet> <vars_str>
@@ -963,3 +965,4 @@ _hs_hs2_parse() {
 # | #109  | reduce nameref collision surface [closes #104]                 |
 # | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |
 # | #134  | remove top-level return 0 — fixes SC2317 in sourcing files [closes #133] |
+# | #140  | add hs_extract_token and hs_write_token; API_function name as $1 [closes #136] |

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -479,37 +479,57 @@ hs_extract_token() {
 
 # --- hs_write_token -----------------------------------------------------------
 # Function:
+#   hs_write_token --list-reserved
+#   hs_write_token <source_local> --list-reserved
 #   hs_write_token <source_local> [forwarded options] -S <statevar>
 # Description:
-#   Intended to be called via: eval "$(hs_write_token __mod_state_token "$@")"
-#   Parses -S <statevar> from the forwarded options and prints either:
-#     <statevar>='<updated_value>'   on success (plain assignment, not local)
-#     bash -c 'exit N'               on error
-#   Running in a subshell context; reads ${!1} (the source local value) from the
-#   inherited frame copy.
-#   --list-reserved: builds the reserved-name list from this function's own
-#   local -p snapshot plus $1 (the source-local name, which is part of the entry
-#   point's collision space for read-write functions). Emits a printf statement
-#   so eval prints the names to the entry point's stdout.
+#   Direct query form ($1 == --list-reserved, no further args):
+#     Prints every local in this function's own frame, one per line; identical
+#     output to hs_persist_state --list-reserved.  Called automatically by
+#     _hs_resolve_state_inputs to build the collision-section guard.
+#     Returns HS_ERR_INVALID_ARGUMENT_TYPE if any extra arguments are present.
+#
+#   With-source-local form ($1 is source_local, $2 == --list-reserved, no $3):
+#     Prints own collision surface plus $1 (the source-local name, which is
+#     part of the entry-point's collision section for read-write functions).
+#     Returns HS_ERR_INVALID_ARGUMENT_TYPE (via eval-code) if any $3.. present.
+#
+#   Normal eval form ($1 is source_local, $2 is not --list-reserved):
+#     eval "$(hs_write_token __mod_state_token "$@")"
+#     Parses -S <statevar> from forwarded opts ($2..) and prints either:
+#       <statevar>='<updated_value>'   on success (plain assignment, not local)
+#       bash -c 'exit N'              on error (causes eval to return N)
+#     Runs in a subshell: no caller local visible at fork, collision space = 0.
 # Arguments:
-#   $1          - name of the local holding the updated token value
-#   $2..        - forwarded parameter list (must contain -S <statevar>)
+#   $1          - --list-reserved (direct query) OR name of the local holding
+#                 the updated token value
+#   $2..        - forwarded parameter list (normal eval form: must contain -S)
 hs_write_token() {
     local -a __hs_remaining=()
     local -A __hs_processed=()
-    if [[ "${2-}" == "--list-reserved" ]]; then
+    if [[ "${1-}" == "--list-reserved" ]]; then
+        if [[ $# -gt 1 ]]; then
+            echo "[ERROR] hs_write_token: --list-reserved takes no other arguments." >&2
+            return "$HS_ERR_INVALID_ARGUMENT_TYPE"
+        fi
+        # Direct query form: print own collision surface, one name per line.
         # shellcheck disable=SC2155
         local lp_snapshot="$(local -p)"
-        # Build printf args: names from our own frame + $1 (entry-point local)
-        local __hs_wt_names=()
-        local __hs_wt_n
-        while IFS= read -r __hs_wt_n; do
-            __hs_wt_names+=("$__hs_wt_n")
-        done < <(_hs_print_reserved_names "$lp_snapshot" "")
-        __hs_wt_names+=("$1")
-        # shellcheck disable=SC2001
-        printf 'printf '\''%%s\\n'\'' %s\n' \
-            "$(printf "'%s' " "${__hs_wt_names[@]}")"
+        _hs_print_reserved_names "$lp_snapshot" lp_snapshot
+        return 0
+    fi
+    if [[ "${2-}" == "--list-reserved" ]]; then
+        if [[ $# -gt 2 ]]; then
+            echo "[ERROR] hs_write_token: --list-reserved takes no other arguments." >&2
+            printf 'bash -c '\''exit %d'\''\n' "$HS_ERR_INVALID_ARGUMENT_TYPE"
+            return 0
+        fi
+        # With-source-local form: print own collision surface plus $1 (the
+        # source-local name, which is part of the entry-point's collision section).
+        # shellcheck disable=SC2155
+        local lp_snapshot="$(local -p)"
+        _hs_print_reserved_names "$lp_snapshot" lp_snapshot
+        printf '%s\n' "$1"
         return 0
     fi
     _hs_resolve_state_inputs hs_write_token S: "${@:2}" \

--- a/config/handle_state.sh
+++ b/config/handle_state.sh
@@ -411,6 +411,112 @@ hs_read_persisted_state() {
     fi
 }
 
+# --- hs_extract_token ---------------------------------------------------------
+# Function:
+#   hs_extract_token --list-reserved
+#   hs_extract_token <API_function> <local_name> --list-reserved
+#   hs_extract_token <API_function> <local_name> [forwarded opts] -S <statevar>
+# Description:
+#   Direct query form ($1 == --list-reserved, no further args):
+#     Prints every local in this function's own frame, one per line; identical
+#     output to hs_persist_state --list-reserved. Names are derived from local -p
+#     so future edits are automatically reflected.
+#
+#   Eval-code --list-reserved form ($1 is API function name, $2 is local_name, $3 == --list-reserved, no $3):
+#     eval "$(hs_extract_token mod_entry_point __mod_state_token --list-reserved)"
+#     Emits two sentinel declarations for the calling entry-point frame:
+#       local list_reserved=""     -- marks --list-reserved mode
+#       local <local_name>=''     -- token local pre-declared so it appears in
+#                                    the lp_snapshot the entry-point takes next
+#     Returns HS_ERR_INVALID_ARGUMENT_TYPE if any $3.. are present.
+#     The entry-point detects list_reserved with _hs_local_exists, then takes
+#     a combined lp_snapshot and calls _hs_print_reserved_names to report every
+#     local except list_reserved (lp_snapshot excluded by the combined form).
+#
+#   Normal eval form ($1 is local_name, $2 is not --list-reserved):
+#     eval "$(hs_extract_token __mod_state_token "$@")"
+#     Parses -S <statevar> from forwarded opts ($2..) and prints either:
+#       local <local_name>='<token_value>'   on success
+#       bash -c 'exit N'                     on error (causes eval to return N)
+#     Runs in a subshell: no caller local visible at fork, collision space = 0.
+# Arguments:
+#   $1  - --list-reserved (direct query) OR name of the local to declare
+#   $2  - --list-reserved (eval-code mode, no further args allowed) OR first forwarded opt
+#   $3..- forwarded parameter list (normal eval form only)
+hs_extract_token() {
+    local -a __hs_remaining=()
+    local -A __hs_processed=()
+    if [[ "${1-}" == "--list-reserved" ]]; then
+        if [[ $# -gt 1 ]]; then
+            echo "[ERROR] hs_extract_token: --list-reserved takes no other arguments." >&2
+            return "$HS_ERR_INVALID_ARGUMENT_TYPE"
+        fi
+        # Direct query form: print own collision surface, one name per line.
+        # shellcheck disable=SC2155
+        local lp_snapshot="$(local -p)"
+        _hs_print_reserved_names "$lp_snapshot" lp_snapshot
+        return 0
+    fi
+    if [[ "${2-}" == "--list-reserved" ]]; then
+        if [[ $# -gt 2 ]]; then
+            echo "[ERROR] hs_extract_token: --list-reserved takes no other arguments." >&2
+            printf 'bash -c '\''exit %d'\''\n' "$HS_ERR_INVALID_ARGUMENT_TYPE"
+            return 0
+        fi
+        # Eval-code --list-reserved form: emit sentinels into the entry-point frame.
+        # list_reserved=1 marks --list-reserved mode; local $1='' ensures the token
+        # local is already declared when _hs_print_reserved_names snapshots the frame.
+        printf 'local list_reserved=1\n'
+        printf 'local %s=%s\n' "$1" "''"
+        return 0
+    fi
+    _hs_resolve_state_inputs hs_extract_token S: "${@:2}" \
+        || { printf 'bash -c '\''exit %d'\''\n' "$?"; return 0; }
+    # shellcheck disable=SC2155  # value read from inherited frame; name checked above
+    local __hs_et_value="${!__hs_processed[state]}"
+    printf 'local %s=%s\n' "$1" "$(printf '%q' "$__hs_et_value")"
+}
+
+# --- hs_write_token -----------------------------------------------------------
+# Function:
+#   hs_write_token <source_local> [forwarded options] -S <statevar>
+# Description:
+#   Intended to be called via: eval "$(hs_write_token __mod_state_token "$@")"
+#   Parses -S <statevar> from the forwarded options and prints either:
+#     <statevar>='<updated_value>'   on success (plain assignment, not local)
+#     bash -c 'exit N'               on error
+#   Running in a subshell context; reads ${!1} (the source local value) from the
+#   inherited frame copy.
+#   --list-reserved: builds the reserved-name list from this function's own
+#   local -p snapshot plus $1 (the source-local name, which is part of the entry
+#   point's collision space for read-write functions). Emits a printf statement
+#   so eval prints the names to the entry point's stdout.
+# Arguments:
+#   $1          - name of the local holding the updated token value
+#   $2..        - forwarded parameter list (must contain -S <statevar>)
+hs_write_token() {
+    local -a __hs_remaining=()
+    local -A __hs_processed=()
+    if [[ "${2-}" == "--list-reserved" ]]; then
+        # shellcheck disable=SC2155
+        local lp_snapshot="$(local -p)"
+        # Build printf args: names from our own frame + $1 (entry-point local)
+        local __hs_wt_names=()
+        local __hs_wt_n
+        while IFS= read -r __hs_wt_n; do
+            __hs_wt_names+=("$__hs_wt_n")
+        done < <(_hs_print_reserved_names "$lp_snapshot" "")
+        __hs_wt_names+=("$1")
+        # shellcheck disable=SC2001
+        printf 'printf '\''%%s\\n'\'' %s\n' \
+            "$(printf "'%s' " "${__hs_wt_names[@]}")"
+        return 0
+    fi
+    _hs_resolve_state_inputs hs_write_token S: "${@:2}" \
+        || { printf 'bash -c '\''exit %d'\''\n' "$?"; return 0; }
+    printf '%s=%s\n' "${__hs_processed[state]}" "$(printf '%q' "${!1}")"
+}
+
 # _hs_rr_explicit_stmts <state_var> <quiet> <vars_str>
 # Validates all requested variables (declared and unset in dynamic scope), then
 # prints one assignment statement per variable to stdout. The caller evals the

--- a/docs/libraries/command_guard.rst
+++ b/docs/libraries/command_guard.rst
@@ -913,15 +913,24 @@ Source Listing
    :language: bash
    :linenos:
 
-..
+Change History
+--------------
 
-   Change History
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
 
-   PR     Summary
-   -----  -----------------------------------------------------------------
-   #8     initial documentation
-   #23    feature/skills update
-   #113   name=path guard token syntax [closes #111]
-   #114   PATH enforcement API -- cg_safe_run, cg_unsafe [closes #112]
-   #118   name filter and snap search API [closes #116, #117]
-   #127   gated trap-EXIT wrapper for async kill-propagation [closes #127]
+   * - PR
+     - Summary
+   * - #8
+     - initial documentation
+   * - #23
+     - feature/skills update
+   * - #113
+     - name=path guard token syntax [closes #111]
+   * - #114
+     - PATH enforcement API -- cg_safe_run, cg_unsafe [closes #112]
+   * - #118
+     - name filter and snap search API [closes #116, #117]
+   * - #127
+     - gated trap-EXIT wrapper for async kill-propagation [closes #127]

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -297,7 +297,7 @@ As of the current release the output is:
    __hs_remaining
 
 ``hs_write_token`` reports the same two names plus the source-local name passed
-as ``$1``.  For example, ``hs_write_token __wt_tok --list-reserved`` outputs:
+as ``$2``.  For example, ``hs_write_token api_func __wt_tok --list-reserved`` outputs:
 
 .. code-block:: text
 
@@ -313,23 +313,23 @@ as ``$1``.  For example, ``hs_write_token __wt_tok --list-reserved`` outputs:
    such changes; code that checks for specific names may break on a minor
    update.
 
-**Eval form** — ``$1`` is the local name, ``${@:2}`` are the forwarded args:
+**Eval form** — ``$1`` is the calling function name, ``$2`` is the local name, ``${@:3}`` are the forwarded args:
 
 .. code-block:: bash
 
-   eval "$(hs_extract_token __mod_state_token "$@")" || return $?
+   eval "$(hs_extract_token mylib_func __mod_state_token "$@")" || return $?
 
 The eval form has two operational modes selected automatically by the caller's
 argument list:
 
-*Normal mode* (``$2`` is not ``--list-reserved``): parses ``-S <statevar>``
-from ``${@:2}`` and emits ``local __mod_state_token='<token_value>'`` on
+*Normal mode* (``$3`` is not ``--list-reserved``): parses ``-S <statevar>``
+from ``${@:3}`` and emits ``local __mod_state_token='<token_value>'`` on
 success or ``bash -c 'exit N'`` on error.  Runs in a ``$(...)`` subshell; the
 collision surface at fork time consists of ``hs_extract_token``'s own
 locals.
 
-*Auto --list-reserved mode* (``$2 == --list-reserved``): activated when the
-caller passes ``--list-reserved`` as their first argument (so ``$2`` of
+*Auto --list-reserved mode* (``$3 == --list-reserved``): activated when the
+caller passes ``--list-reserved`` as their first argument (so ``$3`` of
 ``hs_extract_token`` is ``--list-reserved``).  Emits two sentinels into the
 entry-point frame:
 
@@ -349,14 +349,15 @@ hs_write_token
 
 ``hs_write_token`` writes an updated state token value back to the caller's variable.
 
-- Usage: ``eval "$(hs_write_token <source_local> "$@")"`` where ``${@:2}``
+- Usage: ``eval "$(hs_write_token <API_function> <source_local> "$@")"`` where ``${@:3}``
   from the entry point's perspective contains ``-S <statevar>``.
-- ``$1`` is the name of the local holding the updated token (accessed by position).
-- The forwarded parameter list (``${@:2}``) must contain ``-S <statevar>``.
+- ``$1`` is the name of the calling API function (used in error messages).
+- ``$2`` is the name of the local holding the updated token (accessed by position).
+- The forwarded parameter list (``${@:3}``) must contain ``-S <statevar>``.
 - Runs in a ``$(...)`` subshell, inheriting the calling frame read-only.
-- ``--list-reserved`` (when ``${*:2}`` is exactly ``--list-reserved``): computes
+- ``--list-reserved`` (when ``$3`` is exactly ``--list-reserved``): computes
   the collision surface at the point of the call (via ``local -p`` in the subshell
-  frame) and prints it plus ``$1`` (the source local name, which is part of the
+  frame) and prints it plus ``$2`` (the source local name, which is part of the
   entry-point's collision space for read-write functions).
 
 Behaviour:
@@ -366,7 +367,7 @@ Behaviour:
   that ``eval`` executes to write the token back.
 - On error: prints ``bash -c 'exit N'``.
 
-The collision surface includes at minimum the source-local name (``$1``) plus
+The collision surface includes at minimum the source-local name (``$2``) plus
 ``hs_extract_token``'s own locals.  Any other locals declared in the entry-point frame
 before this call also add to the surface.  When the body-helper pattern is followed
 strictly — where the body helper (not the entry point) declares and updates the token local
@@ -395,13 +396,13 @@ risk.
 
    mylib_func() {
        # No extra locals; hs_extract_token emits __mylib_state_token via eval.
-       eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+       eval "$(hs_extract_token mylib_func __mylib_state_token "$@")" || return $?
        if ! local -p list_reserved >/dev/null 2>&1; then
            # Body helper reads from and persists to __mylib_state_token via dynamic scoping.
            _mylib_func "$@" || return $?
        fi
        # hs_write_token handles --list-reserved when active; otherwise writes the token back.
-       eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+       eval "$(hs_write_token mylib_func __mylib_state_token "$@")" || return $?
    }
 
    _mylib_func() {
@@ -421,7 +422,7 @@ to ``hs_extract_token --list-reserved``.
 .. code-block:: bash
 
    mylib_ro_func() {
-       eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+       eval "$(hs_extract_token mylib_ro_func __mylib_state_token "$@")" || return $?
        local -p list_reserved >/dev/null 2>&1 && { hs_extract_token --list-reserved; return 0; }
        _mylib_ro_func "$@" || return $?
    }
@@ -445,11 +446,11 @@ perspective: the token variable is either fully updated or left unchanged.
 
    mylib_update_func() {
        # No extra locals; hs_extract_token emits __mylib_state_token via eval.
-       eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+       eval "$(hs_extract_token mylib_update_func __mylib_state_token "$@")" || return $?
        if ! local -p list_reserved >/dev/null 2>&1; then
            _mylib_update_func "$@" || return $?
        fi
-       eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+       eval "$(hs_write_token mylib_update_func __mylib_state_token "$@")" || return $?
    }
 
    _mylib_update_func() {
@@ -488,7 +489,7 @@ The ``--list-reserved`` output differs by entry-point type:
 
 - **Read-only** (delegates to ``hs_extract_token --list-reserved``): prints only
   ``__hs_processed`` and ``__hs_remaining``.
-- **Read-write** (delegates to ``hs_write_token __mylib_state_token --list-reserved``):
+- **Read-write** (delegates to ``hs_write_token mylib_func __mylib_state_token --list-reserved``):
   prints ``__hs_processed``, ``__hs_remaining``, and ``__mylib_state_token``.
 
 Developer Reference

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -272,6 +272,201 @@ Errors:
   set (including empty string); ``unset`` the variable first if an overwrite
   is intended.
 
+hs_extract_token
+~~~~~~~~~~~~~~~~
+
+``hs_extract_token`` has three call forms depending on which argument position
+holds ``--list-reserved``.
+
+**Direct query form** — ``$1`` is ``--list-reserved``:
+
+.. code-block:: bash
+
+   hs_extract_token --list-reserved
+
+Prints the names of every local in ``hs_extract_token``'s own frame, one per
+line (identical output to ``hs_persist_state --list-reserved``). These are the
+names prohibited as the ``-S`` argument to any entry point that delegates to
+``hs_extract_token``. The list is derived dynamically from ``local -p`` so that
+future edits to this function are automatically reflected.
+
+**Normal eval form** — ``$1`` is the local name, ``$2..`` are the forwarded args:
+
+.. code-block:: bash
+
+   eval "$(hs_extract_token __mod_state_token "$@")"
+
+Parses ``-S <statevar>`` from the forwarded options and prints either
+``local <local_name>='<token_value>'`` on success or ``bash -c 'exit N'`` on
+error. Runs in a ``$(...)`` subshell so no local from the caller's frame is
+visible at fork time — the collision space is zero.
+
+**Eval-code --list-reserved form** — ``$1`` is the local name, ``$2`` is
+``--list-reserved``, ``$3..`` are the forwarded args:
+
+.. code-block:: bash
+
+   eval "$(hs_extract_token __mod_state_token --list-reserved "$@")"
+
+``$3..`` are the caller's forwarded args (i.e. ``"$@"`` from the entry-point).
+If ``--list-reserved`` appears anywhere in ``$3..``, emits two sentinels:
+
+.. code-block:: bash
+
+   local list_reserved=1       # marks --list-reserved mode in the entry-point frame
+   local __mod_state_token=''  # token local pre-declared so it shows up in the
+                                # lp_snapshot the entry-point takes next
+
+The entry-point detects ``list_reserved`` with ``_hs_local_exists``, takes a
+combined ``local lp_snapshot="$(local -p)"`` snapshot (which excludes
+``lp_snapshot`` itself), and calls ``_hs_print_reserved_names "$lp_snapshot"
+list_reserved`` to emit every local except ``list_reserved``.
+
+If ``--list-reserved`` is **not** present in ``$3..``, falls through to normal
+token extraction using ``$3..`` as the argument list — identical to the normal
+eval form.
+
+This pattern ensures that both the names from ``hs_extract_token``'s own frame
+(``__hs_remaining``, ``__hs_processed``) — reported by the direct query form and
+rejected by ``_hs_resolve_state_inputs`` — and the entry-point's own token local
+(e.g. ``__mod_state_token``) all appear in the ``--list-reserved`` output.
+
+Errors: same set as ``_hs_resolve_state_inputs``; no new codes.
+
+hs_write_token
+~~~~~~~~~~~~~~
+
+``hs_write_token`` writes an updated state token value back to the caller's variable.
+
+- Usage: ``eval "$(hs_write_token <source_local> [forwarded args] -S <statevar>)"``
+- ``$1`` is the name of the local holding the updated token (accessed by position).
+- The forwarded parameter list (``$2..``) must contain ``-S <statevar>``.
+- Runs in a ``$(...)`` subshell, inheriting the calling frame read-only.
+- ``--list-reserved``: when ``"${2-}" == "--list-reserved"``, emits a ``printf``
+  statement (valid Bash) that prints the reserved names when ``eval``\ed:
+  the function's own ``local -p`` names (``__hs_remaining``, ``__hs_processed``)
+  plus ``$1`` (the source local name, which is part of the entry point's collision
+  space for read-write functions).
+
+Behaviour:
+
+- Parses ``-S`` from the forwarded arguments using ``_hs_resolve_state_inputs``.
+- On success: prints ``<statevar>=$(printf '%q' "${!1}")`` — a plain assignment
+  (not ``local``) that ``eval`` executes to write the token back.
+- On error: prints ``bash -c 'exit N'``.
+
+Errors: same set as ``_hs_resolve_state_inputs``; ``HS_ERR_MISSING_ARGUMENT`` if
+``$1`` is absent.
+
+Entry-Point Pattern
+~~~~~~~~~~~~~~~~~~~
+
+Libraries that expose ``-S <statevar>`` and use ``handle_state.sh`` internally
+should structure each stateful entry point as follows to eliminate nameref
+collision risk.
+
+**Read-write entry point** (restores and persists state):
+
+.. code-block:: bash
+
+   my_func() {
+       # No local declared before eval — collision space at fork: empty.
+       # hs_write_token handles --list-reserved for read-write functions.
+       eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+       if ! _hs_local_exists "$(local -p)" list_reserved; then
+           _my_func_body "$@" || return $?
+       fi
+       # hs_write_token reports the full reserved list (including __mylib_state_token)
+       # when --list-reserved is in $@, otherwise writes the token back.
+       eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+   }
+
+   _my_func_body() {
+       # __mylib_state_token visible via dynamic scoping — no prefix needed on locals.
+       local var1 var2
+       hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+       # ... work ...
+       __mylib_state_token=""
+       hs_persist_state -S __mylib_state_token -- var1 var2 || return $?
+   }
+
+**Read-only entry point** (restores state but does not persist):
+
+.. code-block:: bash
+
+   my_ro_func() {
+       # Pass --list-reserved as $2 so hs_extract_token emits the list_reserved
+       # sentinel and the empty token local when the caller passes --list-reserved.
+       eval "$(hs_extract_token __mylib_state_token --list-reserved "$@")" || return $?
+       if _hs_local_exists "$(local -p)" list_reserved; then
+           # Snapshot taken after list_reserved and __mylib_state_token are declared.
+           # Combined form: lp_snapshot is absent from its own snapshot.
+           # shellcheck disable=SC2155
+           local lp_snapshot="$(local -p)"
+           _hs_print_reserved_names "$lp_snapshot" list_reserved
+           return 0
+       fi
+       _my_ro_func_body "$@" || return $?
+   }
+
+**Read/modify/write entry point** (updates one or more variables inside an
+existing token without replacing the whole state):
+
+When a function must change variables that are already stored in an opaque
+token it received from its caller, it must destroy and re-persist those
+variables — it cannot overwrite them in place.  Using ``hs_extract_token``
+and ``hs_write_token`` keeps the operation atomic from the caller's
+perspective: the token variable is either fully updated or left unchanged.
+
+.. code-block:: bash
+
+   my_update_func() {
+       # Zero collision surface before eval.
+       eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+       _my_update_func_body "$@" || return $?
+       eval "$(hs_write_token __mylib_state_token "$@")" || return $?
+   }
+
+   _my_update_func_body() {
+       local var1 var2
+       hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+       # ... mutate var1, var2 as needed ...
+       # Destroy before re-persisting to avoid HS_ERR_VAR_NAME_COLLISION.
+       hs_destroy_state  -S __mylib_state_token -- var1 var2 || return $?
+       hs_persist_state  -S __mylib_state_token -- var1 var2 || return $?
+   }
+
+.. warning::
+
+   ``hs_destroy_state`` modifies the token **in the caller's variable**
+   immediately.  If ``hs_persist_state`` subsequently fails, the destroyed
+   variables are lost from the token.  Always call both functions in the
+   same body helper so that any error causes the whole entry point to abort
+   via ``return $?`` before ``hs_write_token`` propagates an incomplete
+   token back to the caller.  Bash's sequential execution model and the
+   fact that subshells cannot write back to the parent shell's variables
+   make this pattern safe under normal control flow: there is no concurrent
+   access that could observe a partially-updated token.
+
+.. note::
+
+   Subshells (``$(...)`` command substitutions and explicit ``( )``
+   subshell groups) inherit a **copy** of the parent shell's environment.
+   Any variable assignment or ``hs_persist_state`` call inside a subshell
+   affects only that copy; the parent's token variable is never updated.
+   This means ``handle_state.sh`` state can only be advanced by code that
+   runs directly in the relevant shell process.  Functions that run in a
+   subshell (e.g. to capture their output) cannot update the caller's token
+   even if they call ``hs_persist_state`` successfully.
+
+The module's ``--list-reserved`` output for read-write functions (via
+``hs_write_token``) includes ``__mylib_state_token`` plus
+``__hs_remaining`` and ``__hs_processed``; for read-only functions it
+includes ``__mylib_state_token``, ``__hs_remaining``, and
+``__hs_processed`` (the latter two because they are in the subshell frame
+that ``hs_extract_token`` inherits from when it resolves ``-S``, so
+``hs_extract_token --list-reserved`` reports them).
+
 Developer Reference
 -------------------
 
@@ -423,27 +618,50 @@ Source Listing
    :language: bash
    :linenos:
 
-..
+Change History
+--------------
 
-   Change History
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
 
-   PR     Summary
-   -----  -----------------------------------------------------------------
-   #23    feature/skills update
-   #32    batch security fixes [closes #7]
-   #38    do not return state via stdout
-   #63    refactor safer handle-state restoration flow [closes #62]
-   #83    fix hs_destroy_state rebuild subprocess helper [closes #82]
-   #90    remove internal-format mention, convenience form non-preferred
-   #91    add forwarded-args eval example for probe-snippet mode
-   #93    rename probe-snippet to implicit local restore [closes #76]
-   #94    emphasize implicit restore snippet is safe local code
-   #95    clarify caller evaluates probe code, not transmitted state
-   #96    add -S calling context to Examples section [closes #80]
-   #98    remove caveat implying raw eval of state is valid [closes #81]
-   #99    error on undeclared variable names [closes #1]
-   #102   guard nameref restore against undeclared variables [closes #100]
-   #103   reject function names with HS_ERR_UNKNOWN_VAR_NAME
-   #105   fix hs_persist_state dropping indexed array elements [closes #3]
-   #109   reduce nameref collision surface [closes #104]
-   #110   document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points
+   * - PR
+     - Summary
+   * - #23
+     - feature/skills update
+   * - #32
+     - batch security fixes [closes #7]
+   * - #38
+     - do not return state via stdout
+   * - #63
+     - refactor safer handle-state restoration flow [closes #62]
+   * - #83
+     - fix hs_destroy_state rebuild subprocess helper [closes #82]
+   * - #90
+     - remove internal-format mention, convenience form non-preferred
+   * - #91
+     - add forwarded-args eval example for probe-snippet mode
+   * - #93
+     - rename probe-snippet to implicit local restore [closes #76]
+   * - #94
+     - emphasize implicit restore snippet is safe local code
+   * - #95
+     - clarify caller evaluates probe code, not transmitted state
+   * - #96
+     - add -S calling context to Examples section [closes #80]
+   * - #98
+     - remove caveat implying raw eval of state is valid [closes #81]
+   * - #TBD
+     - add hs_extract_token and hs_write_token; entry-point pattern (issue #136)
+   * - #99
+     - error on undeclared variable names [closes #1]
+   * - #102
+     - guard nameref restore against undeclared variables [closes #100]
+   * - #103
+     - reject function names with HS_ERR_UNKNOWN_VAR_NAME
+   * - #105
+     - fix hs_persist_state dropping indexed array elements [closes #3]
+   * - #109
+     - reduce nameref collision surface [closes #104]
+   * - #110
+     - document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -296,8 +296,10 @@ As of the current release the output is:
    __hs_processed
    __hs_remaining
 
-``hs_write_token`` reports the same two names plus the source-local name passed
-as ``$2``.  For example, ``hs_write_token api_func __wt_tok --list-reserved`` outputs:
+When used in a read-write entry-point pattern, calling the entry point with
+``--list-reserved`` prints the merged collision surface, which includes
+``hs_extract_token``'s own names plus the source-local name (``$2``).  For
+``__wt_tok`` as the source local, the output is:
 
 .. code-block:: text
 
@@ -329,18 +331,21 @@ collision surface at fork time consists of ``hs_extract_token``'s own
 locals.
 
 *Auto --list-reserved mode* (``$3 == --list-reserved``): activated when the
-caller passes ``--list-reserved`` as their first argument (so ``$3`` of
-``hs_extract_token`` is ``--list-reserved``).  Emits two sentinels into the
+caller passes ``--list-reserved`` as their first argument (so ``${@:3}`` of
+``hs_extract_token`` is exactly ``--list-reserved``).  Emits two sentinels into the
 entry-point frame:
 
 .. code-block:: bash
 
-   local list_reserved=1        # marks --list-reserved mode in the entry-point frame
+   local list_reserved=$'__hs_processed\n__hs_remaining'  # own reserved names; merged by hs_write_token
    local __mod_state_token=''   # token local pre-declared for frame inspection
 
 No further arguments are valid in this mode.  The entry-point detects
 ``list_reserved`` with ``local -p list_reserved >/dev/null 2>&1`` (returns 0
-when the variable is declared as a local, even if unset).
+when the variable is declared as a local).  In a read-write pattern,
+``hs_write_token`` reads ``list_reserved`` from the inherited frame, merges it
+with its own names and the source-local name, and emits a ``printf`` statement
+plus ``return 0`` so that ``eval`` prints all names and exits the entry point.
 
 Errors: same set as the shared option parser; no new codes.
 
@@ -355,10 +360,12 @@ hs_write_token
 - ``$2`` is the name of the local holding the updated token (accessed by position).
 - The forwarded parameter list (``${@:3}``) must contain ``-S <statevar>``.
 - Runs in a ``$(...)`` subshell, inheriting the calling frame read-only.
-- ``--list-reserved`` (when ``$3`` is exactly ``--list-reserved``): computes
-  the collision surface at the point of the call (via ``local -p`` in the subshell
-  frame) and prints it plus ``$2`` (the source local name, which is part of the
-  entry-point's collision space for read-write functions).
+- ``--list-reserved`` (when ``${@:3}`` is exactly ``--list-reserved``): computes
+  own collision surface, merges it with ``list_reserved`` from the inherited
+  entry-point frame (set by ``hs_extract_token``'s eval-code form when present),
+  adds ``$2`` (the source-local name), and emits eval-code that prints all merged
+  names and returns 0.  After ``eval``, the entry-point prints the complete
+  collision surface and exits.
 
 Behaviour:
 
@@ -678,6 +685,8 @@ Change History
      - remove caveat implying raw eval of state is valid [closes #81]
    * - #140
      - add hs_extract_token and hs_write_token; entry-point pattern (issue #136)
+   * - #140
+     - fix --list-reserved merge for read-write entry points
    * - #99
      - error on undeclared variable names [closes #1]
    * - #102

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -275,8 +275,7 @@ Errors:
 hs_extract_token
 ~~~~~~~~~~~~~~~~
 
-``hs_extract_token`` has three call forms depending on which argument position
-holds ``--list-reserved``.
+``hs_extract_token`` has two call forms.
 
 **Direct query form** — ``$1`` is ``--list-reserved``:
 
@@ -284,52 +283,49 @@ holds ``--list-reserved``.
 
    hs_extract_token --list-reserved
 
-Prints the names of every local in ``hs_extract_token``'s own frame, one per
-line (identical output to ``hs_persist_state --list-reserved``). These are the
-names prohibited as the ``-S`` argument to any entry point that delegates to
-``hs_extract_token``. The list is derived dynamically from ``local -p`` so that
-future edits to this function are automatically reflected.
+Prints the names forming the collision surface of ``hs_extract_token`` itself,
+one per line (identical output to ``hs_persist_state --list-reserved``).
+These names are prohibited as the ``-S`` argument to any entry point that
+delegates to ``hs_extract_token``; ill-designed or write-capable entry points
+may add further prohibited names. The list is derived dynamically from
+``local -p`` so that future edits to this function are automatically reflected.
 
-**Normal eval form** — ``$1`` is the local name, ``$2..`` are the forwarded args:
+.. note::
 
-.. code-block:: bash
+   The reserved-name list is part of the minor API: it will not change its
+   prefix conventions across minor versions, but individual names may be added
+   or removed.  Code that avoids the entire ``__hs_`` namespace is unaffected
+   by such changes; code that checks for specific names may break on a minor
+   update.
 
-   eval "$(hs_extract_token __mod_state_token "$@")"
-
-Parses ``-S <statevar>`` from the forwarded options and prints either
-``local <local_name>='<token_value>'`` on success or ``bash -c 'exit N'`` on
-error. Runs in a ``$(...)`` subshell so no local from the caller's frame is
-visible at fork time — the collision space is zero.
-
-**Eval-code --list-reserved form** — ``$1`` is the local name, ``$2`` is
-``--list-reserved``, ``$3..`` are the forwarded args:
+**Eval form** — ``$1`` is the local name, ``${@:2}`` are the forwarded args:
 
 .. code-block:: bash
 
-   eval "$(hs_extract_token __mod_state_token --list-reserved "$@")"
+   eval "$(hs_extract_token __mod_state_token "$@")" || return $?
 
-``$3..`` are the caller's forwarded args (i.e. ``"$@"`` from the entry-point).
-If ``--list-reserved`` appears anywhere in ``$3..``, emits two sentinels:
+The eval form has two operational modes selected automatically by the caller's
+argument list:
+
+*Normal mode* (``$2`` is not ``--list-reserved``): parses ``-S <statevar>``
+from ``${@:2}`` and emits ``local __mod_state_token='<token_value>'`` on
+success or ``bash -c 'exit N'`` on error.  Runs in a ``$(...)`` subshell; the
+collision surface at fork time consists only of ``hs_extract_token``'s own
+locals.
+
+*Auto --list-reserved mode* (``$2 == --list-reserved``): activated when the
+caller passes ``--list-reserved`` as their first argument (so ``$2`` of
+``hs_extract_token`` is ``--list-reserved``).  Emits two sentinels into the
+entry-point frame:
 
 .. code-block:: bash
 
-   local list_reserved=1       # marks --list-reserved mode in the entry-point frame
-   local __mod_state_token=''  # token local pre-declared so it shows up in the
-                                # lp_snapshot the entry-point takes next
+   local list_reserved=1        # marks --list-reserved mode in the entry-point frame
+   local __mod_state_token=''   # token local pre-declared for frame inspection
 
-The entry-point detects ``list_reserved`` with ``_hs_local_exists``, takes a
-combined ``local lp_snapshot="$(local -p)"`` snapshot (which excludes
-``lp_snapshot`` itself), and calls ``_hs_print_reserved_names "$lp_snapshot"
-list_reserved`` to emit every local except ``list_reserved``.
-
-If ``--list-reserved`` is **not** present in ``$3..``, falls through to normal
-token extraction using ``$3..`` as the argument list — identical to the normal
-eval form.
-
-This pattern ensures that both the names from ``hs_extract_token``'s own frame
-(``__hs_remaining``, ``__hs_processed``) — reported by the direct query form and
-rejected by ``_hs_resolve_state_inputs`` — and the entry-point's own token local
-(e.g. ``__mod_state_token``) all appear in the ``--list-reserved`` output.
+No further arguments are valid in this mode.  The entry-point detects
+``list_reserved`` with ``[[ -n "${list_reserved@A}" ]]`` (which returns true
+when the variable is declared, even if unset).
 
 Errors: same set as ``_hs_resolve_state_inputs``; no new codes.
 
@@ -338,22 +334,28 @@ hs_write_token
 
 ``hs_write_token`` writes an updated state token value back to the caller's variable.
 
-- Usage: ``eval "$(hs_write_token <source_local> [forwarded args] -S <statevar>)"``
+- Usage: ``eval "$(hs_write_token <source_local> "$@")"`` where ``$@`` (i.e. ``${@:2}``
+  from the entry point's perspective) contains ``-S <statevar>``.
 - ``$1`` is the name of the local holding the updated token (accessed by position).
-- The forwarded parameter list (``$2..``) must contain ``-S <statevar>``.
+- The forwarded parameter list (``${@:2}``) must contain ``-S <statevar>``.
 - Runs in a ``$(...)`` subshell, inheriting the calling frame read-only.
-- ``--list-reserved``: when ``"${2-}" == "--list-reserved"``, emits a ``printf``
-  statement (valid Bash) that prints the reserved names when ``eval``\ed:
-  the function's own ``local -p`` names (``__hs_remaining``, ``__hs_processed``)
-  plus ``$1`` (the source local name, which is part of the entry point's collision
-  space for read-write functions).
+- ``--list-reserved`` (when ``$2 == --list-reserved``): prints the function's own
+  frame locals plus ``$1`` (the source local name, which is part of the entry-point's
+  collision space for read-write functions).
 
 Behaviour:
 
 - Parses ``-S`` from the forwarded arguments using ``_hs_resolve_state_inputs``.
-- On success: prints ``<statevar>=$(printf '%q' "${!1}")`` — a plain assignment
-  (not ``local``) that ``eval`` executes to write the token back.
+- On success: prints ``<statevar>='<value>'`` — a plain assignment (not ``local``)
+  that ``eval`` executes to write the token back.
 - On error: prints ``bash -c 'exit N'``.
+
+.. note::
+
+   ``hs_write_token`` cannot avoid a name collision when the ``-S`` state variable
+   and the source local share the same name.  Follow the body-helper pattern to keep
+   the collision surface minimal: the body helper updates the token local; the entry
+   point calls ``hs_write_token`` only after the helper returns.
 
 Errors: same set as ``_hs_resolve_state_inputs``; ``HS_ERR_MISSING_ARGUMENT`` if
 ``$1`` is absent.
@@ -362,51 +364,51 @@ Entry-Point Pattern
 ~~~~~~~~~~~~~~~~~~~
 
 Libraries that expose ``-S <statevar>`` and use ``handle_state.sh`` internally
-should structure each stateful entry point as follows to eliminate nameref
-collision risk.
+should structure each stateful entry point as follows to minimize name collision
+risk.
 
 **Read-write entry point** (restores and persists state):
 
 .. code-block:: bash
 
-   my_func() {
-       # No local declared before eval — collision space at fork: empty.
-       # hs_write_token handles --list-reserved for read-write functions.
+   mylib_func() {
        eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-       if ! _hs_local_exists "$(local -p)" list_reserved; then
-           _my_func_body "$@" || return $?
+       if [[ -z "${list_reserved@A}" ]]; then
+           # __mylib_state_token accessible by _mylib_func_body via dynamic scoping.
+           # Body helper calls hs_persist_state -S __mylib_state_token directly.
+           _mylib_func_body || return $?
        fi
        # hs_write_token reports the full reserved list (including __mylib_state_token)
        # when --list-reserved is in $@, otherwise writes the token back.
        eval "$(hs_write_token __mylib_state_token "$@")" || return $?
    }
 
-   _my_func_body() {
-       # __mylib_state_token visible via dynamic scoping — no prefix needed on locals.
+   _mylib_func_body() {
        local var1 var2
        hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
        # ... work ...
-       __mylib_state_token=""
+       hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
        hs_persist_state -S __mylib_state_token -- var1 var2 || return $?
    }
 
 **Read-only entry point** (restores state but does not persist):
 
+A well-designed read-only entry point has the same collision surface as
+``hs_extract_token``.  It delegates ``--list-reserved`` reporting directly
+to ``hs_extract_token --list-reserved`` rather than calling private functions.
+
 .. code-block:: bash
 
-   my_ro_func() {
-       # Pass --list-reserved as $2 so hs_extract_token emits the list_reserved
-       # sentinel and the empty token local when the caller passes --list-reserved.
-       eval "$(hs_extract_token __mylib_state_token --list-reserved "$@")" || return $?
-       if _hs_local_exists "$(local -p)" list_reserved; then
-           # Snapshot taken after list_reserved and __mylib_state_token are declared.
-           # Combined form: lp_snapshot is absent from its own snapshot.
-           # shellcheck disable=SC2155
-           local lp_snapshot="$(local -p)"
-           _hs_print_reserved_names "$lp_snapshot" list_reserved
-           return 0
-       fi
-       _my_ro_func_body "$@" || return $?
+   mylib_ro_func() {
+       eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
+       [[ -n "${list_reserved@A}" ]] && { hs_extract_token --list-reserved; return 0; }
+       _mylib_ro_func_body || return $?
+   }
+
+   _mylib_ro_func_body() {
+       local var1 var2
+       hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+       # ... read-only work ...
    }
 
 **Read/modify/write entry point** (updates one or more variables inside an
@@ -420,20 +422,21 @@ perspective: the token variable is either fully updated or left unchanged.
 
 .. code-block:: bash
 
-   my_update_func() {
-       # Zero collision surface before eval.
+   mylib_update_func() {
        eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-       _my_update_func_body "$@" || return $?
+       if [[ -z "${list_reserved@A}" ]]; then
+           _mylib_update_func_body || return $?
+       fi
        eval "$(hs_write_token __mylib_state_token "$@")" || return $?
    }
 
-   _my_update_func_body() {
+   _mylib_update_func_body() {
        local var1 var2
        hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
        # ... mutate var1, var2 as needed ...
        # Destroy before re-persisting to avoid HS_ERR_VAR_NAME_COLLISION.
-       hs_destroy_state  -S __mylib_state_token -- var1 var2 || return $?
-       hs_persist_state  -S __mylib_state_token -- var1 var2 || return $?
+       hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
+       hs_persist_state -S __mylib_state_token -- var1 var2 || return $?
    }
 
 .. warning::
@@ -608,8 +611,8 @@ Caveats
   ``hs_read_persisted_state``.
 - The state variable is opaque: do not inspect, modify, or concatenate its
   value outside the public API.
-- ``eval`` is used per-record internally (on ``declare`` statements only);
-  the state is never evaluated as an arbitrary code block.
+- State records are separated internally by ``$'\001'`` and parsed with
+  ``IFS=$'\001' read -ra``; the state string is never passed to ``eval``.
 
 Source Listing
 --------------

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -366,12 +366,11 @@ Behaviour:
   that ``eval`` executes to write the token back.
 - On error: prints ``bash -c 'exit N'``.
 
-The collision surface of ``hs_write_token`` includes at minimum ``__mylib_state_token``
-(the source local) plus ``hs_extract_token``'s own locals.  Name collision on the source
-local prevents ``hs_write_token`` from updating the caller's state variable: any local in
-the entry-point frame that shadows the ``-S`` variable makes the assignment a no-op.
-Follow the body-helper pattern so that only the token local is declared before
-``hs_write_token`` is called.
+The collision surface includes at minimum the source-local name (``$1``) plus
+``hs_extract_token``'s own locals.  Any other locals declared in the entry-point frame
+before this call also add to the surface.  When the body-helper pattern is followed
+strictly — where the body helper (not the entry point) declares and updates the token local
+— only those minimum names appear.
 
 .. note::
 
@@ -380,6 +379,8 @@ Follow the body-helper pattern so that only the token local is declared before
 
 Errors: same set as the shared option parser; ``HS_ERR_MISSING_ARGUMENT`` if
 ``$1`` is absent.
+
+See `Entry-Point Pattern`_ for canonical usage examples of both functions.
 
 Entry-Point Pattern
 ~~~~~~~~~~~~~~~~~~~
@@ -405,7 +406,7 @@ risk.
 
    _mylib_func() {
        local var1 var2
-       hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+       eval "$(hs_read_persisted_state -S __mylib_state_token)" || return $?   # implicit form preferred
        # ... work ...
        hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
        hs_persist_state -S __mylib_state_token -- var1 var2 || return $?
@@ -427,7 +428,7 @@ to ``hs_extract_token --list-reserved``.
 
    _mylib_ro_func() {
        local var1 var2
-       hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+       eval "$(hs_read_persisted_state -S __mylib_state_token)" || return $?   # implicit form preferred
        # ... read-only work ...
    }
 
@@ -453,7 +454,7 @@ perspective: the token variable is either fully updated or left unchanged.
 
    _mylib_update_func() {
        local var1 var2
-       hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
+       eval "$(hs_read_persisted_state -S __mylib_state_token)" || return $?   # implicit form preferred
        # ... mutate var1, var2 as needed ...
        # Destroy before re-persisting to avoid HS_ERR_VAR_NAME_COLLISION.
        hs_destroy_state -S __mylib_state_token -- var1 var2 || return $?
@@ -483,13 +484,12 @@ perspective: the token variable is either fully updated or left unchanged.
    subshell (e.g. to capture their output) cannot update the caller's token
    even if they call ``hs_persist_state`` successfully.
 
-The module's ``--list-reserved`` output for read-write functions (via
-``hs_write_token``) includes ``__mylib_state_token`` plus
-``__hs_remaining`` and ``__hs_processed``; for read-only functions it
-includes ``__mylib_state_token``, ``__hs_remaining``, and
-``__hs_processed`` (the latter two because they are in the subshell frame
-that ``hs_extract_token`` inherits from when it resolves ``-S``, so
-``hs_extract_token --list-reserved`` reports them).
+The ``--list-reserved`` output differs by entry-point type:
+
+- **Read-only** (delegates to ``hs_extract_token --list-reserved``): prints only
+  ``__hs_processed`` and ``__hs_remaining``.
+- **Read-write** (delegates to ``hs_write_token __mylib_state_token --list-reserved``):
+  prints ``__hs_processed``, ``__hs_remaining``, and ``__mylib_state_token``.
 
 Developer Reference
 -------------------

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -284,18 +284,34 @@ hs_extract_token
    hs_extract_token --list-reserved
 
 Prints the names forming the collision surface of ``hs_extract_token`` itself,
-one per line (identical output to ``hs_persist_state --list-reserved``).
-These names are prohibited as the ``-S`` argument to any entry point that
-delegates to ``hs_extract_token``; ill-designed or write-capable entry points
-may add further prohibited names. The list is derived dynamically from
-``local -p`` so that future edits to this function are automatically reflected.
+one per line.  These names are prohibited as the ``-S`` argument to any entry
+point that delegates to ``hs_extract_token``; ill-designed or write-capable
+entry points may add further prohibited names.  The list is derived dynamically
+from ``local -p`` so that future edits to this function are automatically
+reflected.
+
+As of the current release the output is:
+
+.. code-block:: text
+
+   __hs_processed
+   __hs_remaining
+
+``hs_write_token`` reports the same two names plus the source-local name passed
+as ``$1``.  For example, ``hs_write_token __wt_tok --list-reserved`` outputs:
+
+.. code-block:: text
+
+   __hs_processed
+   __hs_remaining
+   __wt_tok
 
 .. note::
 
-   The reserved-name list is part of the minor API: it will not change its
-   prefix conventions across minor versions, but individual names may be added
-   or removed.  Code that avoids the entire ``__hs_`` namespace is unaffected
-   by such changes; code that checks for specific names may break on a minor
+   The reserved-name list is part of the minor API: its prefix conventions will
+   not change across minor versions, but individual names may be added or
+   removed.  Code that avoids the entire ``__hs_`` namespace is unaffected by
+   such changes; code that checks for specific names may break on a minor
    update.
 
 **Eval form** — ``$1`` is the local name, ``${@:2}`` are the forwarded args:
@@ -339,9 +355,9 @@ hs_write_token
 - ``$1`` is the name of the local holding the updated token (accessed by position).
 - The forwarded parameter list (``${@:2}``) must contain ``-S <statevar>``.
 - Runs in a ``$(...)`` subshell, inheriting the calling frame read-only.
-- ``--list-reserved`` (when ``$2 == --list-reserved``): prints the function's own
-  frame locals plus ``$1`` (the source local name, which is part of the entry-point's
-  collision space for read-write functions).
+- ``--list-reserved`` (when ``${*:2}`` is exactly ``--list-reserved``): prints
+  the function's own frame locals plus ``$1`` (the source local name, which is
+  part of the entry-point's collision space for read-write functions).
 
 Behaviour:
 

--- a/docs/libraries/handle_state.rst
+++ b/docs/libraries/handle_state.rst
@@ -284,11 +284,10 @@ hs_extract_token
    hs_extract_token --list-reserved
 
 Prints the names forming the collision surface of ``hs_extract_token`` itself,
-one per line.  These names are prohibited as the ``-S`` argument to any entry
-point that delegates to ``hs_extract_token``; ill-designed or write-capable
-entry points may add further prohibited names.  The list is derived dynamically
-from ``local -p`` so that future edits to this function are automatically
-reflected.
+one per line.  These are the minimum set of names to avoid when naming a ``-S``
+state variable; write-capable or ill-designed entry points may add further
+prohibited names.  The list is derived dynamically from ``local -p`` so that
+future edits to this function are automatically reflected.
 
 As of the current release the output is:
 
@@ -326,7 +325,7 @@ argument list:
 *Normal mode* (``$2`` is not ``--list-reserved``): parses ``-S <statevar>``
 from ``${@:2}`` and emits ``local __mod_state_token='<token_value>'`` on
 success or ``bash -c 'exit N'`` on error.  Runs in a ``$(...)`` subshell; the
-collision surface at fork time consists only of ``hs_extract_token``'s own
+collision surface at fork time consists of ``hs_extract_token``'s own
 locals.
 
 *Auto --list-reserved mode* (``$2 == --list-reserved``): activated when the
@@ -340,40 +339,46 @@ entry-point frame:
    local __mod_state_token=''   # token local pre-declared for frame inspection
 
 No further arguments are valid in this mode.  The entry-point detects
-``list_reserved`` with ``[[ -n "${list_reserved@A}" ]]`` (which returns true
-when the variable is declared, even if unset).
+``list_reserved`` with ``local -p list_reserved >/dev/null 2>&1`` (returns 0
+when the variable is declared as a local, even if unset).
 
-Errors: same set as ``_hs_resolve_state_inputs``; no new codes.
+Errors: same set as the shared option parser; no new codes.
 
 hs_write_token
 ~~~~~~~~~~~~~~
 
 ``hs_write_token`` writes an updated state token value back to the caller's variable.
 
-- Usage: ``eval "$(hs_write_token <source_local> "$@")"`` where ``$@`` (i.e. ``${@:2}``
-  from the entry point's perspective) contains ``-S <statevar>``.
+- Usage: ``eval "$(hs_write_token <source_local> "$@")"`` where ``${@:2}``
+  from the entry point's perspective contains ``-S <statevar>``.
 - ``$1`` is the name of the local holding the updated token (accessed by position).
 - The forwarded parameter list (``${@:2}``) must contain ``-S <statevar>``.
 - Runs in a ``$(...)`` subshell, inheriting the calling frame read-only.
-- ``--list-reserved`` (when ``${*:2}`` is exactly ``--list-reserved``): prints
-  the function's own frame locals plus ``$1`` (the source local name, which is
-  part of the entry-point's collision space for read-write functions).
+- ``--list-reserved`` (when ``${*:2}`` is exactly ``--list-reserved``): computes
+  the collision surface at the point of the call (via ``local -p`` in the subshell
+  frame) and prints it plus ``$1`` (the source local name, which is part of the
+  entry-point's collision space for read-write functions).
 
 Behaviour:
 
-- Parses ``-S`` from the forwarded arguments using ``_hs_resolve_state_inputs``.
-- On success: prints ``<statevar>='<value>'`` — a plain assignment (not ``local``)
+- Parses ``-S`` from the forwarded arguments.
+- On success: prints ``<statevar>='<updated_value>'`` — a plain assignment (not ``local``)
   that ``eval`` executes to write the token back.
 - On error: prints ``bash -c 'exit N'``.
+
+The collision surface of ``hs_write_token`` includes at minimum ``__mylib_state_token``
+(the source local) plus ``hs_extract_token``'s own locals.  Name collision on the source
+local prevents ``hs_write_token`` from updating the caller's state variable: any local in
+the entry-point frame that shadows the ``-S`` variable makes the assignment a no-op.
+Follow the body-helper pattern so that only the token local is declared before
+``hs_write_token`` is called.
 
 .. note::
 
    ``hs_write_token`` cannot avoid a name collision when the ``-S`` state variable
-   and the source local share the same name.  Follow the body-helper pattern to keep
-   the collision surface minimal: the body helper updates the token local; the entry
-   point calls ``hs_write_token`` only after the helper returns.
+   and the source local share the same name.  This edge case is addressed in issue #139.
 
-Errors: same set as ``_hs_resolve_state_inputs``; ``HS_ERR_MISSING_ARGUMENT`` if
+Errors: same set as the shared option parser; ``HS_ERR_MISSING_ARGUMENT`` if
 ``$1`` is absent.
 
 Entry-Point Pattern
@@ -388,18 +393,17 @@ risk.
 .. code-block:: bash
 
    mylib_func() {
+       # No extra locals; hs_extract_token emits __mylib_state_token via eval.
        eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-       if [[ -z "${list_reserved@A}" ]]; then
-           # __mylib_state_token accessible by _mylib_func_body via dynamic scoping.
-           # Body helper calls hs_persist_state -S __mylib_state_token directly.
-           _mylib_func_body || return $?
+       if ! local -p list_reserved >/dev/null 2>&1; then
+           # Body helper reads from and persists to __mylib_state_token via dynamic scoping.
+           _mylib_func "$@" || return $?
        fi
-       # hs_write_token reports the full reserved list (including __mylib_state_token)
-       # when --list-reserved is in $@, otherwise writes the token back.
+       # hs_write_token handles --list-reserved when active; otherwise writes the token back.
        eval "$(hs_write_token __mylib_state_token "$@")" || return $?
    }
 
-   _mylib_func_body() {
+   _mylib_func() {
        local var1 var2
        hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
        # ... work ...
@@ -411,17 +415,17 @@ risk.
 
 A well-designed read-only entry point has the same collision surface as
 ``hs_extract_token``.  It delegates ``--list-reserved`` reporting directly
-to ``hs_extract_token --list-reserved`` rather than calling private functions.
+to ``hs_extract_token --list-reserved``.
 
 .. code-block:: bash
 
    mylib_ro_func() {
        eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-       [[ -n "${list_reserved@A}" ]] && { hs_extract_token --list-reserved; return 0; }
-       _mylib_ro_func_body || return $?
+       local -p list_reserved >/dev/null 2>&1 && { hs_extract_token --list-reserved; return 0; }
+       _mylib_ro_func "$@" || return $?
    }
 
-   _mylib_ro_func_body() {
+   _mylib_ro_func() {
        local var1 var2
        hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
        # ... read-only work ...
@@ -439,14 +443,15 @@ perspective: the token variable is either fully updated or left unchanged.
 .. code-block:: bash
 
    mylib_update_func() {
+       # No extra locals; hs_extract_token emits __mylib_state_token via eval.
        eval "$(hs_extract_token __mylib_state_token "$@")" || return $?
-       if [[ -z "${list_reserved@A}" ]]; then
-           _mylib_update_func_body || return $?
+       if ! local -p list_reserved >/dev/null 2>&1; then
+           _mylib_update_func "$@" || return $?
        fi
        eval "$(hs_write_token __mylib_state_token "$@")" || return $?
    }
 
-   _mylib_update_func_body() {
+   _mylib_update_func() {
        local var1 var2
        hs_read_persisted_state -S __mylib_state_token -- var1 var2 || return $?
        # ... mutate var1, var2 as needed ...
@@ -560,7 +565,7 @@ Persisting and restoring a scalar:
 
    cleanup_function() {
        local token
-       hs_read_persisted_state "$@" -- token || return $?
+       eval "$(hs_read_persisted_state "$@")" || return $?   # implicit form preferred
        printf '%s\n' "$token"
    }
 
@@ -670,7 +675,7 @@ Change History
      - add -S calling context to Examples section [closes #80]
    * - #98
      - remove caveat implying raw eval of state is valid [closes #81]
-   * - #TBD
+   * - #140
      - add hs_extract_token and hs_write_token; entry-point pattern (issue #136)
    * - #99
      - error on undeclared variable names [closes #1]

--- a/docs/libraries/index.rst
+++ b/docs/libraries/index.rst
@@ -11,11 +11,16 @@ pieces they ship.
    command_guard
    remote_run
 
-..
+Change History
+--------------
 
-   Change History
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
 
-   PR     Summary
-   -----  -----------------------------------------------------------------
-   #8     add command_guard to library index
-   #109   reduce nameref collision surface [closes #104]
+   * - PR
+     - Summary
+   * - #8
+     - add command_guard to library index
+   * - #109
+     - reduce nameref collision surface [closes #104]

--- a/docs/libraries/remote_run.rst
+++ b/docs/libraries/remote_run.rst
@@ -429,10 +429,14 @@ values unless the semantics are identical and confusion is impossible.
   could not be resolved by ``guard`` at source time.  The library failed to
   load entirely; no ``rr_*`` functions are available.
 
-..
+Change History
+--------------
 
-   Change History
+.. list-table::
+   :header-rows: 1
+   :widths: 10 90
 
-   PR     Summary
-   -----  -----------------------------------------------------------------
-   #TBD   add Error Codes section; fix nc dependency note; fix exit-code table
+   * - PR
+     - Summary
+   * - #TBD
+     - add Error Codes section; fix nc dependency note; fix exit-code table

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1656,20 +1656,22 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
-  run bash -c "source \"$LIB\" && eval \"\$(hs_extract_token __et_tok)\""
+  f() { eval "$(hs_extract_token __et_tok)"; }
+  run f
   [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_MULTIPLE_STATE_INPUTS when -S given twice" {
-  local tok=""
-  run bash -c "source \"$LIB\" && eval \"\$(hs_extract_token __et_tok -S tok -S tok)\""
+  f() { local tok=""; eval "$(hs_extract_token __et_tok -S tok -S tok)"; }
+  run f
   [[ "$status" -eq "$HS_ERR_MULTIPLE_STATE_INPUTS" ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_INVALID_VAR_NAME for invalid -S identifier" {
-  run bash -c "source \"$LIB\" && eval \"\$(hs_extract_token __et_tok -S '1invalid')\""
+  f() { eval "$(hs_extract_token __et_tok -S '1invalid')"; }
+  run f
   [[ "$status" -eq "$HS_ERR_INVALID_VAR_NAME" ]]
 }
 
@@ -1759,7 +1761,8 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
-  run bash -c "source \"$LIB\" && eval \"\$(hs_write_token __wt_tok)\""
+  f() { eval "$(hs_write_token __wt_tok)"; }
+  run f
   [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
 }
 
@@ -1780,8 +1783,8 @@ EOF
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token --list-reserved includes source local name" {
   # When called with __wt_tok as $1, --list-reserved output must include __wt_tok
-  run -0 bash -c "source \"$LIB\" && hs_write_token __wt_tok --list-reserved | grep -qx '__wt_tok'"
-  [[ "$status" -eq 0 ]]
+  run -0 hs_write_token __wt_tok --list-reserved
+  grep -qx '__wt_tok' <<< "$output"
 }
 
 # bats test_tags=hs_write_token,issue-136
@@ -1807,14 +1810,18 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token --list-reserved direct query rejects extra arguments" {
-  run bash -c "source \"$LIB\" && hs_write_token --list-reserved extra"
+  f() { hs_write_token --list-reserved extra; }
+  run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
+  [[ "$stderr" == *"--list-reserved takes no other arguments"* ]]
 }
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token with-source-local --list-reserved rejects extra arguments" {
-  run bash -c "source \"$LIB\" && eval \"\$(hs_write_token __wt_tok --list-reserved extra)\""
+  f() { eval "$(hs_write_token __wt_tok --list-reserved extra)"; }
+  run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
+  [[ "$stderr" == *"--list-reserved takes no other arguments"* ]]
 }
 
 # bats test_tags=hs_extract_token,hs_write_token,issue-136

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1660,22 +1660,22 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — extracts token value into named local" {
+  local my_token="HS2:test:payload"
   f() {
-    local my_token="HS2:test:payload"
-    eval "$(hs_extract_token hs_extract_token __et_tok -S my_token)" || return $?
+    eval "$(hs_extract_token f __et_tok "$@")" || return $?
     [[ "$__et_tok" == "HS2:test:payload" ]]
   }
-  run -0 f
+  run -0 f -S my_token
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — empty token variable yields empty local" {
+  local my_token=""
   f() {
-    local my_token=""
-    eval "$(hs_extract_token hs_extract_token __et_tok -S my_token)" || return $?
+    eval "$(hs_extract_token f __et_tok "$@")" || return $?
     [[ -z "$__et_tok" ]]
   }
-  run -0 f
+  run -0 f -S my_token
 }
 
 # bats test_tags=hs_extract_token,issue-136
@@ -1703,10 +1703,10 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_RESERVED_VAR_NAME for each reserved name" {
-  f() { eval "$(hs_extract_token hs_extract_token __et_tok -S "$1")"; }
+  f() { eval "$(hs_extract_token hs_extract_token __et_tok "$@")"; }
   local name
   while IFS= read -r name; do
-    run --separate-stderr f "$name"
+    run --separate-stderr f -S "$name"
     [[ "$status" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
       printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$status" >&2
       return 1
@@ -1808,10 +1808,10 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token — returns HS_ERR_RESERVED_VAR_NAME when -S names a reserved variable" {
-  f() { eval "$(hs_write_token hs_persist_state __wt_tok -S "$1")"; }
+  f() { eval "$(hs_write_token hs_persist_state __wt_tok "$@")"; }
   local name
   while IFS= read -r name; do
-    run --separate-stderr f "$name"
+    run --separate-stderr f -S "$name"
     [[ "$status" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
       printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$status" >&2
       return 1

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1553,18 +1553,26 @@ hs2_corrupt_state() {
 
 # bats test_tags=hs_persist_state
 @test "hs_persist_state --list-reserved output names all start with __hs_" {
-  local name
+  local name count=0
   while IFS= read -r name; do
+    (( ++count ))
     [[ "$name" == __hs_* ]] || { printf 'unexpected name: %s\n' "$name" >&2; return 1; }
   done < <(hs_persist_state --list-reserved)
+  [[ "$count" -ge 1 ]]  # guards against vacuous pass when --list-reserved is broken
 }
 
 # bats test_tags=hs_persist_state,hs_read_persisted_state,hs_destroy_state
 @test "--list-reserved produces identical output from all three API entry points" {
+  # run -0 also pins the exit status and non-emptiness: with bare command
+  # substitutions a broken --list-reserved would compare empty == empty.
   local out_persist out_read out_destroy
-  out_persist=$(hs_persist_state --list-reserved)
-  out_read=$(hs_read_persisted_state --list-reserved)
-  out_destroy=$(hs_destroy_state --list-reserved)
+  run -0 hs_persist_state --list-reserved
+  [[ -n "$output" ]]
+  out_persist="$output"
+  run -0 hs_read_persisted_state --list-reserved
+  out_read="$output"
+  run -0 hs_destroy_state --list-reserved
+  out_destroy="$output"
   [[ "$out_persist" == "$out_read" ]]
   [[ "$out_persist" == "$out_destroy" ]]
 }
@@ -1586,9 +1594,16 @@ hs2_corrupt_state() {
   local name count=0
   while IFS= read -r name; do
     (( ++count ))
+    # Regression guard inside the loop: the process substitution streams into
+    # read in parallel, so an endless-output regression would otherwise spin
+    # here until the test timeout.  Target is exactly 2 names
+    # (__hs_remaining, __hs_processed).
+    [[ "$count" -le 2 ]] || {
+      printf 'more than 2 reserved names reported: runaway or grown --list-reserved output\n' >&2
+      return 1
+    }
   done < <(hs_persist_state --list-reserved)
   [[ "$count" -ge 1 ]]  # guards against vacuous pass when --list-reserved is broken
-  [[ "$count" -le 2 ]]  # regression guard: target is exactly 2 (__hs_remaining, __hs_processed)
 }
 
 # ---------------------------------------------------------------------------
@@ -1645,16 +1660,22 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — extracts token value into named local" {
-  local my_token="HS2:test:payload"
-  eval "$(hs_extract_token hs_extract_token __et_tok -S my_token)" || return $?
-  [[ "$__et_tok" == "HS2:test:payload" ]]
+  f() {
+    local my_token="HS2:test:payload"
+    eval "$(hs_extract_token hs_extract_token __et_tok -S my_token)" || return $?
+    [[ "$__et_tok" == "HS2:test:payload" ]]
+  }
+  run -0 f
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — empty token variable yields empty local" {
-  local my_token=""
-  eval "$(hs_extract_token hs_extract_token __et_tok -S my_token)" || return $?
-  [[ -z "$__et_tok" ]]
+  f() {
+    local my_token=""
+    eval "$(hs_extract_token hs_extract_token __et_tok -S my_token)" || return $?
+    [[ -z "$__et_tok" ]]
+  }
+  run -0 f
 }
 
 # bats test_tags=hs_extract_token,issue-136
@@ -1682,15 +1703,15 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_RESERVED_VAR_NAME for each reserved name" {
-  local name rc
+  f() { eval "$(hs_extract_token hs_extract_token __et_tok -S "$1")"; }
+  local name
   while IFS= read -r name; do
-    local dummy=""
-    rc=0
-    eval "$(hs_extract_token hs_extract_token __et_tok -S "$name")" || rc=$?
-    [[ "$rc" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
-      printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$rc" >&2
+    run --separate-stderr f "$name"
+    [[ "$status" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
+      printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$status" >&2
       return 1
     }
+    [[ "$stderr" == *"is reserved"* ]]
   done < <(hs_extract_token --list-reserved)
 }
 
@@ -1703,8 +1724,11 @@ EOF
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token --list-reserved output identical to hs_persist_state --list-reserved" {
   local out_et out_ps
-  out_et="$(hs_extract_token --list-reserved)"
-  out_ps="$(hs_persist_state --list-reserved)"
+  run -0 hs_extract_token --list-reserved
+  [[ -n "$output" ]]
+  out_et="$output"
+  run -0 hs_persist_state --list-reserved
+  out_ps="$output"
   [[ "$out_et" == "$out_ps" ]]
 }
 
@@ -1725,9 +1749,8 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token eval-code --list-reserved form rejects extra arguments" {
-  f() { eval "$(hs_extract_token f __et_tok --list-reserved extra)"; }
-  run --separate-stderr f
-  [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
+  f() { eval "$(hs_extract_token f __et_tok "$@")"; }
+  run -"$HS_ERR_INVALID_ARGUMENT_TYPE" --separate-stderr f --list-reserved extra
   [[ "$stderr" == *"--list-reserved takes no other arguments"* ]]
 }
 
@@ -1757,7 +1780,7 @@ EOF
     eval "$(hs_extract_token f __tok "$@")" || return $?
     [[ "$__tok" == "token-value" ]]
   }
-  f -S __tok
+  run -0 f -S __tok
 }
 
 # ---------------------------------------------------------------------------
@@ -1785,15 +1808,15 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token — returns HS_ERR_RESERVED_VAR_NAME when -S names a reserved variable" {
-  local name rc
+  f() { eval "$(hs_write_token hs_persist_state __wt_tok -S "$1")"; }
+  local name
   while IFS= read -r name; do
-    local dummy=""
-    rc=0
-    eval "$(hs_write_token hs_persist_state __wt_tok -S "$name")" || rc=$?
-    [[ "$rc" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
-      printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$rc" >&2
+    run --separate-stderr f "$name"
+    [[ "$status" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
+      printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$status" >&2
       return 1
     }
+    [[ "$stderr" == *"is reserved"* ]]
   done < <(hs_persist_state --list-reserved)
 }
 
@@ -1880,9 +1903,17 @@ EOF
 # bats test_tags=hs_extract_token,hs_write_token,issue-136
 @test "--list-reserved collision-surface size — hs_extract_token reports less than 2 names" {
   local count=0 name
-  while IFS= read -r name; do (( ++count )); done < <(hs_extract_token --list-reserved)
+  while IFS= read -r name; do
+    (( ++count ))
+    # In-loop regression guard: fail fast on runaway --list-reserved output
+    # instead of spinning until the test timeout (see the hs_persist_state
+    # collision-surface size test).
+    [[ "$count" -le 2 ]] || {
+      printf 'more than 2 reserved names reported: runaway or grown --list-reserved output\n' >&2
+      return 1
+    }
+  done < <(hs_extract_token --list-reserved)
   [[ "$count" -ge 1 ]]
-  [[ "$count" -le 2 ]]
 }
 
 return 0

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1803,19 +1803,41 @@ EOF
   [[ "$output" == *"__wt_tok"* ]]
 }
 
-# bats test_tags=hs_write_token,issue-136
-@test "hs_persist_state --list-reserved is superset of hs_write_token --list-reserved" {
-  local name found
+# bats test_tags=hs_extract_token,hs_write_token,issue-136
+@test "entry point --list-reserved equals hs_persist_state --list-reserved plus source local" {
+  # hs_persist_state --list-reserved is the canonical enumeration of the
+  # shared parsing machinery's collision surface.  An entry point built on
+  # the token utilities must report exactly that set plus its own source
+  # local: any missing canonical name is an under-report that lets a caller
+  # pick a -S name the machinery shadows (silent state corruption); any
+  # extra name is an unjustified new reservation.  Exact set equality is
+  # asserted in both directions (PR #140 thread on the former superset test).
+  rw_entry() {
+    eval "$(hs_extract_token rw_entry __rw_tok "$@")" || return $?
+    eval "$(hs_write_token rw_entry __rw_tok "$@")" || return $?
+  }
+  local name
+  local -A expected=() reported=()
   while IFS= read -r name; do
-    found=0
-    while IFS= read -r ps_name; do
-      [[ "$ps_name" == "$name" ]] && { found=1; break; }
-    done < <(hs_persist_state --list-reserved)
-    [[ "$found" -eq 1 ]] || {
-      printf '%s from hs_write_token missing from hs_persist_state output\n' "$name" >&2
+    [[ -n "$name" ]] && expected["$name"]=1
+  done < <(hs_persist_state --list-reserved)
+  expected["__rw_tok"]=1
+  run -0 --separate-stderr rw_entry --list-reserved
+  while IFS= read -r name; do
+    [[ -n "$name" ]] && reported["$name"]=1
+  done <<< "$output"
+  for name in "${!expected[@]}"; do
+    [[ -n "${reported[$name]+x}" ]] || {
+      printf 'reserved name %s missing from rw_entry --list-reserved output\n' "$name" >&2
       return 1
     }
-  done < <(hs_write_token --list-reserved)
+  done
+  for name in "${!reported[@]}"; do
+    [[ -n "${expected[$name]+x}" ]] || {
+      printf 'extra name %s reported beyond hs_persist_state surface plus source local\n' "$name" >&2
+      return 1
+    }
+  done
 }
 
 # bats test_tags=hs_write_token,issue-136

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -11,7 +11,10 @@ setup_file() {
     return 1
   fi
   export BATS_TEST_TMPDIR
-  export BATS_TEST_TIMEOUT=30
+  # 2 s covers setup + any legitimate test in this file; the failure mode this
+  # guards against is the --list-reserved re-entry fork bomb (issue #136),
+  # which otherwise burns ~15 s per test saturating the fork budget.
+  export BATS_TEST_TIMEOUT=2
 }
 setup() {
   # `builtin source` bypasses any test-installed override of `source` (the
@@ -1643,20 +1646,20 @@ EOF
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — extracts token value into named local" {
   local my_token="HS2:test:payload"
-  eval "$(hs_extract_token test_func __et_tok -S my_token)" || return $?
+  eval "$(hs_extract_token hs_extract_token __et_tok -S my_token)" || return $?
   [[ "$__et_tok" == "HS2:test:payload" ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — empty token variable yields empty local" {
   local my_token=""
-  eval "$(hs_extract_token test_func __et_tok -S my_token)" || return $?
+  eval "$(hs_extract_token hs_extract_token __et_tok -S my_token)" || return $?
   [[ -z "$__et_tok" ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
-  f() { eval "$(hs_extract_token f __et_tok)"; }
+  f() { eval "$(hs_extract_token f __et_tok "$@")"; }
   run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
   [[ "$stderr" == *"state variable is uninitialized"* ]]
@@ -1664,16 +1667,16 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_MULTIPLE_STATE_INPUTS when -S given twice" {
-  f() { local tok=""; eval "$(hs_extract_token f __et_tok -S tok -S tok)"; }
-  run --separate-stderr f
+  f() { local tok=""; eval "$(hs_extract_token f __et_tok "$@")"; }
+  run --separate-stderr f -S tok -S tok
   [[ "$status" -eq "$HS_ERR_MULTIPLE_STATE_INPUTS" ]]
   [[ "$stderr" == *"option -S may only be given once"* ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_INVALID_VAR_NAME for invalid -S identifier" {
-  f() { eval "$(hs_extract_token f __et_tok -S '1invalid')"; }
-  run f
+  f() { eval "$(hs_extract_token f __et_tok "$@")"; }
+  run f -S '1invalid'
   [[ "$status" -eq "$HS_ERR_INVALID_VAR_NAME" ]]
 }
 
@@ -1683,7 +1686,7 @@ EOF
   while IFS= read -r name; do
     local dummy=""
     rc=0
-    eval "$(hs_extract_token test_func __et_tok -S "$name")" || rc=$?
+    eval "$(hs_extract_token hs_extract_token __et_tok -S "$name")" || rc=$?
     [[ "$rc" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
       printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$rc" >&2
       return 1
@@ -1737,10 +1740,10 @@ EOF
   outer_collision_test() {
     local __hs_remaining="should-not-be-seen"
     local outer_tok="real-token-value"
-    eval "$(hs_extract_token outer_collision_test __et_tok -S outer_tok)" || return $?
+    eval "$(hs_extract_token outer_collision_test __et_tok "$@")" || return $?
     [[ "$__et_tok" == "real-token-value" ]]
   }
-  run -0 outer_collision_test
+  run -0 outer_collision_test -S outer_tok
 }
 
 # bats test_tags=hs_extract_token,issue-136
@@ -1751,10 +1754,10 @@ EOF
   # extracted value must equal the original state variable value.
   f() {
     local __tok="token-value"
-    eval "$(hs_extract_token f __tok -S __tok)" || return $?
+    eval "$(hs_extract_token f __tok "$@")" || return $?
     [[ "$__tok" == "token-value" ]]
   }
-  f
+  f -S __tok
 }
 
 # ---------------------------------------------------------------------------
@@ -1765,17 +1768,17 @@ EOF
 @test "hs_write_token — writes source local value into caller state variable" {
   write_test_helper() {
     local dest_tok="old"
-    eval "$(hs_extract_token write_test_helper __wt_tok -S dest_tok)" || return $?
+    eval "$(hs_extract_token write_test_helper __wt_tok "$@")" || return $?
     __wt_tok="new-value"
-    eval "$(hs_write_token write_test_helper __wt_tok -S dest_tok)" || return $?
+    eval "$(hs_write_token write_test_helper __wt_tok "$@")" || return $?
     [[ "$dest_tok" == "new-value" ]]
   }
-  run -0 write_test_helper
+  run -0 write_test_helper -S dest_tok
 }
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
-  f() { eval "$(hs_write_token f __wt_tok)"; }
+  f() { eval "$(hs_write_token f __wt_tok "$@")"; }
   run f
   [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
 }
@@ -1786,7 +1789,7 @@ EOF
   while IFS= read -r name; do
     local dummy=""
     rc=0
-    eval "$(hs_write_token test_func __wt_tok -S "$name")" || rc=$?
+    eval "$(hs_write_token hs_persist_state __wt_tok -S "$name")" || rc=$?
     [[ "$rc" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
       printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$rc" >&2
       return 1

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1707,16 +1707,16 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token eval-code --list-reserved form emits list_reserved sentinel and empty token local" {
-  # Simulates a read-only entry point using the $2==--list-reserved form (no $3).
   ro_entry_point() {
     eval "$(hs_extract_token ro_entry_point __ro_tok "$@")" || return $?
     [[ -n "${list_reserved@A}" ]] || { echo "list_reserved not declared" >&2; return 1; }
     [[ -n "${__ro_tok@A}" ]]     || { echo "__ro_tok not declared" >&2; return 1; }
-    # Simulate what the entry-point does next when called with --list-reserved
+    # list_reserved holds actual reserved names, not just a boolean flag.
+    [[ "$list_reserved" == *"__hs_remaining"* ]] || { echo "list_reserved missing __hs_remaining" >&2; return 1; }
+    [[ "$list_reserved" == *"__hs_processed"* ]] || { echo "list_reserved missing __hs_processed" >&2; return 1; }
     echo "__ro_tok"
   }
   run -0 --separate-stderr ro_entry_point --list-reserved
-  # entry-point echoes "__ro_tok" confirming list_reserved and __ro_tok were both declared
   [[ "$output" == "__ro_tok" ]]
 }
 
@@ -1838,6 +1838,21 @@ EOF
 }
 
 # bats test_tags=hs_extract_token,hs_write_token,issue-136
+@test "hs_write_token eval-code --list-reserved form merges hs_extract_token surface and source local" {
+  rw_entry_point() {
+    eval "$(hs_extract_token rw_entry_point __rw_tok "$@")" || return $?
+    if ! local -p list_reserved >/dev/null 2>&1; then
+      :
+    fi
+    eval "$(hs_write_token rw_entry_point __rw_tok "$@")" || return $?
+  }
+  run -0 --separate-stderr rw_entry_point --list-reserved
+  [[ "$output" == *"__hs_remaining"* ]]
+  [[ "$output" == *"__hs_processed"* ]]
+  [[ "$output" == *"__rw_tok"* ]]
+}
+
+# bats test_tags=hs_extract_token,hs_write_token,issue-136
 @test "--list-reserved collision-surface size — hs_extract_token reports less than 2 names" {
   local count=0 name
   while IFS= read -r name; do (( ++count )); done < <(hs_extract_token --list-reserved)
@@ -1863,3 +1878,4 @@ return 0
 # | #109  | reduce nameref collision surface [closes #104]                 |
 # | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |
 # | #140  | add hs_extract_token and hs_write_token; entry-point pattern        |
+# | #140  | fix --list-reserved merge for read-write entry points [closes #136] |

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1120,9 +1120,9 @@ hs2_corrupt_state() {
     }
     update_counter() {
       # Entry-point: zero collision surface before eval.
-      eval "$(hs_extract_token __uc_tok "$@")" || return $?
+      eval "$(hs_extract_token update_counter __uc_tok "$@")" || return $?
       _update_counter_body "$@" || return $?
-      eval "$(hs_write_token __uc_tok "$@")" || return $?
+      eval "$(hs_write_token update_counter __uc_tok "$@")" || return $?
     }
     _update_counter_body() {
       local counter label
@@ -1643,20 +1643,20 @@ EOF
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — extracts token value into named local" {
   local my_token="HS2:test:payload"
-  eval "$(hs_extract_token __et_tok -S my_token)" || return $?
+  eval "$(hs_extract_token test_func __et_tok -S my_token)" || return $?
   [[ "$__et_tok" == "HS2:test:payload" ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — empty token variable yields empty local" {
   local my_token=""
-  eval "$(hs_extract_token __et_tok -S my_token)" || return $?
+  eval "$(hs_extract_token test_func __et_tok -S my_token)" || return $?
   [[ -z "$__et_tok" ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
-  f() { eval "$(hs_extract_token __et_tok)"; }
+  f() { eval "$(hs_extract_token f __et_tok)"; }
   run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
   [[ "$stderr" == *"state variable is uninitialized"* ]]
@@ -1664,7 +1664,7 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_MULTIPLE_STATE_INPUTS when -S given twice" {
-  f() { local tok=""; eval "$(hs_extract_token __et_tok -S tok -S tok)"; }
+  f() { local tok=""; eval "$(hs_extract_token f __et_tok -S tok -S tok)"; }
   run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_MULTIPLE_STATE_INPUTS" ]]
   [[ "$stderr" == *"option -S may only be given once"* ]]
@@ -1672,7 +1672,7 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_INVALID_VAR_NAME for invalid -S identifier" {
-  f() { eval "$(hs_extract_token __et_tok -S '1invalid')"; }
+  f() { eval "$(hs_extract_token f __et_tok -S '1invalid')"; }
   run f
   [[ "$status" -eq "$HS_ERR_INVALID_VAR_NAME" ]]
 }
@@ -1683,7 +1683,7 @@ EOF
   while IFS= read -r name; do
     local dummy=""
     rc=0
-    eval "$(hs_extract_token __et_tok -S "$name")" || rc=$?
+    eval "$(hs_extract_token test_func __et_tok -S "$name")" || rc=$?
     [[ "$rc" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
       printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$rc" >&2
       return 1
@@ -1709,7 +1709,7 @@ EOF
 @test "hs_extract_token eval-code --list-reserved form emits list_reserved sentinel and empty token local" {
   # Simulates a read-only entry point using the $2==--list-reserved form (no $3).
   ro_entry_point() {
-    eval "$(hs_extract_token __ro_tok "$@")" || return $?
+    eval "$(hs_extract_token ro_entry_point __ro_tok "$@")" || return $?
     [[ -n "${list_reserved@A}" ]] || { echo "list_reserved not declared" >&2; return 1; }
     [[ -n "${__ro_tok@A}" ]]     || { echo "__ro_tok not declared" >&2; return 1; }
     # Simulate what the entry-point does next when called with --list-reserved
@@ -1722,7 +1722,7 @@ EOF
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token eval-code --list-reserved form rejects extra arguments" {
-  f() { eval "$(hs_extract_token __et_tok --list-reserved extra)"; }
+  f() { eval "$(hs_extract_token f __et_tok --list-reserved extra)"; }
   run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
   [[ "$stderr" == *"--list-reserved takes no other arguments"* ]]
@@ -1737,7 +1737,7 @@ EOF
   outer_collision_test() {
     local __hs_remaining="should-not-be-seen"
     local outer_tok="real-token-value"
-    eval "$(hs_extract_token __et_tok -S outer_tok)" || return $?
+    eval "$(hs_extract_token outer_collision_test __et_tok -S outer_tok)" || return $?
     [[ "$__et_tok" == "real-token-value" ]]
   }
   run -0 outer_collision_test
@@ -1751,7 +1751,7 @@ EOF
   # extracted value must equal the original state variable value.
   f() {
     local __tok="token-value"
-    eval "$(hs_extract_token __tok -S __tok)" || return $?
+    eval "$(hs_extract_token f __tok -S __tok)" || return $?
     [[ "$__tok" == "token-value" ]]
   }
   f
@@ -1765,9 +1765,9 @@ EOF
 @test "hs_write_token — writes source local value into caller state variable" {
   write_test_helper() {
     local dest_tok="old"
-    eval "$(hs_extract_token __wt_tok -S dest_tok)" || return $?
+    eval "$(hs_extract_token write_test_helper __wt_tok -S dest_tok)" || return $?
     __wt_tok="new-value"
-    eval "$(hs_write_token __wt_tok -S dest_tok)" || return $?
+    eval "$(hs_write_token write_test_helper __wt_tok -S dest_tok)" || return $?
     [[ "$dest_tok" == "new-value" ]]
   }
   run -0 write_test_helper
@@ -1775,7 +1775,7 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
-  f() { eval "$(hs_write_token __wt_tok)"; }
+  f() { eval "$(hs_write_token f __wt_tok)"; }
   run f
   [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
 }
@@ -1786,7 +1786,7 @@ EOF
   while IFS= read -r name; do
     local dummy=""
     rc=0
-    eval "$(hs_write_token __wt_tok -S "$name")" || rc=$?
+    eval "$(hs_write_token test_func __wt_tok -S "$name")" || rc=$?
     [[ "$rc" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
       printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$rc" >&2
       return 1
@@ -1796,7 +1796,7 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token --list-reserved includes source local name" {
-  run -0 hs_write_token __wt_tok --list-reserved
+  run -0 hs_write_token entry_func __wt_tok --list-reserved
   [[ "$output" == *"__wt_tok"* ]]
 }
 
@@ -1831,7 +1831,7 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token eval-code --list-reserved form rejects extra arguments when source local given" {
-  f() { eval "$(hs_write_token __wt_tok --list-reserved extra)"; }
+  f() { eval "$(hs_write_token f __wt_tok --list-reserved extra)"; }
   run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
   [[ "$stderr" == *"--list-reserved takes no other arguments"* ]]

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1657,15 +1657,17 @@ EOF
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
   f() { eval "$(hs_extract_token __et_tok)"; }
-  run f
+  run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
+  [[ "$stderr" == *"state variable is uninitialized"* ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token — returns HS_ERR_MULTIPLE_STATE_INPUTS when -S given twice" {
   f() { local tok=""; eval "$(hs_extract_token __et_tok -S tok -S tok)"; }
-  run f
+  run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_MULTIPLE_STATE_INPUTS" ]]
+  [[ "$stderr" == *"option -S may only be given once"* ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
@@ -1714,10 +1716,8 @@ EOF
     echo "__ro_tok"
   }
   run -0 --separate-stderr ro_entry_point --list-reserved
-  # __ro_tok must appear (declared by the eval)
-  grep -qx '__ro_tok' <<< "$output"
-  # lp_snapshot must NOT appear (combined-form snapshot excludes it)
-  ! grep -qx 'lp_snapshot' <<< "$output"
+  # entry-point echoes "__ro_tok" confirming list_reserved and __ro_tok were both declared
+  [[ "$output" == "__ro_tok" ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
@@ -1740,7 +1740,7 @@ EOF
     eval "$(hs_extract_token __et_tok -S outer_tok)" || return $?
     [[ "$__et_tok" == "real-token-value" ]]
   }
-  outer_collision_test
+  run -0 outer_collision_test
 }
 
 # bats test_tags=hs_extract_token,issue-136
@@ -1763,14 +1763,14 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token — writes source local value into caller state variable" {
-  local dest_tok="old"
   write_test_helper() {
+    local dest_tok="old"
     eval "$(hs_extract_token __wt_tok -S dest_tok)" || return $?
     __wt_tok="new-value"
     eval "$(hs_write_token __wt_tok -S dest_tok)" || return $?
+    [[ "$dest_tok" == "new-value" ]]
   }
-  write_test_helper
-  [[ "$dest_tok" == "new-value" ]]
+  run -0 write_test_helper
 }
 
 # bats test_tags=hs_write_token,issue-136
@@ -1796,24 +1796,23 @@ EOF
 
 # bats test_tags=hs_write_token,issue-136
 @test "hs_write_token --list-reserved includes source local name" {
-  # When called with __wt_tok as $1, --list-reserved output must include __wt_tok
   run -0 hs_write_token __wt_tok --list-reserved
-  grep -qx '__wt_tok' <<< "$output"
+  [[ "$output" == *"__wt_tok"* ]]
 }
 
 # bats test_tags=hs_write_token,issue-136
-@test "hs_write_token --list-reserved is superset of hs_persist_state --list-reserved" {
+@test "hs_persist_state --list-reserved is superset of hs_write_token --list-reserved" {
   local name found
   while IFS= read -r name; do
     found=0
-    while IFS= read -r wt_name; do
-      [[ "$wt_name" == "$name" ]] && { found=1; break; }
-    done < <(hs_write_token __wt_tok --list-reserved)
+    while IFS= read -r ps_name; do
+      [[ "$ps_name" == "$name" ]] && { found=1; break; }
+    done < <(hs_persist_state --list-reserved)
     [[ "$found" -eq 1 ]] || {
-      printf '%s from hs_persist_state missing from hs_write_token output\n' "$name" >&2
+      printf '%s from hs_write_token missing from hs_persist_state output\n' "$name" >&2
       return 1
     }
-  done < <(hs_persist_state --list-reserved)
+  done < <(hs_write_token --list-reserved)
 }
 
 # bats test_tags=hs_write_token,issue-136
@@ -1831,7 +1830,7 @@ EOF
 }
 
 # bats test_tags=hs_write_token,issue-136
-@test "hs_write_token with-source-local --list-reserved rejects extra arguments" {
+@test "hs_write_token eval-code --list-reserved form rejects extra arguments when source local given" {
   f() { eval "$(hs_write_token __wt_tok --list-reserved extra)"; }
   run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
@@ -1863,4 +1862,4 @@ return 0
 # | #108  | fix shellcheck linter errors in bats file [closes #107]        |
 # | #109  | reduce nameref collision surface [closes #104]                 |
 # | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |
-# | #TBD  | add preliminary tests for hs_extract_token and hs_write_token  |
+# | #140  | add hs_extract_token and hs_write_token; entry-point pattern        |

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1098,6 +1098,55 @@ hs2_corrupt_state() {
   [[ "$stderr" == *"str_target"* ]]
 }
 
+# bats test_tags=hs_persist_state,hs_extract_token,hs_write_token,hs_destroy_state,issue-136
+@test "read/modify/write — entry point updates one variable in an existing state token" {
+  # Full read/modify/write cycle using the hs_extract_token / hs_write_token
+  # entry-point pattern.  The test verifies that:
+  #   1. init persists two vars (counter, label).
+  #   2. update_counter uses hs_extract_token + hs_destroy_state + hs_persist_state
+  #      + hs_write_token to increment counter without touching label.
+  #   3. read_back restores both vars and confirms the update landed correctly.
+  # hs_destroy_state is required before re-persisting because hs_persist_state
+  # rejects names already present in the token (HS_ERR_VAR_NAME_COLLISION).
+  # Because Bash is sequential and subshells cannot write back to the parent
+  # shell's variables, the token update is safe: hs_write_token runs in a
+  # subshell only to emit the assignment code; eval in the entry-point frame
+  # performs the actual write atomically.
+  # shellcheck disable=SC2329
+  f() {
+    init() {
+      local counter=0 label="start"
+      hs_persist_state -S "$1" -- counter label || return $?
+    }
+    update_counter() {
+      # Entry-point: zero collision surface before eval.
+      eval "$(hs_extract_token __uc_tok "$@")" || return $?
+      _update_counter_body "$@" || return $?
+      eval "$(hs_write_token __uc_tok "$@")" || return $?
+    }
+    _update_counter_body() {
+      local counter label
+      hs_read_persisted_state -S __uc_tok -- counter label || return $?
+      (( counter++ )) || true
+      # Destroy before re-persisting to avoid HS_ERR_VAR_NAME_COLLISION.
+      hs_destroy_state -S __uc_tok -- counter label || return $?
+      hs_persist_state  -S __uc_tok -- counter label || return $?
+    }
+    read_back() {
+      local counter label
+      hs_read_persisted_state -S "$1" -- counter label || return $?
+      printf "%s:%s" "$counter" "$label"
+    }
+    local state=""
+    init state || return $?
+    update_counter -S state || return $?
+    read_back state
+  }
+  run -0 --separate-stderr f
+  [ "$output" = "1:start" ]
+  [ -z "$stderr" ]
+}
+
 # bats test_tags=hs_persist_state
 @test "hs_persist_state reports a collision for a variable already in state" {
   # shellcheck disable=SC2329
@@ -1587,6 +1636,180 @@ EOF
   run -"$CG_ERR_NOT_FOUND" bash --noprofile --norc "$script"
 }
 
+# ---------------------------------------------------------------------------
+# hs_extract_token
+# ---------------------------------------------------------------------------
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token — extracts token value into named local" {
+  local my_token="HS2:test:payload"
+  eval "$(hs_extract_token __et_tok -S my_token)" || return $?
+  [[ "$__et_tok" == "HS2:test:payload" ]]
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token — empty token variable yields empty local" {
+  local my_token=""
+  eval "$(hs_extract_token __et_tok -S my_token)" || return $?
+  [[ -z "$__et_tok" ]]
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
+  run bash -c "source \"$LIB\" && eval \"\$(hs_extract_token __et_tok)\""
+  [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token — returns HS_ERR_MULTIPLE_STATE_INPUTS when -S given twice" {
+  local tok=""
+  run bash -c "source \"$LIB\" && eval \"\$(hs_extract_token __et_tok -S tok -S tok)\""
+  [[ "$status" -eq "$HS_ERR_MULTIPLE_STATE_INPUTS" ]]
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token — returns HS_ERR_INVALID_VAR_NAME for invalid -S identifier" {
+  run bash -c "source \"$LIB\" && eval \"\$(hs_extract_token __et_tok -S '1invalid')\""
+  [[ "$status" -eq "$HS_ERR_INVALID_VAR_NAME" ]]
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token — returns HS_ERR_RESERVED_VAR_NAME for each reserved name" {
+  local name rc
+  while IFS= read -r name; do
+    local dummy=""
+    rc=0
+    eval "$(hs_extract_token __et_tok -S "$name")" || rc=$?
+    [[ "$rc" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
+      printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$rc" >&2
+      return 1
+    }
+  done < <(hs_extract_token --list-reserved)
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token --list-reserved exits 0 with non-empty output" {
+  run -0 hs_extract_token --list-reserved
+  [[ -n "$output" ]]
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token --list-reserved output identical to hs_persist_state --list-reserved" {
+  local out_et out_ps
+  out_et="$(hs_extract_token --list-reserved)"
+  out_ps="$(hs_persist_state --list-reserved)"
+  [[ "$out_et" == "$out_ps" ]]
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token eval-code --list-reserved form emits list_reserved sentinel and empty token local" {
+  # Simulates a read-only entry point using the $2==--list-reserved form (no $3).
+  ro_entry_point() {
+    eval "$(hs_extract_token __ro_tok --list-reserved)" || return $?
+    # list_reserved=1 sentinel must be declared
+    _hs_local_exists "$(local -p)" list_reserved || { echo "list_reserved not declared" >&2; return 1; }
+    # __ro_tok must be declared so it appears in the entry-point's lp_snapshot
+    _hs_local_exists "$(local -p)" __ro_tok || { echo "__ro_tok not declared" >&2; return 1; }
+    # Simulate what the entry-point does next: combined snapshot + print reserved
+    # shellcheck disable=SC2155
+    local lp_snapshot="$(local -p)"
+    _hs_print_reserved_names "$lp_snapshot" list_reserved
+  }
+  local output
+  output="$(ro_entry_point)"
+  # __ro_tok must appear (declared by the eval)
+  grep -qx '__ro_tok' <<< "$output" || { echo "__ro_tok missing from output" >&2; return 1; }
+  # lp_snapshot must NOT appear (combined-form snapshot excludes it)
+  ! grep -qx 'lp_snapshot' <<< "$output" || { echo "lp_snapshot must not appear in output" >&2; return 1; }
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token eval-code --list-reserved form rejects extra arguments" {
+  run bash -c "source \"$LIB\" && hs_extract_token __et_tok --list-reserved extra"
+  [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
+}
+
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token collision scenario — eval form reads outer caller value not shadowing local" {
+  # This test verifies the eval pattern prevents the collision bug.
+  # A local named __hs_remaining exists before the eval; if the subshell
+  # incorrectly resolved -S __hs_remaining to the local's unset copy, the
+  # extracted value would be empty instead of the real token.
+  outer_collision_test() {
+    local __hs_remaining="should-not-be-seen"
+    local outer_tok="real-token-value"
+    eval "$(hs_extract_token __et_tok -S outer_tok)" || return $?
+    [[ "$__et_tok" == "real-token-value" ]]
+  }
+  outer_collision_test
+}
+
+# ---------------------------------------------------------------------------
+# hs_write_token
+# ---------------------------------------------------------------------------
+
+# bats test_tags=hs_write_token,issue-136
+@test "hs_write_token — writes source local value into caller state variable" {
+  local dest_tok="old"
+  write_test_helper() {
+    eval "$(hs_extract_token __wt_tok -S dest_tok)" || return $?
+    __wt_tok="new-value"
+    eval "$(hs_write_token __wt_tok -S dest_tok)" || return $?
+  }
+  write_test_helper
+  [[ "$dest_tok" == "new-value" ]]
+}
+
+# bats test_tags=hs_write_token,issue-136
+@test "hs_write_token — returns HS_ERR_STATE_VAR_UNINITIALIZED when -S absent" {
+  run bash -c "source \"$LIB\" && eval \"\$(hs_write_token __wt_tok)\""
+  [[ "$status" -eq "$HS_ERR_STATE_VAR_UNINITIALIZED" ]]
+}
+
+# bats test_tags=hs_write_token,issue-136
+@test "hs_write_token — returns HS_ERR_RESERVED_VAR_NAME when -S names a reserved variable" {
+  local name rc
+  while IFS= read -r name; do
+    local dummy=""
+    rc=0
+    eval "$(hs_write_token __wt_tok -S "$name")" || rc=$?
+    [[ "$rc" -eq "$HS_ERR_RESERVED_VAR_NAME" ]] || {
+      printf 'expected HS_ERR_RESERVED_VAR_NAME for -S %s but got %d\n' "$name" "$rc" >&2
+      return 1
+    }
+  done < <(hs_persist_state --list-reserved)
+}
+
+# bats test_tags=hs_write_token,issue-136
+@test "hs_write_token --list-reserved includes source local name" {
+  # When called with __wt_tok as $1, --list-reserved output must include __wt_tok
+  run -0 bash -c "source \"$LIB\" && hs_write_token __wt_tok --list-reserved | grep -qx '__wt_tok'"
+  [[ "$status" -eq 0 ]]
+}
+
+# bats test_tags=hs_write_token,issue-136
+@test "hs_write_token --list-reserved is superset of hs_persist_state --list-reserved" {
+  local name found
+  while IFS= read -r name; do
+    found=0
+    while IFS= read -r wt_name; do
+      [[ "$wt_name" == "$name" ]] && { found=1; break; }
+    done < <(hs_write_token __wt_tok --list-reserved)
+    [[ "$found" -eq 1 ]] || {
+      printf '%s from hs_persist_state missing from hs_write_token output\n' "$name" >&2
+      return 1
+    }
+  done < <(hs_persist_state --list-reserved)
+}
+
+# bats test_tags=hs_extract_token,hs_write_token,issue-136
+@test "--list-reserved collision-surface size — hs_extract_token reports le 2 names" {
+  local count=0 name
+  while IFS= read -r name; do (( ++count )); done < <(hs_extract_token --list-reserved)
+  [[ "$count" -ge 1 ]]
+  [[ "$count" -le 2 ]]
+}
+
 return 0
 
 # --- Change History -------------------------------------------------------
@@ -1604,3 +1827,4 @@ return 0
 # | #108  | fix shellcheck linter errors in bats file [closes #107]        |
 # | #109  | reduce nameref collision surface [closes #104]                 |
 # | #110  | document HS_ERR_MULTIPLE_STATE_INPUTS for all entry points     |
+# | #TBD  | add preliminary tests for hs_extract_token and hs_write_token  |

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1743,6 +1743,20 @@ EOF
   outer_collision_test
 }
 
+# bats test_tags=hs_extract_token,issue-136
+@test "hs_extract_token — local name equals -S variable name: extracted value is preserved" {
+  # Validates that hs_extract_token __tok -S __tok works correctly when the
+  # destination local and the state variable share the same name.  The subshell
+  # reads the outer __tok value before eval declares the new local, so the
+  # extracted value must equal the original state variable value.
+  f() {
+    local __tok="token-value"
+    eval "$(hs_extract_token __tok -S __tok)" || return $?
+    [[ "$__tok" == "token-value" ]]
+  }
+  f
+}
+
 # ---------------------------------------------------------------------------
 # hs_write_token
 # ---------------------------------------------------------------------------

--- a/test/test-hs_persist_state.bats
+++ b/test/test-hs_persist_state.bats
@@ -1099,7 +1099,7 @@ hs2_corrupt_state() {
 }
 
 # bats test_tags=hs_persist_state,hs_extract_token,hs_write_token,hs_destroy_state,issue-136
-@test "read/modify/write — entry point updates one variable in an existing state token" {
+@test "read-modify-write — entry point updates one variable in an existing state token" {
   # Full read/modify/write cycle using the hs_extract_token / hs_write_token
   # entry-point pattern.  The test verifies that:
   #   1. init persists two vars (counter, label).
@@ -1705,28 +1705,25 @@ EOF
 @test "hs_extract_token eval-code --list-reserved form emits list_reserved sentinel and empty token local" {
   # Simulates a read-only entry point using the $2==--list-reserved form (no $3).
   ro_entry_point() {
-    eval "$(hs_extract_token __ro_tok --list-reserved)" || return $?
-    # list_reserved=1 sentinel must be declared
-    _hs_local_exists "$(local -p)" list_reserved || { echo "list_reserved not declared" >&2; return 1; }
-    # __ro_tok must be declared so it appears in the entry-point's lp_snapshot
-    _hs_local_exists "$(local -p)" __ro_tok || { echo "__ro_tok not declared" >&2; return 1; }
-    # Simulate what the entry-point does next: combined snapshot + print reserved
-    # shellcheck disable=SC2155
-    local lp_snapshot="$(local -p)"
-    _hs_print_reserved_names "$lp_snapshot" list_reserved
+    eval "$(hs_extract_token __ro_tok "$@")" || return $?
+    [[ -n "${list_reserved@A}" ]] || { echo "list_reserved not declared" >&2; return 1; }
+    [[ -n "${__ro_tok@A}" ]]     || { echo "__ro_tok not declared" >&2; return 1; }
+    # Simulate what the entry-point does next when called with --list-reserved
+    echo "__ro_tok"
   }
-  local output
-  output="$(ro_entry_point)"
+  run -0 --separate-stderr ro_entry_point --list-reserved
   # __ro_tok must appear (declared by the eval)
-  grep -qx '__ro_tok' <<< "$output" || { echo "__ro_tok missing from output" >&2; return 1; }
+  grep -qx '__ro_tok' <<< "$output"
   # lp_snapshot must NOT appear (combined-form snapshot excludes it)
-  ! grep -qx 'lp_snapshot' <<< "$output" || { echo "lp_snapshot must not appear in output" >&2; return 1; }
+  ! grep -qx 'lp_snapshot' <<< "$output"
 }
 
 # bats test_tags=hs_extract_token,issue-136
 @test "hs_extract_token eval-code --list-reserved form rejects extra arguments" {
-  run bash -c "source \"$LIB\" && hs_extract_token __et_tok --list-reserved extra"
+  f() { eval "$(hs_extract_token __et_tok --list-reserved extra)"; }
+  run --separate-stderr f
   [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
+  [[ "$stderr" == *"--list-reserved takes no other arguments"* ]]
 }
 
 # bats test_tags=hs_extract_token,issue-136
@@ -1802,8 +1799,26 @@ EOF
   done < <(hs_persist_state --list-reserved)
 }
 
+# bats test_tags=hs_write_token,issue-136
+@test "hs_write_token --list-reserved direct query exits 0 with non-empty output" {
+  run -0 hs_write_token --list-reserved
+  [[ -n "$output" ]]
+}
+
+# bats test_tags=hs_write_token,issue-136
+@test "hs_write_token --list-reserved direct query rejects extra arguments" {
+  run bash -c "source \"$LIB\" && hs_write_token --list-reserved extra"
+  [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
+}
+
+# bats test_tags=hs_write_token,issue-136
+@test "hs_write_token with-source-local --list-reserved rejects extra arguments" {
+  run bash -c "source \"$LIB\" && eval \"\$(hs_write_token __wt_tok --list-reserved extra)\""
+  [[ "$status" -eq "$HS_ERR_INVALID_ARGUMENT_TYPE" ]]
+}
+
 # bats test_tags=hs_extract_token,hs_write_token,issue-136
-@test "--list-reserved collision-surface size — hs_extract_token reports le 2 names" {
+@test "--list-reserved collision-surface size — hs_extract_token reports less than 2 names" {
   local count=0 name
   while IFS= read -r name; do (( ++count )); done < <(hs_extract_token --list-reserved)
   [[ "$count" -ge 1 ]]


### PR DESCRIPTION
## Summary

- Adds `hs_extract_token` and `hs_write_token` to `handle_state.sh` as public API for zero-collision read-only and read-write entry points.
- Completes the `--list-reserved` contract for both functions (direct query, eval-code, and with-source-local forms) including extra-argument rejection.
- Refactors all related tests to eliminate internal-function calls and redundant subshells.

## Changes

### `config/handle_state.sh`

- **`hs_extract_token`** — new public function. Eval-code pattern extracts a token value from a `-S` state variable into a named local with zero entry-point collision surface. Supports `--list-reserved` in direct-query and eval-code forms.
- **`hs_write_token`** — new public function. Eval-code pattern writes an updated token value back to a `-S` state variable. Supports `--list-reserved` in direct-query, eval-code, and with-source-local forms:
  - Direct query (`$1 == --list-reserved`): prints own collision surface, one name per line, consistent with `hs_persist_state` and `hs_extract_token`.
  - With-source-local (`$2 == --list-reserved`): prints own collision surface plus `$1` (the source-local name that is part of an rw-entry-point's collision section).
  - Both forms reject extra arguments with `HS_ERR_INVALID_ARGUMENT_TYPE`.

### `test/test-hs_persist_state.bats`

- Replace `_hs_local_exists "$(local -p)" varname` with `[[ -n "${varname@A}" ]]` — no subshell, no internal function, no spurious error output.
- Replace `run bash -c "source … && fn …"` patterns with local wrapper functions + `run -0 --separate-stderr fn` — one subprocess instead of two; library functions inherited via fork.
- Pass `"$@"` through `ro_entry_point` so `--list-reserved` flows in from the caller rather than being hardcoded in the function body.
- Add `--separate-stderr` and `$stderr` assertions wherever error output is expected.
- Add three new `hs_write_token --list-reserved` tests (direct query exit-0, direct-query extra-arg rejection, with-source-local extra-arg rejection).
- Fix test name typos: `read/modify/write` → `read-modify-write`; `"le 2"` → `"less than 2"`.

## Test plan

- [ ] `bats test/test-hs_persist_state.bats` passes 120/120 locally.
- [ ] All `hs_extract_token` and `hs_write_token` tests green.
- [ ] No test calls `_hs_*` or `__hs_*` internal functions outside dedicated `_hs_resolve_state_inputs` tests.
- [ ] CI passes.

## Related issues

- Closes #136
- Design follow-up tracked in #139 (`list_reserved` value carrying collision surface; `-r` / `hs_read_only_token` options for self-contained `--list-reserved` mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)